### PR TITLE
docs(openspec): scope llm-skills-structure change

### DIFF
--- a/openspec/changes/llm-skills-structure/design.md
+++ b/openspec/changes/llm-skills-structure/design.md
@@ -1,0 +1,211 @@
+## Overview
+
+Create five task-oriented skills under `skills/`, modeled on
+`github.com/android/skills`. Each skill is a self-contained SKILL.md
+with YAML frontmatter (for agent discovery) and a markdown body
+(for agent consumption). A top-level `skills/README.md` serves as a
+thin index for humans browsing the repo and agents looking up what's
+available.
+
+## Directory layout
+
+```
+skills/
+├── README.md                         # Index + install guidance
+├── atproto-setup/
+│   └── SKILL.md
+├── atproto-oauth/
+│   ├── SKILL.md
+│   └── references/
+│       ├── client-metadata-template.json
+│       └── android-redirect-capture.kt
+├── atproto-read/
+│   ├── SKILL.md
+│   └── references/
+│       ├── open-union-arms.md
+│       └── pagination-ui-pattern.kt
+├── atproto-write-records/
+│   ├── SKILL.md
+│   └── references/
+│       └── common-records.md
+└── atproto-types-reference/
+    └── SKILL.md
+```
+
+Flat (no category subdirectories) because we only have 5 skills and
+all belong to one capability. `android/skills` uses categories because
+it covers the whole Android platform — we don't need that hierarchy.
+
+## Skill frontmatter format
+
+Matches `android/skills` conventions verbatim so any tooling they build
+works against our files too:
+
+```yaml
+---
+name: atproto-oauth
+description: >
+  Use this skill when integrating AT Protocol OAuth 2.0 login into an
+  Android app using the kikin81/atproto-kotlin library. Covers hosting
+  the client-metadata JSON, configuring the Android intent filter for
+  the redirect URI, implementing an encrypted OAuthSessionStore, and
+  driving the beginLogin / completeLogin flow.
+license: MIT (see repo LICENSE)
+metadata:
+  author: kikin81
+  library-version: "4.6.0"
+  keywords:
+    - AT Protocol
+    - Bluesky
+    - OAuth
+    - DPoP
+    - Android
+    - authentication
+---
+```
+
+Key rules:
+- **`description` is what agents pattern-match on.** Start with
+  "Use this skill when…" so the trigger phrasing is explicit.
+- **`library-version`** in metadata so agents and humans can detect
+  drift against current `gradle.properties`.
+- **`keywords`** supplement the description for fuzzy matching.
+
+## Skill content conventions
+
+Each SKILL.md body:
+1. **Objective** — one sentence, what task this skill completes
+2. **Prerequisites** — what agents should assume already exists
+3. **Step-by-step** — numbered, copy-pasteable code blocks
+4. **Common pitfalls** — `## Common pitfalls` subsection, bulleted
+5. **Related skills** — backlinks to other SKILL.md files when a task
+   naturally chains into another (e.g. `atproto-oauth` → `atproto-read`)
+
+Target size: 100–250 lines per SKILL.md. Push overflow into
+`references/*` files that the SKILL.md explicitly links.
+
+## Skill scopes and boundaries
+
+### atproto-setup
+
+Scope: first-install Gradle wiring. Repositories, three ATProto
+dependencies + Ktor engine, minimum SDK / JDK, module overview
+(runtime = hand-written, models = generated, oauth = JVM-only).
+
+Out of scope: any actual API calls.
+
+### atproto-oauth
+
+Scope: the full OAuth pipeline for an Android consumer.
+- Hosting `client-metadata.json` (references template)
+- AndroidManifest intent filter for the redirect URI
+- `AndroidOAuthSessionStore` with `EncryptedSharedPreferences`
+- `AtOAuth` DI/instantiation
+- `beginLogin` → Custom Tabs → `completeLogin` → `createClient`
+- `logout`
+
+Out of scope: non-Android OAuth, non-OAuth authentication.
+
+### atproto-read
+
+Scope: reading from the AT Protocol. Three coherent subsections:
+1. Calling a `*Service` query (`FeedService(client).getTimeline(...)`)
+2. Paginating with `*PageFlow()` + UI suspension pattern
+3. Handling open unions — feed reason, post embeds, quoted records,
+   `*Unknown` arms, `decodeRecord<T>()` for typed records
+
+This is the largest skill. If it grows past ~250 lines, split by
+subsection into `atproto-read-queries`, `atproto-read-pagination`,
+`atproto-read-unions`. Not splitting preemptively — artificial
+boundaries hurt the "how do I render a timeline" query which touches
+all three.
+
+### atproto-write-records
+
+Scope: mutations via `RepoService`.
+- `createRecord` pattern with `encodeRecord(serializer, value, type)`
+- `deleteRecord` pattern with rkey extraction from AtUri
+- Canonical recipes for `Post`, `Like`, `Repost`, `Follow`, `Block`
+- Datetime formatting for `createdAt`
+
+Out of scope: `putRecord` (rare in practice), mutation batching.
+
+### atproto-types-reference
+
+Scope: cross-cutting type semantics that every other skill assumes.
+- `AtField<T>` three-state optionality (`Missing` / `Null` / `Defined`)
+- Runtime value classes (`Did`, `Handle`, `AtUri`, `Cid`, `Datetime`,
+  `Nsid`, `RecordKey`, `AtIdentifier`) with a table of each one's
+  wire shape and when to use it
+- The "don't do this" pitfalls that span multiple skills
+  (no raw strings, no `explicitNulls=false`, no direct `XrpcClient`
+  calls for ATProto, etc.)
+
+This is the skill agents load once and remember rules from. The other
+skills link back to specific sections here.
+
+## skills/README.md
+
+Concise index:
+- One-line description per skill
+- Installation snippet the consumer pastes into their repo's
+  `CLAUDE.md` — specifically, a block pointing to the raw GitHub URLs
+  of each SKILL.md so the agent can `WebFetch` on demand
+- Note about using `gh api` or direct clone for bulk installation
+
+Example installation snippet (goes in consumer's `CLAUDE.md`):
+
+```markdown
+## atproto-kotlin skills
+
+When working on ATProto features, reference these skills as needed:
+
+- Setup (Gradle deps): https://raw.githubusercontent.com/kikin81/atproto-kotlin/main/skills/atproto-setup/SKILL.md
+- OAuth login flow: https://raw.githubusercontent.com/kikin81/atproto-kotlin/main/skills/atproto-oauth/SKILL.md
+- Reading feeds + pagination + embeds: https://raw.githubusercontent.com/kikin81/atproto-kotlin/main/skills/atproto-read/SKILL.md
+- Posting, liking, deleting: https://raw.githubusercontent.com/kikin81/atproto-kotlin/main/skills/atproto-write-records/SKILL.md
+- Type reference (AtField, value classes): https://raw.githubusercontent.com/kikin81/atproto-kotlin/main/skills/atproto-types-reference/SKILL.md
+
+Fetch the one that matches the task — not all of them.
+```
+
+## Source material
+
+The 5 skills can be carved from the closed PR #8 (`docs/llm-usage-guide`
+branch, `LLM_USAGE.md`). The branch is retained as reference. Each
+skill's body is 60–80% content already written there, reshaped for
+the SKILL.md structure and trimmed for focus.
+
+## Versioning and drift
+
+`metadata.library-version` in each SKILL.md documents which library
+version the snippets were validated against. A future change can
+automate this via a pre-commit hook that reads `gradle.properties` and
+updates every SKILL.md's `library-version` field.
+
+For this change: set `library-version: "4.6.0"` (current release) in
+every skill and move on. Drift management is out of scope.
+
+## Non-goals
+
+- **Plugin publishing.** Not a separate npm package, not an
+  installable Claude Code plugin. Agents fetch raw URLs.
+- **Dokka replacement.** Dokka still exists for human API reference.
+  Skills are for task-oriented agent use.
+- **Automated version-bump hook.** Manual for now. Defer to a
+  follow-up change once we see how often versions drift.
+- **Sample-app-specific skills.** The `:samples:android` app is
+  referenced as prior art but isn't documented as a skill — consumers
+  build their own UI.
+- **CI validation that SKILL.md examples compile.** Would be nice —
+  tests-as-skills — but way out of scope here.
+
+## Testing
+
+- **Manual smoke test:** paste the installation block into a scratch
+  `CLAUDE.md` in a throwaway Android project, ask Claude to "set up
+  OAuth with Bluesky," verify it fetches `atproto-oauth/SKILL.md` and
+  the snippets compile against the published artifacts.
+- **Structural lint:** each SKILL.md must parse as valid YAML front-
+  matter + markdown (no custom validator — just eyeball during review).
+- **No build CI for this change.** Docs-only.

--- a/openspec/changes/llm-skills-structure/proposal.md
+++ b/openspec/changes/llm-skills-structure/proposal.md
@@ -1,0 +1,72 @@
+## Why
+
+A monolithic `LLM_USAGE.md` (PR #8) was drafted to give LLM agents
+consuming this library a single-load cheat sheet. Closed in favor of a
+**skills-based structure** modeled on
+[`github.com/android/skills`](https://github.com/android/skills) because:
+
+1. **Token efficiency.** A single 480-line doc loads in full every time
+   an agent needs *any* ATProto knowledge. Skills load only the section
+   relevant to the current task.
+2. **Triggerable via frontmatter.** Each skill's `description` field
+   ("Use this skill when…") acts as a discovery index — agents pattern-
+   match the current request against the skill list and fetch only
+   matching ones.
+3. **Better failure mode.** If the agent fetches the wrong skill, the
+   cost is small and the right one is still discoverable. Wrong guesses
+   on a monolith mean wasted context either way.
+4. **Version isolation.** Bumping only the OAuth flow doesn't churn the
+   pagination docs. Each skill has its own `metadata` block.
+5. **Reference artifacts.** Skills can carry a `references/` directory
+   with supporting material (client metadata templates, snippet files)
+   that the agent fetches only when the SKILL.md explicitly points to it.
+
+The use case — a single client app consumed by one author — doesn't
+warrant a full plugin-publishing flow. Skills stay in this repo and the
+consumer's `CLAUDE.md` points agents to the relevant raw URLs.
+
+## What Changes
+
+- **New top-level `skills/` directory** containing task-oriented skills
+  with the `android/skills` layout conventions: YAML frontmatter
+  (`name`, `description`, `metadata`), markdown body, optional
+  `references/` subdirectory.
+- **Initial skill set (5 skills)** covering the coherent tasks an
+  agent will encounter in a consuming Android app:
+  - `atproto-setup` — Gradle dependencies, module overview, Ktor engine
+  - `atproto-oauth` — Client metadata, Android redirect plumbing,
+    session store, `AtOAuth` login/logout flow
+  - `atproto-read` — `*Service` query pattern, `*PageFlow` pagination,
+    open-union dispatch (embeds, reasons, quoted records)
+  - `atproto-write-records` — `createRecord` / `deleteRecord` via
+    `RepoService`, `encodeRecord()` pattern, common record types
+    (`Post`, `Like`, `Follow`, `Repost`)
+  - `atproto-types-reference` — `AtField<T>` three-state optionality,
+    runtime value classes, cross-cutting pitfalls
+- **`skills/README.md`** as a concise index: skill list, one-line hook
+  each, pointer to installation instructions for the consumer's
+  `CLAUDE.md`.
+- **No `LLM_USAGE.md`.** The skills replace it entirely.
+
+## Capabilities
+
+### New Capabilities
+
+- `consumer-skills`: collection of Claude-Code-compatible SKILL.md
+  files that guide LLM agents through common ATProto consumer-side
+  tasks.
+
+## Impact
+
+- **New directory**: `skills/` with 5 SKILL.md files plus a README and
+  references material (client-metadata template, snippet files where
+  useful).
+- **No production code changes.** Docs-only; runtime, generator, OAuth
+  module, and sample app are untouched.
+- **Breaking changes**: none.
+- **Version drift**: skills are tagged with the documented library
+  version in their `metadata` block. A follow-up change can automate
+  version bumps against `gradle.properties` if drift becomes painful.
+- **Distribution**: no plugin marketplace entry. Agents discover skills
+  via a pointer in the consuming repo's `CLAUDE.md` and fetch raw
+  SKILL.md URLs on demand.

--- a/openspec/changes/llm-skills-structure/specs/consumer-skills/spec.md
+++ b/openspec/changes/llm-skills-structure/specs/consumer-skills/spec.md
@@ -1,0 +1,96 @@
+## ADDED Requirements
+
+### Requirement: Repository SHALL host a skills directory for LLM consumers
+
+The repository SHALL host a top-level `skills/` directory containing
+task-oriented SKILL.md files that guide LLM agents through common
+consumer-side tasks (setup, OAuth, reading data, writing records,
+type reference). Each skill SHALL be a self-contained directory
+with at minimum a `SKILL.md` file and optionally a `references/`
+subdirectory for supporting material.
+
+The structure SHALL follow the conventions established by
+[`github.com/android/skills`](https://github.com/android/skills)
+so that agents familiar with that layout can consume these skills
+without reinterpretation.
+
+#### Scenario: Fresh clone exposes the skills directory
+
+- **WHEN** a contributor clones the repository at `main`
+- **THEN** `skills/` exists at the repo root
+- **AND** it contains a `README.md` and at least one skill subdirectory
+- **AND** each skill subdirectory contains a `SKILL.md` at its root
+
+### Requirement: Each SKILL.md SHALL declare discovery metadata in YAML frontmatter
+
+Every `SKILL.md` file SHALL begin with a YAML frontmatter block
+containing at minimum `name`, `description`, and a `metadata` map with
+`library-version` and `keywords`. The `description` SHALL be phrased
+so that an agent can pattern-match user intent against it — the
+convention is to begin with "Use this skill when…".
+
+#### Scenario: Skill frontmatter is parseable and discoverable
+
+- **GIVEN** a SKILL.md file at `skills/atproto-oauth/SKILL.md`
+- **WHEN** the file is parsed as YAML frontmatter plus markdown body
+- **THEN** the frontmatter contains `name: atproto-oauth`
+- **AND** `description` begins with "Use this skill when"
+- **AND** `metadata.library-version` is set to the current
+  `gradle.properties` version
+- **AND** `metadata.keywords` is a list of at least three terms
+
+### Requirement: Initial skill set SHALL cover consumer-side task surface
+
+The initial skills directory SHALL include at minimum the following
+five skills, each scoped to a coherent task:
+
+1. `atproto-setup` — Gradle dependencies and module overview
+2. `atproto-oauth` — End-to-end OAuth flow for Android consumers
+3. `atproto-read` — Query calls, cursor pagination, open-union dispatch
+4. `atproto-write-records` — `createRecord` / `deleteRecord` via
+   `RepoService` with `encodeRecord()`
+5. `atproto-types-reference` — `AtField<T>` semantics, runtime value
+   classes, cross-cutting pitfalls
+
+#### Scenario: All five initial skills are present
+
+- **WHEN** a user lists `skills/` at `main`
+- **THEN** it contains subdirectories named `atproto-setup`,
+  `atproto-oauth`, `atproto-read`, `atproto-write-records`, and
+  `atproto-types-reference`
+- **AND** each of those subdirectories contains a valid `SKILL.md`
+
+### Requirement: skills/README.md SHALL provide a consumer installation snippet
+
+The `skills/README.md` SHALL include a ready-to-paste block for the
+consumer repository's `CLAUDE.md` that lists each SKILL.md's
+raw GitHub URL. The snippet SHALL direct agents to fetch only the
+skill that matches the current task.
+
+#### Scenario: Consumer app pastes the snippet and fetches a skill
+
+- **GIVEN** a downstream Android project whose `CLAUDE.md` contains
+  the installation snippet from `skills/README.md`
+- **WHEN** the author asks Claude to "set up OAuth login against
+  Bluesky"
+- **THEN** Claude identifies `atproto-oauth` as the matching skill
+- **AND** fetches
+  `https://raw.githubusercontent.com/kikin81/atproto-kotlin/main/skills/atproto-oauth/SKILL.md`
+  rather than loading all five skills
+
+### Requirement: Skills SHALL link to referenced library artifacts, not restate their source
+
+When a skill needs to show a file that lives elsewhere in the repo
+(e.g. the sample app's `FeedViewModel.kt`), the SKILL.md SHALL link
+to the file via its raw GitHub URL or its in-repo path rather than
+duplicating its contents inline. This keeps skills small and prevents
+content drift when the source file changes.
+
+#### Scenario: Skill references sample code by URL
+
+- **GIVEN** `atproto-read/SKILL.md` discusses pagination
+- **WHEN** it needs to point at a working `*PageFlow()` integration
+  example
+- **THEN** it links to
+  `https://raw.githubusercontent.com/kikin81/atproto-kotlin/main/samples/android/src/main/kotlin/io/github/kikin81/atproto/samples/bluesky/ui/FeedViewModel.kt`
+- **AND** does not inline the full file contents

--- a/openspec/changes/llm-skills-structure/tasks.md
+++ b/openspec/changes/llm-skills-structure/tasks.md
@@ -1,0 +1,108 @@
+## 1. Scaffolding
+
+- [ ] 1.1 Create `skills/` directory with `README.md` stub
+- [ ] 1.2 Create subdirectories for each of the five initial skills:
+      `atproto-setup/`, `atproto-oauth/`, `atproto-read/`,
+      `atproto-write-records/`, `atproto-types-reference/`
+
+## 2. Write SKILL.md: atproto-setup
+
+- [ ] 2.1 Draft frontmatter (`name`, `description`, `metadata` with
+      `library-version: "4.6.0"` and keywords)
+- [ ] 2.2 Body: Maven Central coordinates, three ATProto dependencies,
+      Ktor engine selection, minimum JDK/Android SDK, short module
+      table (runtime = hand-written, models = generated, oauth =
+      JVM-only)
+- [ ] 2.3 Common pitfalls: forgetting an engine, mixing versions
+- [ ] 2.4 Related skills backlink to `atproto-oauth`
+
+## 3. Write SKILL.md: atproto-oauth
+
+- [ ] 3.1 Draft frontmatter (OAuth / DPoP / Android keywords)
+- [ ] 3.2 Body sections: client-metadata JSON, AndroidManifest intent
+      filter, `OAuthSessionStore` with `EncryptedSharedPreferences`,
+      `AtOAuth` DI, `beginLogin` → Custom Tabs → `completeLogin` →
+      `createClient`, `logout`, session restore on app start
+- [ ] 3.3 Add `references/client-metadata-template.json` with a
+      ready-to-host JSON
+- [ ] 3.4 Add `references/android-redirect-capture.kt` showing
+      `onNewIntent` + `singleTask` wiring
+- [ ] 3.5 Common pitfalls: single-slash redirect URI, `singleTask` flag,
+      not using EncryptedSharedPreferences
+- [ ] 3.6 Related skills backlink to `atproto-read` and
+      `atproto-write-records`
+
+## 4. Write SKILL.md: atproto-read
+
+- [ ] 4.1 Draft frontmatter (queries / pagination / unions keywords)
+- [ ] 4.2 Body subsection 1: `*Service` query pattern
+      (`FeedService(client).getTimeline(...)`)
+- [ ] 4.3 Body subsection 2: `*PageFlow()` vs `*Flow()`, ViewModel
+      pattern with `Channel` for load-more gating
+- [ ] 4.4 Body subsection 3: open-union dispatch (`ReasonRepost`,
+      `ImagesView`, `RecordView`, `RecordWithMediaView`, `*Unknown`
+      arms), `decodeRecord<T>()` for typed records
+- [ ] 4.5 Add `references/open-union-arms.md` with a compact table of
+      every open union and its known arms
+- [ ] 4.6 Add `references/pagination-ui-pattern.kt` with a complete
+      ViewModel pagination snippet
+- [ ] 4.7 Common pitfalls: using `*Flow()` for UI, not handling
+      `*Unknown`, assuming `Paging 3` integration
+- [ ] 4.8 Monitor skill size; split into three skills if it exceeds
+      ~250 lines
+
+## 5. Write SKILL.md: atproto-write-records
+
+- [ ] 5.1 Draft frontmatter (records / createRecord / encodeRecord
+      keywords)
+- [ ] 5.2 Body: `createRecord` via `RepoService`, `encodeRecord()`
+      pattern, rkey extraction from AtUri, `deleteRecord`
+- [ ] 5.3 Canonical snippets for `Post`, `Like`, `Repost`, `Follow`,
+      `Block`
+- [ ] 5.4 Add `references/common-records.md` with a record-type
+      reference table (collection NSID → record class → common fields)
+- [ ] 5.5 Common pitfalls: forgetting `$type`, instantiating with
+      positional args, mixing `putRecord` with `createRecord`
+- [ ] 5.6 Related skills backlink to `atproto-types-reference` for
+      `AtField` on mutations
+
+## 6. Write SKILL.md: atproto-types-reference
+
+- [ ] 6.1 Draft frontmatter (types / AtField / value classes keywords)
+- [ ] 6.2 Body section 1: `AtField<T>` three-state semantics with
+      mutation example; why `explicitNulls=false` breaks it
+- [ ] 6.3 Body section 2: value-classes table (`Did`, `Handle`,
+      `AtUri`, `Cid`, `Datetime`, `Nsid`, `RecordKey`, `AtIdentifier`)
+      with wire-shape and `.raw` access pattern
+- [ ] 6.4 Body section 3: cross-cutting pitfalls list (don't edit
+      generated sources, don't reuse client across logout/login, etc.)
+
+## 7. Write skills/README.md
+
+- [ ] 7.1 One-line description per skill with in-repo links
+- [ ] 7.2 Consumer-`CLAUDE.md` installation snippet with raw GitHub
+      URLs to each SKILL.md
+- [ ] 7.3 Note on how to detect `library-version` drift against
+      `gradle.properties`
+- [ ] 7.4 Link back to repo README and Dokka API reference as
+      human-oriented resources
+
+## 8. Review and ship
+
+- [ ] 8.1 Each SKILL.md parses as valid YAML frontmatter + markdown
+      (manual eyeball)
+- [ ] 8.2 Each SKILL.md stays under ~250 lines (push overflow to
+      `references/`)
+- [ ] 8.3 Dry-run: paste consumer installation snippet into a scratch
+      project's `CLAUDE.md`, ask Claude to set up OAuth, verify it
+      fetches `atproto-oauth/SKILL.md` and nothing else
+- [ ] 8.4 Delete the `docs/llm-usage-guide` local branch once skills
+      ship — it's been superseded
+
+## 9. Archive
+
+- [ ] 9.1 `openspec status --change llm-skills-structure` reports 4/4
+      artifacts complete
+- [ ] 9.2 Archive change to
+      `openspec/changes/archive/<date>-llm-skills-structure/` and
+      sync the delta into `openspec/specs/consumer-skills/`


### PR DESCRIPTION
## Summary

Scopes a new OpenSpec change that replaces the closed `LLM_USAGE.md` proposal (PR #8) with a skills-based structure modeled on [`github.com/android/skills`](https://github.com/android/skills).

- **5 initial skills** under `skills/`: `atproto-setup`, `atproto-oauth`, `atproto-read`, `atproto-write-records`, `atproto-types-reference`.
- Each SKILL.md carries YAML frontmatter (`name`, `description`, `metadata.library-version`, `keywords`) so agents can pattern-match the current task and fetch only the one they need.
- `skills/README.md` ships a copy-pasteable snippet for consumer repos' `CLAUDE.md` — raw GitHub URLs to each SKILL.md, with instructions to fetch only the matching skill.
- Source material is carved from the closed PR #8's `LLM_USAGE.md` (branch retained as reference).
- Docs-only. No runtime, generator, or sample-app changes.

## Design decisions worth flagging

- **Flat structure, no categories.** `android/skills` uses categories because it covers the whole platform; we only have 5 skills in one capability, so `skills/<skill>/SKILL.md` is enough.
- **No plugin publishing.** Agents fetch raw URLs. No npm package, no Claude Code plugin registry entry. Can formalize later if this grows.
- **`library-version: \"4.6.0\"`** baked into each skill's metadata. Manual drift management for now — auto-bump hook deferred to a follow-up.
- **`atproto-read` is the largest skill.** Covers queries + pagination + unions because tasks like \"render a timeline\" touch all three. Monitored during implementation — split if it exceeds ~250 lines.

## Non-goals

- Plugin / marketplace publishing
- CI validation that SKILL.md examples compile against published artifacts
- Auto-bumping `library-version` on every release
- Sample-app-as-a-skill

## Test plan

- [ ] `openspec status --change llm-skills-structure` reports 4/4 artifacts complete
- [ ] Spec delta lands cleanly under `specs/consumer-skills/spec.md` on archive
- [ ] Skill scopes feel right before implementation starts (five skills, not three, not ten)