### PR TITLE
docs(openspec): scope lexicon-drift-automation change

### DIFF
--- a/openspec/changes/lexicon-drift-automation/design.md
+++ b/openspec/changes/lexicon-drift-automation/design.md
@@ -1,0 +1,182 @@
+## Overview
+
+Automate lexicon drift detection via a scheduled GitHub Actions workflow
+that bumps `@atproto/lex`, regenerates models, and opens a PR when
+anything changes. The PR becomes the review surface for upstream changes.
+
+## Workflow: lexicon-bump.yaml
+
+### Trigger
+
+```yaml
+on:
+  schedule:
+    - cron: "0 14 * * 1" # 14:00 UTC Mondays → 7am PT, reviewable during the week
+  workflow_dispatch: {}   # manual kickoff for ad-hoc bumps
+```
+
+Weekly is a reasonable default: `@atproto/lex` on npm ships at roughly
+that cadence, and any faster pollutes the PR queue.
+
+### Job steps
+
+1. **Checkout** with a fetch depth of 1 and `token: ${{ secrets.RELEASE_PAT }}`
+   so the PR-creation step can push a branch.
+2. **Set up Node 22 + JDK 17** (matches existing workflows).
+3. **Bump the npm dependency**:
+   ```bash
+   cd at-protocol-generator
+   npm update @atproto/lex
+   ```
+   This respects the semver range in `package.json`. After this change
+   lands with an exact pin, we use a more explicit approach:
+   ```bash
+   npm install @atproto/lex@latest --save-exact
+   ```
+   This always grabs the newest published version and rewrites
+   `package.json` + `package-lock.json`.
+4. **Refresh the pinned corpus**: `npx lex install` (without `--ci`). This
+   rewrites `lexicons.json` with the newest CIDs and re-downloads the
+   corpus into `lexicons/` (gitignored).
+5. **Regenerate models**: `./gradlew :at-protocol-generator:generateModels`.
+6. **Detect changes**:
+   ```bash
+   git add at-protocol-generator/package.json \
+           at-protocol-generator/package-lock.json \
+           at-protocol-generator/lexicons.json \
+           at-protocol-models/build/generated/source/lexicon/
+   if git diff --cached --quiet; then
+     echo "no_changes=true" >> "$GITHUB_OUTPUT"
+   fi
+   ```
+   Note: generated sources live under `build/`, which is **not** committed.
+   We don't commit generated sources — the PR only includes `package.json`,
+   `package-lock.json`, and `lexicons.json`. Generator output is regenerated
+   from these three files, so the tests on the PR already validate it.
+7. **Open or update a PR** via `peter-evans/create-pull-request@v7`:
+   - Branch: `chore/lexicon-bump` (stable branch — successive runs update
+     the same PR rather than creating a pile of stale ones)
+   - Title: `chore(lexicons): bump @atproto/lex to <version>`
+   - Body: see below
+   - Labels: `lexicon-bump`, `dependencies`
+8. **Skip if no changes**: the entire job short-circuits when
+   `no_changes=true` so we don't open empty PRs.
+
+### PR body content
+
+The body is generated inline by the workflow and contains:
+
+```
+## Lexicon corpus update
+
+Bumps `@atproto/lex` from `<old>` to `<new>`.
+
+### lexicons.json
+
+- Added: N new lexicon CIDs (list first 20, then "...")
+- Removed: N lexicons (list)
+- Updated: N lexicons whose CID changed (list)
+
+### What reviewers should check
+
+- [ ] CI passes (generator regeneration, runtime tests, sample APK build)
+- [ ] Skim the generator golden-file diff if any generator logic was
+      affected
+- [ ] Verify no new lexicon references are missing Kotlin types (compile
+      failure in `:at-protocol-models`)
+
+### Release impact
+
+If this PR merges with only additive changes (new types, new fields),
+expect a `feat:` release. If it removes or renames anything, expect a
+`BREAKING CHANGE:` release — the PR title should be updated to
+`feat!: bump @atproto/lex to <version>` before merging.
+```
+
+We don't try to classify the change as feat/fix automatically — that's a
+human judgment call based on looking at the diff.
+
+### Failure modes
+
+- **Workflow runs but CI fails on the PR**: the PR stays open, the
+  maintainer investigates. Could be a generator bug surfaced by a new
+  lexicon shape (fix the generator, push to the PR branch) or a lexicon
+  we genuinely don't want to support yet (close the PR, hold).
+- **`npx lex install` fails**: the workflow fails, the maintainer gets a
+  notification from GitHub. No PR opened.
+- **Two consecutive upstream releases between runs**: the stable branch
+  (`chore/lexicon-bump`) gets force-updated to the newer version. Reviews
+  in progress get rebased — acceptable, since the unit of review is
+  "adopt the current upstream."
+
+## package.json pin
+
+Change:
+
+```json
+{ "dependencies": { "@atproto/lex": "*" } }
+```
+
+to the currently-resolved version (today that's `0.0.24`):
+
+```json
+{ "dependencies": { "@atproto/lex": "0.0.24" } }
+```
+
+Exact pinning (not `^`) matches the spirit of CID pinning in
+`lexicons.json`: we want explicit, reviewable bumps, not silent semver
+drift. The scheduled workflow uses `--save-exact` to keep it that way.
+
+## Permissions
+
+The workflow needs:
+- `contents: write` — to push the `chore/lexicon-bump` branch
+- `pull-requests: write` — to open/update the PR
+
+These already exist on the `GITHUB_TOKEN` in other workflows, but PR
+creation across a branch requires a PAT with `workflow` scope if the PR
+is to trigger CI. Use the existing `RELEASE_PAT` secret that
+`release.yaml` already relies on.
+
+## Documentation
+
+Add a short section to `CONTRIBUTING.md` under "Larger architectural
+changes" or a new "Lexicon updates" section:
+
+```markdown
+### Lexicon updates
+
+Upstream AT Protocol lexicons are bumped automatically. A scheduled
+workflow opens a PR titled `chore(lexicons): bump @atproto/lex to <v>`
+each week when upstream has drifted. To trigger a manual bump, run the
+`lexicon-bump` workflow via the Actions tab on GitHub. Merging the PR
+cuts a release whose semver bump depends on whether the generator
+output added, removed, or broke existing types.
+```
+
+## Non-goals
+
+- **Automatic feat/fix classification.** Humans read the diff and adjust
+  the PR title before merging if a breaking change landed.
+- **Automatic retrying or bisecting generator failures.** If new lexicon
+  shapes break the generator, the PR stays red until fixed manually.
+- **Consolidating CI lexicon fetches** (the 2x–3x `lex install --ci`
+  duplication noted in analysis). That's a separate optimization — this
+  change is about drift detection, not CI efficiency.
+- **Releasing `:at-protocol-models` with a version string derived from
+  `@atproto/lex`.** The existing spec already gestures at this but the
+  release pipeline doesn't implement it; treat as out of scope here.
+- **Committing generated sources.** Generator output stays in `build/`
+  per current architecture.
+
+## Testing
+
+- **Workflow syntax**: Lint the new YAML via the existing
+  `open-turo/actions-jvm/lint` step in `ci.yaml` (picks up workflow
+  files automatically).
+- **Manual smoke test**: Run the workflow via `workflow_dispatch` on the
+  feature branch. Verify a PR opens against `main` with the expected
+  body shape. Close the test PR without merging.
+- **Dry-run**: Optional env var `LEXICON_BUMP_DRY_RUN=true` could skip
+  the PR-open step and just print what would have happened — useful for
+  debugging the workflow without polluting PRs. Defer unless needed.

--- a/openspec/changes/lexicon-drift-automation/proposal.md
+++ b/openspec/changes/lexicon-drift-automation/proposal.md
@@ -1,0 +1,61 @@
+## Why
+
+Upstream AT Protocol lexicons at `@atproto/lex` evolve continuously, but this
+repo has no automated way to detect drift. The current flow relies on a
+maintainer manually running `npx lex install` locally, noticing changes in
+`lexicons.json`, and opening a PR. Two concrete consequences:
+
+1. **Invisible drift.** Between manual bumps, the models published to Maven
+   Central diverge silently from the upstream lexicon corpus. Users report
+   missing fields or types before the maintainer notices.
+2. **Fragile version declaration.** `at-protocol-generator/package.json`
+   declares `"@atproto/lex": "*"`. Reproducibility is accidentally maintained
+   by `package-lock.json` alone — any `npm install` (instead of `npm ci`)
+   would silently pick up a newer major. CI runs `npm ci` so we're safe
+   today, but the declaration is a latent footgun.
+
+A scheduled workflow that bumps the lexicon corpus and opens a PR turns
+drift into a reviewable, testable event. The PR is the review surface: CI
+runs the full test suite against the new corpus; the maintainer skims the
+generator output diff before merging.
+
+## What Changes
+
+- **New scheduled GitHub Actions workflow** (`.github/workflows/
+  lexicon-bump.yaml`) that runs weekly and on `workflow_dispatch`. The job:
+  1. Runs `npm update @atproto/lex` to pick up new npm releases
+  2. Runs `npx lex install` (no `--ci`) to refresh `lexicons.json` against
+     upstream CIDs
+  3. Runs `./gradlew :at-protocol-generator:generateModels`
+  4. If any of `package.json`, `package-lock.json`, `lexicons.json`, or
+     generated sources changed, opens a PR titled
+     `chore(lexicons): bump corpus to @atproto/lex@<version>`
+  5. PR body includes: old/new `@atproto/lex` version, summary of
+     `lexicons.json` changes (CIDs added/removed/updated), and a
+     byte-level summary of generated source deltas.
+- **Tighten `package.json` version pin**: change `"@atproto/lex": "*"` to
+  a specific version matching what `package-lock.json` currently resolves.
+  The scheduled workflow is then responsible for bumping it.
+- **Document the flow** in `CONTRIBUTING.md` so external contributors know
+  that lexicon bumps are automated and how to trigger a manual run.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `lexicon-toolchain`: adds requirements for automated drift detection and
+  strict npm version pinning.
+
+## Impact
+
+- **New file**: `.github/workflows/lexicon-bump.yaml` (scheduled workflow).
+- **Modified file**: `at-protocol-generator/package.json` — exact pin for
+  `@atproto/lex` instead of `"*"`.
+- **Modified file**: `CONTRIBUTING.md` — short section on lexicon updates.
+- **No runtime or generator code changes.** The generator already handles
+  regeneration idempotently via `generateModels`'s up-to-date check.
+- **Breaking changes**: none. The artifact surface is unaffected.
+- **Release cadence**: once the workflow lands, new lexicon adoption shifts
+  from "whenever someone remembers" to "weekly, reviewable." Each merged
+  bump PR cuts either a `fix:` or `feat:` release depending on whether the
+  generator output is additive or breaking.

--- a/openspec/changes/lexicon-drift-automation/specs/lexicon-toolchain/spec.md
+++ b/openspec/changes/lexicon-drift-automation/specs/lexicon-toolchain/spec.md
@@ -1,0 +1,65 @@
+## ADDED Requirements
+
+### Requirement: Toolchain SHALL detect upstream lexicon drift on a schedule
+
+The system SHALL run a scheduled GitHub Actions workflow
+(`.github/workflows/lexicon-bump.yaml`) at least weekly that attempts to
+upgrade the pinned `@atproto/lex` npm dependency to the newest published
+version and refresh the CID-pinned corpus in `lexicons.json`. When any
+of `package.json`, `package-lock.json`, or `lexicons.json` changes as a
+result, the workflow SHALL open a pull request against `main` so the
+drift can be reviewed, tested by CI, and merged.
+
+The workflow SHALL also be runnable manually via `workflow_dispatch`.
+
+#### Scenario: Upstream release triggers a bump PR
+
+- **GIVEN** the repo is pinned to `@atproto/lex@0.0.24` and upstream has
+  published `@atproto/lex@0.0.25` with lexicon changes
+- **WHEN** the scheduled `lexicon-bump` workflow runs
+- **THEN** a pull request is opened titled
+  `chore(lexicons): bump @atproto/lex to 0.0.25`
+- **AND** the PR includes the updated `package.json`,
+  `package-lock.json`, and `lexicons.json`
+- **AND** the PR body summarizes the CID additions, removals, and
+  updates in `lexicons.json`
+- **AND** CI runs on the PR so the maintainer can verify generator
+  regeneration and tests pass against the new corpus before merging
+
+#### Scenario: No upstream changes produces no PR
+
+- **WHEN** the scheduled workflow runs and `npm install @atproto/lex@latest`
+  resolves the already-pinned version, **AND** `npx lex install` produces
+  no changes to `lexicons.json`
+- **THEN** no pull request is opened and the workflow exits successfully
+
+#### Scenario: Successive bumps reuse one PR branch
+
+- **GIVEN** an open PR from a prior scheduled run at
+  `chore/lexicon-bump` targeting `0.0.25`
+- **WHEN** a subsequent run finds `0.0.26` is now available
+- **THEN** the workflow updates the existing `chore/lexicon-bump` branch
+  to `0.0.26` rather than opening a second PR
+
+### Requirement: The @atproto/lex npm dependency SHALL be pinned to an exact version
+
+The `at-protocol-generator/package.json` SHALL declare
+`@atproto/lex` with an exact version (no `*`, no `^`, no `~`). Version
+bumps SHALL flow exclusively through the scheduled lexicon-bump
+workflow or explicit manual PRs — never as a side effect of an
+unintended `npm install`.
+
+#### Scenario: Fresh npm install picks up the exact pinned version
+
+- **GIVEN** `at-protocol-generator/package.json` declares
+  `"@atproto/lex": "0.0.24"`
+- **WHEN** a contributor runs `npm install` from a clean clone
+- **THEN** the installed version of `@atproto/lex` is `0.0.24` (not a
+  later semver-compatible version)
+
+#### Scenario: Scheduled bump uses save-exact
+
+- **WHEN** the scheduled workflow runs
+  `npm install @atproto/lex@latest --save-exact`
+- **THEN** the resulting `package.json` declares the exact newly
+  installed version (no `^` prefix)

--- a/openspec/changes/lexicon-drift-automation/tasks.md
+++ b/openspec/changes/lexicon-drift-automation/tasks.md
@@ -1,0 +1,63 @@
+## 1. Pin the npm dependency
+
+- [ ] 1.1 Read current resolved version from
+      `at-protocol-generator/package-lock.json` (presently `0.0.24`)
+- [ ] 1.2 Replace `"@atproto/lex": "*"` with the exact version in
+      `at-protocol-generator/package.json`
+- [ ] 1.3 Run `npm ci` locally in `at-protocol-generator/` to confirm
+      lockfile is still consistent
+- [ ] 1.4 Verify `./gradlew :at-protocol-generator:generateModels` still
+      succeeds with the tightened pin
+
+## 2. Scheduled workflow
+
+- [ ] 2.1 Create `.github/workflows/lexicon-bump.yaml` with triggers
+      `schedule: cron "0 14 * * 1"` and `workflow_dispatch: {}`
+- [ ] 2.2 Add job: checkout with `token: ${{ secrets.RELEASE_PAT }}`,
+      setup Node 22, setup JDK 17, setup Android SDK, setup Gradle
+- [ ] 2.3 Add step: `npm install @atproto/lex@latest --save-exact` in
+      `at-protocol-generator/`
+- [ ] 2.4 Add step: `npx lex install` (no `--ci`) to refresh lexicon
+      corpus and CID pins
+- [ ] 2.5 Add step: `./gradlew :at-protocol-generator:generateModels`
+      to validate the new corpus compiles
+- [ ] 2.6 Add diff-detection step that sets an output
+      `changes=true|false` based on whether `package.json`,
+      `package-lock.json`, or `lexicons.json` have staged changes
+- [ ] 2.7 Add conditional step: when `changes=true`, extract old and
+      new `@atproto/lex` versions and build the PR body (Added /
+      Removed / Updated CIDs, reviewer checklist, release impact note)
+- [ ] 2.8 Add step: `peter-evans/create-pull-request@v7` with stable
+      branch `chore/lexicon-bump`, title
+      `chore(lexicons): bump @atproto/lex to <version>`, labels
+      `lexicon-bump` and `dependencies`
+- [ ] 2.9 Verify workflow YAML passes the existing
+      `open-turo/actions-jvm/lint` check
+
+## 3. Documentation
+
+- [ ] 3.1 Add a "Lexicon updates" subsection to `CONTRIBUTING.md`
+      explaining the automated bump flow and how to trigger a manual
+      run via the Actions tab
+- [ ] 3.2 Update the module table note in `CONTRIBUTING.md` or
+      `README.md` to reference the automated workflow
+
+## 4. Manual verification
+
+- [ ] 4.1 Push the branch and run the workflow via `workflow_dispatch`
+      on the feature branch
+- [ ] 4.2 Confirm the workflow completes and, if upstream has drifted,
+      opens a PR with the expected title and body shape
+- [ ] 4.3 If the test PR opens, close it without merging (the real
+      bump PR will come from a later scheduled run against `main`)
+- [ ] 4.4 Confirm the PR's own CI passes (generator regeneration,
+      runtime tests, sample APK build) against whatever lexicon state
+      the test run produced
+
+## 5. Archive
+
+- [ ] 5.1 `openspec status --change lexicon-drift-automation` reports
+      all artifacts complete
+- [ ] 5.2 Archive the change into
+      `openspec/changes/archive/<date>-lexicon-drift-automation/` and
+      sync the spec delta into `openspec/specs/lexicon-toolchain/`


### PR DESCRIPTION
## Summary

Scopes a new OpenSpec change under `openspec/changes/lexicon-drift-automation/` that proposes automating upstream `@atproto/lex` drift detection.

- **Proposal**: a weekly scheduled workflow (`.github/workflows/lexicon-bump.yaml`) runs `npm install @atproto/lex@latest --save-exact` + `npx lex install` + `generateModels`, and opens a PR against `main` when any of `package.json`, `package-lock.json`, or `lexicons.json` drift.
- **Also tightens** the `"@atproto/lex": "*"` declaration in `at-protocol-generator/package.json` to an exact pin so drift can only enter via the automated PR.
- **Spec-only**: no runtime, generator, or CI changes in this PR. Implementation is tracked in the change's `tasks.md` and will land as a follow-up.

## Design decisions worth flagging

- Stable PR branch (`chore/lexicon-bump`) — successive runs update the same PR rather than piling up stale ones.
- No auto feat/fix classification — maintainer rewrites the title to `feat:` / `feat!:` based on the diff before merging.
- Generated sources stay in `build/` (not committed). PR only includes the 3 pin files; CI regenerates models on the PR and validates them.
- Uses `RELEASE_PAT` so the opened PR actually triggers CI (the default `GITHUB_TOKEN` doesn't).

## Non-goals (deferred)

- Consolidating the 2x–3x `lex install --ci` duplication across CI jobs
- Auto-classifying feat vs fix vs breaking
- Tying `:at-protocol-models` version string to `@atproto/lex` version
- Committing generator output

## Test plan

- [ ] `openspec status --change lexicon-drift-automation` reports 4/4 artifacts complete
- [ ] Review `proposal.md`, `design.md`, `specs/lexicon-toolchain/spec.md`, `tasks.md` render correctly on the PR
- [ ] Confirm the proposal name and scope feel right before merging the spec