### PR TITLE
feat(samples/android): render repost attribution and quoted records

### DIFF
--- a/openspec/changes/sample-repost-embeds/design.md
+++ b/openspec/changes/sample-repost-embeds/design.md
@@ -1,0 +1,207 @@
+## Overview
+
+Extend `FeedScreen`'s `PostRow` to surface two feed concepts the sample
+currently ignores: the `FeedViewPost.reason` header for reposts, and
+the quoted-record arms of `PostView.embed` for quote posts. No library
+module is touched — the generated models already model these cases
+via the open unions `FeedViewPostReasonUnion` and `PostViewEmbedUnion`.
+
+## Data model recap (from generated code)
+
+```kotlin
+// app.bsky.feed.FeedViewPost
+data class FeedViewPost(
+    val post: PostView,
+    val reason: FeedViewPostReasonUnion? = null,  // ReasonRepost | ReasonPin | Unknown
+    val reply: ReplyRef? = null,
+    ...
+)
+
+// app.bsky.feed.ReasonRepost  (one arm of FeedViewPostReasonUnion)
+data class ReasonRepost(
+    val by: ProfileViewBasic,   // contains .handle, .displayName, .avatar
+    val indexedAt: Datetime,
+    val uri: AtUri? = null,
+    val cid: Cid? = null,
+) : FeedViewPostReasonUnion
+
+// app.bsky.embed.RecordView  (one arm of PostViewEmbedUnion)
+data class RecordView(
+    val record: RecordViewRecordUnion,  // RecordViewRecord | NotFound | Blocked | Detached | Unknown
+) : PostViewEmbedUnion
+
+// app.bsky.embed.RecordWithMediaView  (another arm)
+data class RecordWithMediaView(
+    val record: RecordView,
+    val media: RecordWithMediaViewMediaUnion,  // ImagesView | VideoView | ExternalView | Unknown
+) : PostViewEmbedUnion
+
+// The actual quoted post payload
+data class RecordViewRecord(
+    val author: ProfileViewBasic,
+    val value: JsonObject,               // decode to app.bsky.feed.Post for text/createdAt
+    val embeds: List<RecordViewRecordEmbedsUnion>? = null,
+    ...
+)
+```
+
+## Repost header
+
+In `PostRow`, before the existing author/handle row, pattern-match on
+`entry.reason`:
+
+```kotlin
+@Composable
+private fun RepostHeader(reason: FeedViewPostReasonUnion?) {
+    val repost = reason as? ReasonRepost ?: return
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier.padding(bottom = 4.dp),
+    ) {
+        Icon(Icons.Filled.Repeat, contentDescription = null, modifier = Modifier.size(14.dp))
+        Spacer(Modifier.size(6.dp))
+        Text(
+            "Reposted by @${repost.by.handle.raw}",
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+```
+
+`ReasonPin` and the `Unknown` arm render nothing (the header just does
+not appear). This keeps the change focused on reposts; pinned-post UI
+can follow later.
+
+Call site in `PostRow` becomes:
+
+```kotlin
+Column(Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 12.dp)) {
+    RepostHeader(entry.reason)   // NEW
+    Row(...) { /* existing author + timestamp */ }
+    ...
+}
+```
+
+That requires threading `FeedViewPost` (not just `PostView`) into
+`PostRow`. The existing `entry` already carries it at the call site.
+
+## Quoted record card
+
+Add a helper that extracts the quoted record, regardless of which
+embed arm is in use:
+
+```kotlin
+internal fun extractQuotedRecord(post: PostView): RecordViewRecord? =
+    when (val embed = post.embed) {
+        is RecordView -> embed.record as? RecordViewRecord
+        is RecordWithMediaView -> embed.record.record as? RecordViewRecord
+        else -> null
+    }
+```
+
+The `as? RecordViewRecord` cast filters `NotFound` / `Blocked` /
+`Detached` / `Unknown` arms of `RecordViewRecordUnion` — those render
+as a separate placeholder composable:
+
+```kotlin
+internal fun extractQuotedPlaceholder(post: PostView): String? =
+    when (val embed = post.embed) {
+        is RecordView -> placeholderFor(embed.record)
+        is RecordWithMediaView -> placeholderFor(embed.record.record)
+        else -> null
+    }
+
+private fun placeholderFor(union: RecordViewRecordUnion): String? = when (union) {
+    is RecordViewNotFound -> "Quoted post not found"
+    is RecordViewBlocked -> "Quoted post from a blocked account"
+    is RecordViewDetached -> "Quoted post was detached by its author"
+    is RecordViewRecordUnion.Unknown -> "Quoted post unavailable"
+    is RecordViewRecord -> null
+}
+```
+
+The quoted card is rendered between the comment text and the existing
+image thumbnail row:
+
+```kotlin
+@Composable
+private fun QuotedRecordCard(record: RecordViewRecord) {
+    val quoted = runCatching { record.value.decodeRecord<Post>() }.getOrNull()
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = 8.dp)
+            .clip(RoundedCornerShape(8.dp))
+            .border(1.dp, MaterialTheme.colorScheme.outlineVariant, RoundedCornerShape(8.dp))
+            .padding(12.dp),
+    ) {
+        Text("@${record.author.handle.raw}", style = MaterialTheme.typography.bodySmall, fontWeight = FontWeight.Bold)
+        quoted?.text?.takeIf { it.isNotBlank() }?.let {
+            Spacer(Modifier.height(4.dp))
+            Text(it, style = MaterialTheme.typography.bodyMedium)
+        }
+        extractFirstImageThumbFromEmbeds(record.embeds)?.let { url ->
+            Spacer(Modifier.height(8.dp))
+            AsyncImage(model = url, contentDescription = null, /* ... */)
+        }
+    }
+}
+```
+
+## Media embed on quote+media
+
+`RecordWithMediaView.media` is its own open union. Reuse the same
+extractor logic for `ImagesView` that `extractFirstImageThumb` already
+uses:
+
+```kotlin
+internal fun extractFirstImageThumb(post: PostView): String? =
+    when (val embed = post.embed) {
+        is ImagesView -> embed.images.firstOrNull()?.thumb?.raw
+        is RecordWithMediaView -> (embed.media as? ImagesView)?.images?.firstOrNull()?.thumb?.raw
+        else -> null
+    }
+```
+
+This keeps the single `thumbUrl` value in `PostRow` — no layout
+shuffling required. The quoted card renders above it.
+
+## Test fixtures
+
+`FeedScreenTest` currently exercises the plain-post and
+`ImagesView`-embed paths. Add two fixture timelines:
+
+1. **Repost**: `FeedViewPost` with `reason = ReasonRepost(by = <profile>, indexedAt = ...)`
+   and a regular post. Assert `extractFirstImageThumb` behavior unchanged
+   and that a `Composable`-facing helper reports the reposter handle.
+2. **Quote post**: `PostView.embed = RecordView(record = RecordViewRecord(...))`
+   where the inner `value` JSON deserializes to an `app.bsky.feed.Post`.
+   Assert `extractQuotedRecord` returns a non-null `RecordViewRecord`
+   with the expected author handle and decoded text.
+3. **Quote+media**: `PostView.embed = RecordWithMediaView(record = ..., media = ImagesView(...))`.
+   Assert both `extractQuotedRecord` and `extractFirstImageThumb`
+   return non-null.
+4. **Unknown/Blocked/NotFound**: Each rendered via
+   `RecordView(record = <placeholder arm>)`. Assert `extractQuotedRecord`
+   returns null and `extractQuotedPlaceholder` returns the expected
+   string.
+
+All fixtures use canned JSON decoded through the existing MockEngine
+helpers — no live network, in line with the sample smoke-test rule.
+
+## Non-goals
+
+- **ReasonPin UI**: rendering a "Pinned" chip. Unions are handled
+  (no crash on the `ReasonPin` arm), but we deliberately don't add
+  the chip in this change.
+- **Nested quotes**: a quoted post that itself quotes another post.
+  `RecordViewRecord.embeds` is available but ignored — only the
+  first-level quote is rendered.
+- **Video and external link embeds** inside
+  `RecordWithMediaView.media`. Only `ImagesView` is surfaced; other
+  arms fall through silently.
+- **Tap-to-navigate** into a quoted post's thread. The quoted card is
+  display-only for now.
+- **Repost action button** (adding a repost affordance next to like).
+  Out of scope; this change is purely about rendering.

--- a/openspec/changes/sample-repost-embeds/proposal.md
+++ b/openspec/changes/sample-repost-embeds/proposal.md
@@ -1,0 +1,62 @@
+## Why
+
+The Android sample currently collapses two distinct Bluesky feed concepts
+into a plain text row:
+
+1. **Reposts** (`FeedViewPost.reason = ReasonRepost`) render with the
+   original author's handle and no attribution to the account that
+   reposted them. From the viewer's perspective the post appears in the
+   timeline "out of nowhere" — there is no "Reposted by @alice" header.
+2. **Quote posts** (`PostView.embed = RecordView` /
+   `RecordWithMediaView`) render the quoting user's comment text but
+   silently drop the embedded original post. The feed shows a bare
+   comment with no indication of what it refers to, which makes the
+   thread unreadable.
+
+Both variants are modeled correctly in the generated code (the union
+arms exist in `FeedViewPostReasonUnion` and `PostViewEmbedUnion`), so
+this is strictly a sample-UI gap. Surfacing reposts and quoted records
+demonstrates how a downstream consumer pattern-matches the generated
+open unions — the primary value the sample exists to show.
+
+## What Changes
+
+- **Repost attribution**: When a `FeedViewPost` carries a `ReasonRepost`
+  reason, render a compact "Reposted by @handle" header above the post
+  row using `reason.by.handle`.
+- **Quote post rendering**: When a `PostView.embed` resolves to
+  `RecordView` (quote-only) or `RecordWithMediaView` (quote + media),
+  render the embedded `RecordViewRecord` as a bordered sub-card inside
+  the outer post row, showing the quoted author handle, the quoted
+  post's text (decoded from `value: JsonObject` via `decodeRecord<Post>()`),
+  and the quoted post's first image thumbnail if present in `embeds`.
+- **Graceful fallbacks for union variants we don't own**:
+  `RecordViewNotFound`, `RecordViewBlocked`, `RecordViewDetached`, and
+  the open-union `Unknown` arm all render a small italic placeholder
+  ("Quoted post unavailable") instead of being dropped silently.
+- **Media embeds inside quote+media**: The media half of
+  `RecordWithMediaView` reuses the existing `ImagesView` thumbnail
+  extractor so quote-with-image posts render both the quoted card and
+  the new image.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `android-sample`: Feed row renders the `FeedViewPost.reason` header
+  for reposts and the `PostView.embed` record/recordWithMedia variants
+  as an embedded quoted card. Existing text / image / like / delete
+  behavior is unchanged.
+
+## Impact
+
+- **samples/android**: `FeedScreen.kt` gains a repost header composable
+  and a quoted-record sub-card composable. `extractFirstImageThumb` is
+  extended (or a sibling helper is added) to unwrap
+  `RecordWithMediaView.media` before falling through to `ImagesView`.
+  `FeedScreenTest` gains fixtures exercising repost + quote-post JSON.
+- **at-protocol-runtime / at-protocol-models / at-protocol-generator**:
+  No changes. Existing generated models already expose every field the
+  sample needs.
+- **Breaking changes**: None. This change is additive to the sample
+  module only and does not alter any library module or published API.

--- a/openspec/changes/sample-repost-embeds/specs/android-sample/spec.md
+++ b/openspec/changes/sample-repost-embeds/specs/android-sample/spec.md
@@ -1,0 +1,107 @@
+## ADDED Requirements
+
+### Requirement: Sample SHALL display repost attribution for ReasonRepost feed entries
+
+When a `FeedViewPost` returned by `app.bsky.feed.getTimeline` carries a
+`reason` that deserializes to the `ReasonRepost` arm of
+`FeedViewPostReasonUnion`, the feed row SHALL render a "Reposted by
+@{handle}" header above the original post content, sourced from
+`reason.by.handle`. Entries with a `null` reason, a `ReasonPin` reason,
+or the open-union `Unknown` reason arm SHALL render without the
+repost header and SHALL NOT crash.
+
+#### Scenario: Repost reason surfaces the reposter handle
+
+- **WHEN** the timeline contains a `FeedViewPost` whose `reason`
+  deserializes to `ReasonRepost(by = ProfileViewBasic(handle = "alice.bsky.social"), ...)`
+- **THEN** the row renders the text "Reposted by @alice.bsky.social"
+  above the existing author handle and timestamp row
+- **AND** the original post's author handle, text, and any image embed
+  continue to render unchanged below the header
+
+#### Scenario: Non-repost reasons render without a header
+
+- **WHEN** the timeline contains entries whose `reason` is `null`,
+  a `ReasonPin`, or the `Unknown` arm of `FeedViewPostReasonUnion`
+- **THEN** the row renders no repost header
+- **AND** no exception is thrown during composition
+
+### Requirement: Sample SHALL render the embedded quoted record for RecordView embeds
+
+When a `PostView.embed` deserializes to the `RecordView` arm of
+`PostViewEmbedUnion` and `RecordView.record` is a `RecordViewRecord`,
+the feed row SHALL render a bordered sub-card containing the quoted
+author handle, the quoted post text (decoded from `RecordViewRecord.value`
+as `app.bsky.feed.Post`), and the first image thumbnail from the
+quoted post's `embeds`, if one is present.
+
+#### Scenario: Quote post renders both comment and embedded record
+
+- **WHEN** the timeline contains a `PostView` whose own record has
+  non-empty text "check this out" and whose `embed` field deserializes
+  to `RecordView(record = RecordViewRecord(author = alice, value = {...text: "original post"...}))`
+- **THEN** the row renders the outer comment text "check this out"
+- **AND** below it, a bordered sub-card renders "@alice…" as the
+  quoted author and "original post" as the quoted text
+
+#### Scenario: Quoted record value that fails to decode renders only the author
+
+- **WHEN** the quoted `RecordViewRecord.value` JSON cannot be decoded
+  into `app.bsky.feed.Post` (e.g. because the record is a custom
+  collection outside the sample's known types)
+- **THEN** the quoted sub-card still renders with the quoted author
+  handle
+- **AND** the sample does not crash or drop the outer post from the feed
+
+### Requirement: Sample SHALL render quoted record and media together for RecordWithMediaView embeds
+
+When a `PostView.embed` deserializes to the `RecordWithMediaView` arm
+of `PostViewEmbedUnion`, the feed row SHALL render both (a) the
+embedded quoted record sub-card described above, extracted from
+`RecordWithMediaView.record.record`, and (b) the first image thumbnail
+extracted from `RecordWithMediaView.media` when that media union is
+the `ImagesView` arm. Non-image media arms (video, external, Unknown)
+SHALL render the quoted card with no outer thumbnail, without crashing.
+
+#### Scenario: Quote + image embed renders the quoted card above the thumbnail
+
+- **WHEN** the timeline contains a `PostView` whose `embed` deserializes
+  to `RecordWithMediaView(record = RecordView(record = RecordViewRecord(...)), media = ImagesView(images = [img, ...]))`
+- **THEN** the row renders the quoted record sub-card (author + text)
+- **AND** below the sub-card renders the first image's `thumb` URL
+  via `AsyncImage`
+
+#### Scenario: Quote + non-image media renders only the quoted card
+
+- **WHEN** the `media` arm of `RecordWithMediaView` is `VideoView`,
+  `ExternalView`, or the open-union `Unknown` variant
+- **THEN** the row renders the quoted record sub-card
+- **AND** renders no outer media thumbnail
+- **AND** does not crash
+
+### Requirement: Sample SHALL render a graceful placeholder for unavailable quoted records
+
+When a `PostView.embed` is `RecordView` or `RecordWithMediaView` but
+the inner `record` resolves to `RecordViewNotFound`,
+`RecordViewBlocked`, `RecordViewDetached`, or the `Unknown` arm of
+`RecordViewRecordUnion`, the feed row SHALL render a small italic
+placeholder string in place of the quoted sub-card rather than dropping
+the embed silently. The outer post's text, author, and like/delete
+controls SHALL render unchanged.
+
+#### Scenario: Blocked quoted record renders a placeholder
+
+- **WHEN** `PostView.embed = RecordView(record = RecordViewBlocked(...))`
+- **THEN** the row renders an italic placeholder reading "Quoted post
+  from a blocked account" (or equivalent) in the location the quoted
+  sub-card would otherwise occupy
+- **AND** the outer post renders normally
+
+#### Scenario: Unknown quoted record arm renders a placeholder
+
+- **WHEN** the inner `record` resolves to the `Unknown` arm of
+  `RecordViewRecordUnion` because the server returned a newer lexicon
+  type than the sample knows
+- **THEN** the row renders an italic placeholder reading "Quoted post
+  unavailable" (or equivalent) and does not drop the outer post or
+  throw

--- a/openspec/changes/sample-repost-embeds/tasks.md
+++ b/openspec/changes/sample-repost-embeds/tasks.md
@@ -1,0 +1,58 @@
+## 1. Repost attribution header
+
+- [x] 1.1 Thread `FeedViewPost` (not just `PostView`) into `PostRow` so
+      the row can see `entry.reason`
+- [x] 1.2 Add a `RepostHeader` composable that pattern-matches
+      `entry.reason as? ReasonRepost` and renders
+      "Reposted by @${reason.by.handle.raw}" with a small repeat icon
+- [x] 1.3 Render the header above the existing author/timestamp row,
+      only when the cast succeeds (ReasonPin / Unknown / null → no header)
+
+## 2. Quoted record extraction helpers
+
+- [x] 2.1 Add `extractQuotedRecord(post: PostView): RecordViewRecord?`
+      that unwraps `RecordView.record` and `RecordWithMediaView.record.record`,
+      returning null for the NotFound / Blocked / Detached / Unknown arms
+- [x] 2.2 Add `extractQuotedPlaceholder(post: PostView): String?`
+      returning a localized placeholder for each non-record arm
+- [x] 2.3 Extend `extractFirstImageThumb` to also accept
+      `RecordWithMediaView` by inspecting `embed.media as? ImagesView`
+
+## 3. Quoted record card composable
+
+- [x] 3.1 Add a `QuotedRecordCard(record: RecordViewRecord)` composable
+      with a bordered rounded container
+- [x] 3.2 Decode `record.value` to `app.bsky.feed.Post` via
+      `decodeRecord<Post>()`; tolerate decode failure by rendering only
+      the quoted author handle
+- [x] 3.3 Render quoted author handle, quoted post text (if non-blank),
+      and the first image thumbnail from `record.embeds` if present
+- [x] 3.4 Wire the card into `PostRow` between the comment text and the
+      outer image thumbnail; render the placeholder text in the same slot
+      when `extractQuotedRecord` returns null but `extractQuotedPlaceholder`
+      returns a string
+
+## 4. Tests
+
+- [x] 4.1 Add a canned-JSON fixture for a reposted plain post and assert
+      the extracted reposter handle matches
+- [x] 4.2 Add a canned-JSON fixture for a quote post (RecordView arm)
+      and assert `extractQuotedRecord` returns the expected author and
+      decoded text
+- [x] 4.3 Add a canned-JSON fixture for a quote+media post
+      (RecordWithMediaView arm) and assert both the quoted record and the
+      media thumbnail are extracted
+- [x] 4.4 Add canned-JSON fixtures for each non-record
+      RecordViewRecordUnion arm (NotFound, Blocked, Detached, Unknown)
+      and assert `extractQuotedPlaceholder` returns the expected text
+      and `extractQuotedRecord` returns null
+- [x] 4.5 Run `./gradlew :samples:android:testDebugUnitTest` and confirm
+      all new tests pass alongside existing ones
+
+## 5. Build verification
+
+- [x] 5.1 `./gradlew :samples:android:assembleDebug` builds
+- [x] 5.2 `./gradlew spotlessCheck` passes
+- [x] 5.3 Manual test on device: log in, scroll the timeline, and confirm
+      reposts display a "Reposted by" header and quote posts display a
+      bordered sub-card with the quoted author + text

--- a/samples/android/src/main/kotlin/io/github/kikin81/atproto/samples/bluesky/ui/FeedScreen.kt
+++ b/samples/android/src/main/kotlin/io/github/kikin81/atproto/samples/bluesky/ui/FeedScreen.kt
@@ -1,5 +1,6 @@
 package io.github.kikin81.atproto.samples.bluesky.ui
 
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -19,6 +20,7 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.FavoriteBorder
+import androidx.compose.material.icons.filled.Repeat
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -38,13 +40,25 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import coil.compose.AsyncImage
 import io.github.kikin81.atproto.app.bsky.embed.ImagesView
+import io.github.kikin81.atproto.app.bsky.embed.RecordView
+import io.github.kikin81.atproto.app.bsky.embed.RecordViewBlocked
+import io.github.kikin81.atproto.app.bsky.embed.RecordViewDetached
+import io.github.kikin81.atproto.app.bsky.embed.RecordViewNotFound
+import io.github.kikin81.atproto.app.bsky.embed.RecordViewRecord
+import io.github.kikin81.atproto.app.bsky.embed.RecordViewRecordEmbedsUnion
+import io.github.kikin81.atproto.app.bsky.embed.RecordViewRecordUnion
+import io.github.kikin81.atproto.app.bsky.embed.RecordWithMediaView
+import io.github.kikin81.atproto.app.bsky.feed.FeedViewPost
+import io.github.kikin81.atproto.app.bsky.feed.FeedViewPostReasonUnion
 import io.github.kikin81.atproto.app.bsky.feed.Post
 import io.github.kikin81.atproto.app.bsky.feed.PostView
+import io.github.kikin81.atproto.app.bsky.feed.ReasonRepost
 import io.github.kikin81.atproto.runtime.Datetime
 import io.github.kikin81.atproto.runtime.decodeRecord
 import java.time.OffsetDateTime
@@ -103,7 +117,7 @@ fun FeedScreen(
                     LazyColumn(Modifier.fillMaxSize()) {
                         items(s.feed) { entry ->
                             PostRow(
-                                post = entry.post,
+                                entry = entry,
                                 isOwnPost = entry.post.author.did.raw == currentDid,
                                 onLikeToggle = { viewModel.onEvent(FeedEvent.ToggleLike(entry.post)) },
                                 onDelete = { viewModel.onEvent(FeedEvent.DeletePost(entry.post)) },
@@ -124,19 +138,23 @@ fun FeedScreen(
 
 @Composable
 private fun PostRow(
-    post: PostView,
+    entry: FeedViewPost,
     isOwnPost: Boolean,
     onLikeToggle: () -> Unit,
     onDelete: () -> Unit,
 ) {
+    val post = entry.post
     val record = runCatching { post.record.decodeRecord<Post>() }.getOrNull()
     val text = record?.text.orEmpty()
     val createdAt = record?.createdAt ?: post.indexedAt
     val thumbUrl = extractFirstImageThumb(post)
+    val quotedRecord = extractQuotedRecord(post)
+    val quotedPlaceholder = if (quotedRecord == null) extractQuotedPlaceholder(post) else null
     val isLiked = post.viewer?.like != null
     val likeCount = post.likeCount ?: 0
 
     Column(Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 12.dp)) {
+        RepostHeader(entry.reason)
         Row(verticalAlignment = Alignment.CenterVertically) {
             Text(
                 "@${post.author.handle.raw}",
@@ -153,6 +171,17 @@ private fun PostRow(
         if (text.isNotBlank()) {
             Spacer(Modifier.height(4.dp))
             Text(text, style = MaterialTheme.typography.bodyLarge)
+        }
+        if (quotedRecord != null) {
+            QuotedRecordCard(quotedRecord)
+        } else if (quotedPlaceholder != null) {
+            Spacer(Modifier.height(8.dp))
+            Text(
+                quotedPlaceholder,
+                style = MaterialTheme.typography.bodySmall,
+                fontStyle = FontStyle.Italic,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
         }
         if (thumbUrl != null) {
             Spacer(Modifier.height(8.dp))
@@ -195,10 +224,100 @@ private fun PostRow(
     }
 }
 
-internal fun extractFirstImageThumb(post: PostView): String? {
-    val embed = post.embed ?: return null
-    val imagesView = embed as? ImagesView ?: return null
-    return imagesView.images.firstOrNull()?.thumb?.raw
+internal fun extractFirstImageThumb(post: PostView): String? = when (val embed = post.embed) {
+    is ImagesView -> embed.images.firstOrNull()?.thumb?.raw
+    is RecordWithMediaView -> (embed.media as? ImagesView)?.images?.firstOrNull()?.thumb?.raw
+    else -> null
+}
+
+internal fun extractQuotedRecord(post: PostView): RecordViewRecord? = when (val embed = post.embed) {
+    is RecordView -> embed.record as? RecordViewRecord
+    is RecordWithMediaView -> embed.record.record as? RecordViewRecord
+    else -> null
+}
+
+internal fun extractQuotedPlaceholder(post: PostView): String? = when (val embed = post.embed) {
+    is RecordView -> placeholderFor(embed.record)
+    is RecordWithMediaView -> placeholderFor(embed.record.record)
+    else -> null
+}
+
+private fun placeholderFor(union: RecordViewRecordUnion): String? = when (union) {
+    is RecordViewNotFound -> "Quoted post not found"
+    is RecordViewBlocked -> "Quoted post from a blocked account"
+    is RecordViewDetached -> "Quoted post was detached by its author"
+    is RecordViewRecordUnion.Unknown -> "Quoted post unavailable"
+    is RecordViewRecord -> null
+    else -> null
+}
+
+private fun extractFirstImageThumbFromEmbeds(embeds: List<RecordViewRecordEmbedsUnion>?): String? {
+    embeds ?: return null
+    for (e in embeds) {
+        when (e) {
+            is ImagesView -> return e.images.firstOrNull()?.thumb?.raw
+            is RecordWithMediaView -> (e.media as? ImagesView)?.images?.firstOrNull()?.thumb?.raw?.let { return it }
+            else -> Unit
+        }
+    }
+    return null
+}
+
+@Composable
+private fun RepostHeader(reason: FeedViewPostReasonUnion?) {
+    val repost = reason as? ReasonRepost ?: return
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier.padding(bottom = 4.dp),
+    ) {
+        Icon(
+            imageVector = Icons.Filled.Repeat,
+            contentDescription = null,
+            modifier = Modifier.size(14.dp),
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Spacer(Modifier.size(6.dp))
+        Text(
+            "Reposted by @${repost.by.handle.raw}",
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
+private fun QuotedRecordCard(record: RecordViewRecord) {
+    val quoted = runCatching { record.value.decodeRecord<Post>() }.getOrNull()
+    val quotedText = quoted?.text.orEmpty()
+    val quotedThumb = extractFirstImageThumbFromEmbeds(record.embeds)
+
+    Spacer(Modifier.height(8.dp))
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(8.dp))
+            .border(1.dp, MaterialTheme.colorScheme.outlineVariant, RoundedCornerShape(8.dp))
+            .padding(12.dp),
+    ) {
+        Text(
+            "@${record.author.handle.raw}",
+            fontWeight = FontWeight.Bold,
+            style = MaterialTheme.typography.bodySmall,
+        )
+        if (quotedText.isNotBlank()) {
+            Spacer(Modifier.height(4.dp))
+            Text(quotedText, style = MaterialTheme.typography.bodyMedium)
+        }
+        if (quotedThumb != null) {
+            Spacer(Modifier.height(8.dp))
+            AsyncImage(
+                model = quotedThumb,
+                contentDescription = null,
+                modifier = Modifier.fillMaxWidth().height(160.dp).clip(RoundedCornerShape(6.dp)),
+                contentScale = ContentScale.Crop,
+            )
+        }
+    }
 }
 
 private val datetimeFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("MMM d, h:mm a")

--- a/samples/android/src/test/kotlin/io/github/kikin81/atproto/samples/bluesky/ui/FeedScreenTest.kt
+++ b/samples/android/src/test/kotlin/io/github/kikin81/atproto/samples/bluesky/ui/FeedScreenTest.kt
@@ -1,9 +1,12 @@
 package io.github.kikin81.atproto.samples.bluesky.ui
 
 import io.github.kikin81.atproto.app.bsky.embed.ImagesView
+import io.github.kikin81.atproto.app.bsky.embed.RecordView
+import io.github.kikin81.atproto.app.bsky.embed.RecordWithMediaView
 import io.github.kikin81.atproto.app.bsky.feed.GetTimelineResponse
 import io.github.kikin81.atproto.app.bsky.feed.Post
 import io.github.kikin81.atproto.app.bsky.feed.PostViewEmbedUnion
+import io.github.kikin81.atproto.app.bsky.feed.ReasonRepost
 import io.github.kikin81.atproto.runtime.decodeRecord
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
@@ -73,6 +76,106 @@ class FeedScreenTest {
         assertNull(post.embed)
         assertNull(extractFirstImageThumb(post))
         assertEquals("plain text post", post.record.decodeRecord<Post>().text)
+    }
+
+    @Test
+    fun repostReasonSurfacesReposterHandle() = runTest {
+        val response = json.decodeFromString(
+            GetTimelineResponse.serializer(),
+            TIMELINE_WITH_REPOST_REASON,
+        )
+        val entry = response.feed.single()
+
+        val reason = assertNotNull(entry.reason)
+        val repost = assertIs<ReasonRepost>(reason)
+        assertEquals("alice.bsky.social", repost.by.handle.raw)
+        // The underlying post and its extractors behave exactly like a plain post.
+        assertNull(extractFirstImageThumb(entry.post))
+        assertNull(extractQuotedRecord(entry.post))
+    }
+
+    @Test
+    fun quotePostExtractsEmbeddedRecord() = runTest {
+        val response = json.decodeFromString(
+            GetTimelineResponse.serializer(),
+            TIMELINE_WITH_QUOTE_POST,
+        )
+        val post = response.feed.single().post
+
+        val embed = assertNotNull(post.embed)
+        assertIs<RecordView>(embed)
+
+        val quoted = assertNotNull(extractQuotedRecord(post))
+        assertEquals("dan.bsky.social", quoted.author.handle.raw)
+        assertEquals("original post", quoted.value.decodeRecord<Post>().text)
+        assertNull(extractQuotedPlaceholder(post))
+        // Quote-only embeds carry no outer media.
+        assertNull(extractFirstImageThumb(post))
+    }
+
+    @Test
+    fun quotePostWithMediaExtractsBothQuoteAndThumb() = runTest {
+        val response = json.decodeFromString(
+            GetTimelineResponse.serializer(),
+            TIMELINE_WITH_QUOTE_AND_MEDIA,
+        )
+        val post = response.feed.single().post
+
+        val embed = assertNotNull(post.embed)
+        assertIs<RecordWithMediaView>(embed)
+
+        val quoted = assertNotNull(extractQuotedRecord(post))
+        assertEquals("eve.bsky.social", quoted.author.handle.raw)
+        assertEquals("quoted original", quoted.value.decodeRecord<Post>().text)
+        assertEquals("https://cdn.bsky.app/img/outer.jpg", extractFirstImageThumb(post))
+    }
+
+    @Test
+    fun blockedQuotedRecordYieldsPlaceholder() = runTest {
+        val response = json.decodeFromString(
+            GetTimelineResponse.serializer(),
+            TIMELINE_WITH_BLOCKED_QUOTE,
+        )
+        val post = response.feed.single().post
+
+        assertNull(extractQuotedRecord(post))
+        assertEquals("Quoted post from a blocked account", extractQuotedPlaceholder(post))
+    }
+
+    @Test
+    fun notFoundQuotedRecordYieldsPlaceholder() = runTest {
+        val response = json.decodeFromString(
+            GetTimelineResponse.serializer(),
+            TIMELINE_WITH_NOTFOUND_QUOTE,
+        )
+        val post = response.feed.single().post
+
+        assertNull(extractQuotedRecord(post))
+        assertEquals("Quoted post not found", extractQuotedPlaceholder(post))
+    }
+
+    @Test
+    fun detachedQuotedRecordYieldsPlaceholder() = runTest {
+        val response = json.decodeFromString(
+            GetTimelineResponse.serializer(),
+            TIMELINE_WITH_DETACHED_QUOTE,
+        )
+        val post = response.feed.single().post
+
+        assertNull(extractQuotedRecord(post))
+        assertEquals("Quoted post was detached by its author", extractQuotedPlaceholder(post))
+    }
+
+    @Test
+    fun unknownQuotedRecordArmYieldsPlaceholder() = runTest {
+        val response = json.decodeFromString(
+            GetTimelineResponse.serializer(),
+            TIMELINE_WITH_UNKNOWN_QUOTE,
+        )
+        val post = response.feed.single().post
+
+        assertNull(extractQuotedRecord(post))
+        assertEquals("Quoted post unavailable", extractQuotedPlaceholder(post))
     }
 
     private companion object {
@@ -155,6 +258,251 @@ class FeedScreenTest {
                       "createdAt": "2025-01-03T09:30:00Z"
                     },
                     "indexedAt": "2025-01-03T09:30:00Z"
+                  }
+                }
+              ]
+            }
+        """
+
+        const val TIMELINE_WITH_REPOST_REASON = """
+            {
+              "feed": [
+                {
+                  "post": {
+                    "uri": "at://did:plc:original/app.bsky.feed.post/reposted",
+                    "cid": "bafyorig",
+                    "author": {
+                      "did": "did:plc:original",
+                      "handle": "dan.bsky.social"
+                    },
+                    "record": {
+                      "text": "original content",
+                      "createdAt": "2025-02-01T00:00:00Z"
+                    },
+                    "indexedAt": "2025-02-01T00:00:00Z"
+                  },
+                  "reason": {
+                    "${'$'}type": "app.bsky.feed.defs#reasonRepost",
+                    "by": {
+                      "did": "did:plc:reposter",
+                      "handle": "alice.bsky.social"
+                    },
+                    "indexedAt": "2025-02-02T00:00:00Z"
+                  }
+                }
+              ]
+            }
+        """
+
+        const val TIMELINE_WITH_QUOTE_POST = """
+            {
+              "feed": [
+                {
+                  "post": {
+                    "uri": "at://did:plc:quoter/app.bsky.feed.post/q1",
+                    "cid": "bafyquote",
+                    "author": {
+                      "did": "did:plc:quoter",
+                      "handle": "bob.bsky.social"
+                    },
+                    "record": {
+                      "text": "check this out",
+                      "createdAt": "2025-03-01T00:00:00Z"
+                    },
+                    "embed": {
+                      "${'$'}type": "app.bsky.embed.record#view",
+                      "record": {
+                        "${'$'}type": "app.bsky.embed.record#viewRecord",
+                        "uri": "at://did:plc:original/app.bsky.feed.post/orig",
+                        "cid": "bafyorig",
+                        "author": {
+                          "did": "did:plc:original",
+                          "handle": "dan.bsky.social"
+                        },
+                        "value": {
+                          "${'$'}type": "app.bsky.feed.post",
+                          "text": "original post",
+                          "createdAt": "2025-02-28T00:00:00Z"
+                        },
+                        "indexedAt": "2025-02-28T00:00:00Z"
+                      }
+                    },
+                    "indexedAt": "2025-03-01T00:00:00Z"
+                  }
+                }
+              ]
+            }
+        """
+
+        const val TIMELINE_WITH_QUOTE_AND_MEDIA = """
+            {
+              "feed": [
+                {
+                  "post": {
+                    "uri": "at://did:plc:quoter/app.bsky.feed.post/q2",
+                    "cid": "bafyquote2",
+                    "author": {
+                      "did": "did:plc:quoter",
+                      "handle": "bob.bsky.social"
+                    },
+                    "record": {
+                      "text": "quote + image",
+                      "createdAt": "2025-03-02T00:00:00Z"
+                    },
+                    "embed": {
+                      "${'$'}type": "app.bsky.embed.recordWithMedia#view",
+                      "record": {
+                        "${'$'}type": "app.bsky.embed.record#view",
+                        "record": {
+                          "${'$'}type": "app.bsky.embed.record#viewRecord",
+                          "uri": "at://did:plc:original/app.bsky.feed.post/orig2",
+                          "cid": "bafyorig2",
+                          "author": {
+                            "did": "did:plc:original",
+                            "handle": "eve.bsky.social"
+                          },
+                          "value": {
+                            "${'$'}type": "app.bsky.feed.post",
+                            "text": "quoted original",
+                            "createdAt": "2025-03-01T12:00:00Z"
+                          },
+                          "indexedAt": "2025-03-01T12:00:00Z"
+                        }
+                      },
+                      "media": {
+                        "${'$'}type": "app.bsky.embed.images#view",
+                        "images": [
+                          {
+                            "thumb": "https://cdn.bsky.app/img/outer.jpg",
+                            "fullsize": "https://cdn.bsky.app/img/outer-full.jpg",
+                            "alt": "outer image"
+                          }
+                        ]
+                      }
+                    },
+                    "indexedAt": "2025-03-02T00:00:00Z"
+                  }
+                }
+              ]
+            }
+        """
+
+        const val TIMELINE_WITH_BLOCKED_QUOTE = """
+            {
+              "feed": [
+                {
+                  "post": {
+                    "uri": "at://did:plc:quoter/app.bsky.feed.post/blocked",
+                    "cid": "bafyblocked",
+                    "author": {
+                      "did": "did:plc:quoter",
+                      "handle": "bob.bsky.social"
+                    },
+                    "record": {
+                      "text": "",
+                      "createdAt": "2025-04-01T00:00:00Z"
+                    },
+                    "embed": {
+                      "${'$'}type": "app.bsky.embed.record#view",
+                      "record": {
+                        "${'$'}type": "app.bsky.embed.record#viewBlocked",
+                        "uri": "at://did:plc:blocked/app.bsky.feed.post/x",
+                        "blocked": true,
+                        "author": {
+                          "did": "did:plc:blocked"
+                        }
+                      }
+                    },
+                    "indexedAt": "2025-04-01T00:00:00Z"
+                  }
+                }
+              ]
+            }
+        """
+
+        const val TIMELINE_WITH_NOTFOUND_QUOTE = """
+            {
+              "feed": [
+                {
+                  "post": {
+                    "uri": "at://did:plc:quoter/app.bsky.feed.post/notfound",
+                    "cid": "bafynotfound",
+                    "author": {
+                      "did": "did:plc:quoter",
+                      "handle": "bob.bsky.social"
+                    },
+                    "record": {
+                      "text": "",
+                      "createdAt": "2025-04-02T00:00:00Z"
+                    },
+                    "embed": {
+                      "${'$'}type": "app.bsky.embed.record#view",
+                      "record": {
+                        "${'$'}type": "app.bsky.embed.record#viewNotFound",
+                        "uri": "at://did:plc:gone/app.bsky.feed.post/y",
+                        "notFound": true
+                      }
+                    },
+                    "indexedAt": "2025-04-02T00:00:00Z"
+                  }
+                }
+              ]
+            }
+        """
+
+        const val TIMELINE_WITH_DETACHED_QUOTE = """
+            {
+              "feed": [
+                {
+                  "post": {
+                    "uri": "at://did:plc:quoter/app.bsky.feed.post/detached",
+                    "cid": "bafydetached",
+                    "author": {
+                      "did": "did:plc:quoter",
+                      "handle": "bob.bsky.social"
+                    },
+                    "record": {
+                      "text": "",
+                      "createdAt": "2025-04-03T00:00:00Z"
+                    },
+                    "embed": {
+                      "${'$'}type": "app.bsky.embed.record#view",
+                      "record": {
+                        "${'$'}type": "app.bsky.embed.record#viewDetached",
+                        "uri": "at://did:plc:author/app.bsky.feed.post/z",
+                        "detached": true
+                      }
+                    },
+                    "indexedAt": "2025-04-03T00:00:00Z"
+                  }
+                }
+              ]
+            }
+        """
+
+        const val TIMELINE_WITH_UNKNOWN_QUOTE = """
+            {
+              "feed": [
+                {
+                  "post": {
+                    "uri": "at://did:plc:quoter/app.bsky.feed.post/unkq",
+                    "cid": "bafyunkq",
+                    "author": {
+                      "did": "did:plc:quoter",
+                      "handle": "bob.bsky.social"
+                    },
+                    "record": {
+                      "text": "",
+                      "createdAt": "2025-04-04T00:00:00Z"
+                    },
+                    "embed": {
+                      "${'$'}type": "app.bsky.embed.record#view",
+                      "record": {
+                        "${'$'}type": "app.bsky.embed.record#viewFromFuture",
+                        "custom": "data"
+                      }
+                    },
+                    "indexedAt": "2025-04-04T00:00:00Z"
                   }
                 }
               ]


### PR DESCRIPTION
## Summary

- Renders "Reposted by @handle" attribution above feed rows whose `FeedViewPost.reason` deserializes to the `ReasonRepost` arm
- Renders `RecordView` and `RecordWithMediaView` embed arms as a bordered quoted sub-card (author, decoded post text, inner image), with an italic placeholder for NotFound / Blocked / Detached / Unknown arms
- Extends `extractFirstImageThumb` to also unwrap `RecordWithMediaView.media` so quote+image posts render both the quoted card and the outer thumbnail
- Adds an OpenSpec change under `openspec/changes/sample-repost-embeds/` (proposal + design + spec delta + tasks) documenting the gap and the fix

No library module is modified — the generated `FeedViewPostReasonUnion` and `PostViewEmbedUnion` already modeled every case; this is strictly a sample-UI gap being filled.

## Test plan

- [x] `./gradlew :samples:android:testDebugUnitTest` — 10/10 pass (3 existing + 7 new fixtures covering repost, quote-only, quote+media, blocked / notFound / detached / unknown arms)
- [x] `./gradlew :samples:android:assembleDebug` builds
- [x] `./gradlew spotlessCheck` passes
- [x] Manual device test: reposts show attribution header, quote posts render the embedded record sub-card

🤖 Generated with [Claude Code](https://claude.com/claude-code)