### PR TITLE
docs: add CONTRIBUTING guide and GitHub issue/PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,57 @@
+---
+name: Bug report
+about: Something in the SDK is broken or behaves unexpectedly
+title: "[bug] "
+labels: bug
+assignees: ''
+---
+
+## Summary
+
+<!-- One or two sentences. What did you expect, and what actually happened? -->
+
+## Affected module
+
+<!-- Delete the ones that don't apply. -->
+
+- [ ] `at-protocol-runtime`
+- [ ] `at-protocol-generator`
+- [ ] `at-protocol-models` (generated code)
+- [ ] `at-protocol-oauth`
+- [ ] `samples:android`
+- [ ] Docs / build / CI
+
+## Versions
+
+- **Library version:** <!-- e.g. 4.5.0 -->
+- **Kotlin version:** <!-- e.g. 2.1.0 -->
+- **JDK:** <!-- e.g. Temurin 17.0.12 -->
+- **Platform:** <!-- JVM / Android API 34 / iOS 17 / etc. -->
+- **Ktor version (if relevant):** <!-- e.g. 3.0.0 -->
+
+## Reproduction
+
+<!--
+Minimum code to reproduce. A snippet is fine; a tiny repo is ideal.
+If the bug requires a real PDS / Bluesky account, say so — it doesn't
+block the report but helps us triage.
+-->
+
+```kotlin
+// your code here
+```
+
+## Stack trace / error output
+
+<details>
+<summary>Full stack trace</summary>
+
+```
+paste the full trace here, not a screenshot
+```
+
+</details>
+
+## What I've already tried
+
+<!-- Optional but helpful — any workarounds, related issues, etc. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question or usage help
+    url: https://github.com/kikin81/atproto-kotlin/discussions
+    about: For how-to questions and design discussion, open a Discussion instead of an issue.
+  - name: AT Protocol spec questions
+    url: https://atproto.com
+    about: Questions about the AT Protocol itself (not this SDK) belong upstream.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,46 @@
+---
+name: Feature request
+about: Suggest a new capability or improvement
+title: "[feat] "
+labels: enhancement
+assignees: ''
+---
+
+## Problem
+
+<!--
+What are you trying to do, and why is it hard or impossible with the
+current API? Be concrete — "I want to build X and can't because Y" is
+worth more than "it would be nice if…".
+-->
+
+## Proposed solution
+
+<!--
+Sketch the API or behavior you'd like. Code snippets welcome. Don't worry
+about polishing — we'll iterate in the thread.
+-->
+
+```kotlin
+// what you want to be able to write
+```
+
+## Alternatives considered
+
+<!-- Other approaches you've thought about, and why they don't fit. -->
+
+## Scope
+
+<!-- Delete the ones that don't apply. -->
+
+- [ ] New public API on `at-protocol-runtime`
+- [ ] Change to generator output (would affect all generated models)
+- [ ] OAuth / auth flow
+- [ ] Sample app / docs
+- [ ] Other
+
+## Willing to contribute?
+
+- [ ] I'd like to open the PR myself
+- [ ] I can help test a maintainer's implementation
+- [ ] Just filing the request

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,45 @@
+<!--
+Thanks for the PR! A few quick things:
+
+- Title should follow Conventional Commits (feat:, fix:, chore:, docs:, …).
+  A feat: or fix: title on main cuts a release, so pick deliberately.
+- If this closes an issue, reference it below (e.g. "Closes #123").
+- Tick the checklist at the bottom before requesting review.
+-->
+
+## Summary
+
+<!-- What does this PR do, and why? One short paragraph. -->
+
+## Affected module
+
+- [ ] `at-protocol-runtime`
+- [ ] `at-protocol-generator`
+- [ ] `at-protocol-models` (generator change — regenerated output included)
+- [ ] `at-protocol-oauth`
+- [ ] `samples:android`
+- [ ] Docs / build / CI
+
+## How it was verified
+
+<!--
+List the commands / flows you actually ran. Be specific — "works on my
+machine" is not enough. Examples:
+
+- ./gradlew :at-protocol-oauth:test
+- ./gradlew :at-protocol-generator:test (golden files updated, diff reviewed)
+- Installed sample app, logged in, scrolled 3 pages of timeline
+-->
+
+## Breaking changes
+
+<!-- If none, write "none". If yes, describe the break and the migration path. -->
+
+## Checklist
+
+- [ ] Tests added or updated (or: "N/A, docs-only")
+- [ ] `./gradlew build` passes locally
+- [ ] `./gradlew spotlessCheck` passes locally
+- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
+- [ ] For generator changes: golden fixtures regenerated and diff reviewed
+- [ ] For public API changes: KDoc added/updated

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,122 @@
+# Contributing to atproto-kotlin
+
+Thanks for considering a contribution! This project is a code-generated AT
+Protocol Kotlin Multiplatform SDK, so there are a few quirks worth knowing
+about before you open a PR.
+
+## Quick start
+
+```bash
+# 1. Clone and install the upstream lexicon corpus (pinned by CID).
+git clone https://github.com/kikin81/atproto-kotlin.git
+cd atproto-kotlin/at-protocol-generator && npx lex install --ci && cd -
+
+# 2. Build everything: runtime, generator, models, oauth, sample.
+./gradlew build
+```
+
+**Prerequisites:**
+
+- **JDK 17** (tracked by `.java-version` / `.sdkmanrc`)
+- **Node 22+** (for `npx lex install`)
+- **Android SDK** (API 36+, only if you're touching `:samples:android`)
+
+Gradle 9.3.1 ships via the wrapper — no separate install needed.
+
+## Repo map: what you can edit
+
+| Module | Hand-written? | Notes |
+|---|---|---|
+| `:at-protocol-runtime` | **Yes** | Value classes, `AtField`, `OpenUnionSerializer`, `XrpcClient`, `AuthProvider`. Edit freely. |
+| `:at-protocol-generator` | **Yes** | The Lexicon parser, IR, and KotlinPoet emitters. Edit freely, but see "Regenerating models" below. |
+| `:at-protocol-models` | **No — generated** | Do not edit files under `at-protocol-models/build/generated/…`. To change generated output, edit the generator. |
+| `:at-protocol-oauth` | **Yes** | OAuth 2.0 + PAR + PKCE + DPoP. Edit freely. |
+| `:samples:android` | **Yes** | Reference Compose consumer. Great place to verify end-to-end changes. |
+
+### Regenerating models after generator changes
+
+```bash
+./gradlew :at-protocol-models:generateModels
+```
+
+If you change emitter output, update the golden fixtures:
+
+```bash
+GOLDEN_UPDATE=1 ./gradlew :at-protocol-generator:test --tests '*GoldenFileTest*'
+```
+
+Review the diff carefully — golden updates are a signal, not a rubber stamp.
+
+## The contribution flow
+
+1. **Open an issue first** for anything non-trivial. It's faster to align on
+   approach before code than to rework a PR. For typo fixes or small
+   documentation tweaks, just open a PR.
+2. **Fork + branch** from `main`. Use a descriptive branch name
+   (`feat/<thing>`, `fix/<thing>`).
+3. **Write tests.** JUnit 5 via `kotlin.test` across all modules. MockEngine
+   (Ktor) for HTTP-level tests. See existing tests for the pattern.
+4. **Verify locally** before pushing:
+   ```bash
+   ./gradlew build spotlessCheck
+   ```
+5. **Conventional Commits** — enforced by commitlint. Use `feat:`, `fix:`,
+   `chore:`, `docs:`, `test:`, `refactor:`, `ci:`. A `feat:` or `fix:` on
+   `main` cuts a release, so pick the prefix deliberately.
+6. **Install pre-commit hooks once** so formatting + commit-msg validation run
+   locally:
+   ```bash
+   pre-commit install && pre-commit install --hook-type commit-msg
+   ```
+7. **Open a PR** against `main`. Fill out the template. CI must be green.
+
+## Verifying your change
+
+Depending on what you touched:
+
+- **Runtime or models:** unit tests under the relevant module are usually
+  enough. `./gradlew :at-protocol-runtime:jvmTest` or
+  `./gradlew :at-protocol-models:jvmTest`.
+- **Generator:** run the golden file tests and review the diff.
+- **OAuth:** `./gradlew :at-protocol-oauth:test` covers the MockEngine
+  flows. For end-to-end DPoP you'll want to run the Android sample.
+- **Anything consumer-facing:** build and run the sample app —
+  `./gradlew :samples:android:installDebug`. Logging in and scrolling the
+  timeline exercises OAuth, XRPC, open unions, and the generated service
+  surface in one go.
+
+## Code style
+
+Spotless + ktlint 1.4.1 are enforced. Pre-commit hooks and CI will block
+unformatted code. If you didn't install the hooks, run:
+
+```bash
+./gradlew spotlessApply
+```
+
+before committing. No wildcard imports. No max line length. Compose
+`@Composable` function naming is disabled (lowercase-friendly helper names
+are fine).
+
+## Larger architectural changes (OpenSpec)
+
+For significant structural work — new modules, generator rewrites, changes
+to the public API shape — this repo uses an
+[OpenSpec](https://github.com/kikin81/openspec) workflow under
+[`openspec/`](openspec/). You do **not** need to author an OpenSpec proposal
+for a bug fix or a minor feature.
+
+If your idea is large enough that it might need one, open an issue first
+and a maintainer will guide you through the process.
+
+## Releases (FYI)
+
+Every push to `main` runs semantic-release. `feat:` bumps minor, `fix:`
+bumps patch, `BREAKING CHANGE:` footer bumps major, everything else is
+no-release. Artifacts publish to Maven Central and GitHub Packages
+automatically. You don't need to touch version numbers — CI owns them.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under
+the [MIT License](LICENSE).


### PR DESCRIPTION
## Summary

- Adds a top-level `CONTRIBUTING.md` aimed at external Kotlin devs: quick-start build steps, a module map flagging `:at-protocol-models` as generated/do-not-edit, verification guidance per module, and a lean pointer to the OpenSpec flow for large architectural changes only.
- Adds `.github/ISSUE_TEMPLATE/` with `bug_report.md`, `feature_request.md`, and `config.yml` (disables blank issues, routes how-to questions to Discussions and upstream atproto spec questions to atproto.com).
- Adds `.github/PULL_REQUEST_TEMPLATE.md` with affected-module checklist, verification-commands section, and Conventional Commits reminder (since `feat:` / `fix:` titles cut releases on merge).

## Test plan

- [ ] Browse `CONTRIBUTING.md` on the PR page and confirm links render
- [ ] Open a draft issue on this branch and confirm bug/feature templates show up and blank issues are hidden
- [ ] Confirm this PR itself renders the new PR template (sanity check on the template)