### PR TITLE
docs(dokka): add module descriptions to API docs landing page

### DIFF
--- a/MODULE.md
+++ b/MODULE.md
@@ -1,0 +1,42 @@
+# Module atproto-kotlin
+
+Code-generated [AT Protocol](https://atproto.com) Kotlin Multiplatform SDK
+for Bluesky and atproto-powered apps. Parses the upstream `@atproto/lex`
+lexicon corpus at build time and emits idiomatic Kotlin: immutable `data
+class` records, sealed-equivalent open unions with `$type` dispatch,
+typed value classes for every string format, and `suspend fun` XRPC
+service interfaces ready to drop into a Ktor client.
+
+## Quick start
+
+```kotlin
+// build.gradle.kts
+dependencies {
+    implementation("io.github.kikin81.atproto:at-protocol-runtime:<version>")
+    implementation("io.github.kikin81.atproto:at-protocol-models:<version>")
+    implementation("io.github.kikin81.atproto:at-protocol-oauth:<version>") // optional
+    implementation("io.ktor:ktor-client-cio:3.x") // or your preferred engine
+}
+```
+
+```kotlin
+val client = XrpcClient(
+    baseUrl = "https://bsky.social",
+    httpClient = HttpClient(CIO),
+    authProvider = myAuthProvider,
+)
+val timeline = FeedService(client).getTimeline(GetTimelineRequest(limit = 25L))
+```
+
+See each module's documentation for details:
+
+- **at-protocol-runtime** — Hand-written base: value classes, `AtField`,
+  `XrpcClient`, `AuthProvider`, pagination helpers.
+- **at-protocol-models** — Generated records, requests/responses, open
+  unions, and `*Service` classes.
+- **at-protocol-oauth** — OAuth 2.0 with PAR + PKCE + DPoP for public
+  clients (Android / JVM).
+
+For LLM agents consuming this library, fetch task-oriented skills from
+[`skills/`](https://github.com/kikin81/atproto-kotlin/tree/main/skills)
+instead of browsing this API reference.

--- a/at-protocol-models/MODULE.md
+++ b/at-protocol-models/MODULE.md
@@ -1,0 +1,54 @@
+# Module at-protocol-models
+
+**Code-generated** AT Protocol models and service bindings. Kotlin
+Multiplatform (JVM + iOS). This is what downstream consumers depend on
+to call Bluesky and atproto endpoints.
+
+## What's in here
+
+Everything under this module is emitted by `:at-protocol-generator`
+at build time from the upstream `@atproto/lex` lexicon corpus. You
+won't find a `src/commonMain/` — the sources live under
+`build/generated/source/lexicon/` and flow through to the published jar.
+
+Per lexicon NSID, the generator emits:
+
+- **Record types** — data classes like `Post`, `Like`, `Follow`,
+  `Profile`, `Generator` for every `record` lexicon definition.
+- **Request / response pairs** — `GetTimelineRequest` + `GetTimelineResponse`,
+  etc., for every `query` and `procedure`.
+- **`<Namespace>Service`** — classes like `FeedService`, `ActorService`,
+  `GraphService`, `RepoService` that wrap an `XrpcClient` and expose
+  every NSID as a `suspend fun`.
+- **Open unions** — sealed interfaces like `PostViewEmbed`, `Reason`,
+  `RecordViewRecordUnion` with a data-class arm per known `$type` plus
+  an `Unknown` fallback for unknown variants.
+- **`*Flow()` / `*PageFlow()` extensions** — cursor pagination
+  convenience functions on service classes, auto-generated for every
+  paginated query.
+- **Typed string formats** — the generator uses the value classes from
+  `at-protocol-runtime` (`Did`, `Handle`, `AtUri`, …) for fields
+  declared with those formats in the lexicon.
+
+## How regeneration works
+
+The `:at-protocol-generator:generateModels` Gradle task regenerates
+this module's sources from `at-protocol-generator/lexicons/`. It runs
+automatically before every `compileKotlin*` task on `:at-protocol-models`
+and is Gradle-incremental — idle when lexicons haven't changed.
+
+## Do not edit generated sources
+
+Files under `at-protocol-models/build/generated/` and the published
+`at-protocol-models-<version>.jar` are the output of KotlinPoet
+emitters in the generator. Incorrect output is a generator bug —
+open an issue at
+[kikin81/atproto-kotlin](https://github.com/kikin81/atproto-kotlin/issues).
+
+## Versioning
+
+Bumped automatically on every `feat:` or `fix:` commit to `main` via
+semantic-release. New `@atproto/lex` releases land via an
+auto-generated PR (see
+[`lexicon-drift-automation`](https://github.com/kikin81/atproto-kotlin/blob/main/openspec/specs/lexicon-toolchain/spec.md))
+and cut a release when merged.

--- a/at-protocol-models/build.gradle.kts
+++ b/at-protocol-models/build.gradle.kts
@@ -9,6 +9,12 @@ plugins {
 // `:at-protocol-runtime/build.gradle.kts` for the rationale.
 val isMacHost = System.getProperty("os.name").lowercase().contains("mac")
 
+dokka {
+    dokkaSourceSets.configureEach {
+        includes.from("MODULE.md")
+    }
+}
+
 kotlin {
     jvmToolchain(17)
 

--- a/at-protocol-oauth/MODULE.md
+++ b/at-protocol-oauth/MODULE.md
@@ -1,0 +1,54 @@
+# Module at-protocol-oauth
+
+AT Protocol OAuth 2.0 module for public clients (Android and JVM
+desktop apps). JVM-only — `java.security` is used for EC P-256 key
+generation and signing so no external JWT library is pulled in.
+
+## What's in here
+
+- **`AtOAuth`** — flow orchestrator. `beginLogin(handle)` resolves the
+  handle to DID → PDS → authorization server, runs Pushed Authorization
+  Request (PAR) with PKCE + DPoP, and returns an authorization URL to
+  open in a browser. `completeLogin(redirectUri)` exchanges the code
+  for DPoP-bound tokens and persists the session. `createClient()`
+  returns an `XrpcClient` with a `DpopAuthProvider` that handles token
+  refresh and DPoP nonce rotation transparently.
+- **`DpopAuthProvider`** — `AuthProvider` implementation that attaches
+  `Authorization: DPoP <token>` + `DPoP: <proof>` headers on every
+  request, rotates nonces on 401, and refreshes access tokens.
+- **`OAuthSession` / `OAuthSessionStore`** — serializable session
+  carrying the DPoP private key + tokens, plus a `SessionStore` interface
+  for persistence. Consumer apps implement `SessionStore` (typically
+  backed by `EncryptedSharedPreferences` on Android).
+- **`DpopSigner`** — EC P-256 DPoP JWT signer built on `java.security`.
+  Calibrates its clock against the server's `Date` header to prevent
+  `iat` rejection on devices with clock drift.
+- **Discovery** — handle → DID (DNS-over-HTTPS + HTTP fallback) → PDS →
+  authorization server metadata resolution.
+- **PKCE** — S256 challenge + verifier generation.
+
+## Security properties
+
+- **DPoP (RFC 9449)** proof-of-possession binds access tokens to a
+  per-client EC P-256 keypair. Stolen tokens cannot be replayed
+  without the private key.
+- **PKCE S256 (RFC 7636)** prevents authorization-code interception.
+- **State + `iss` + `sub` validation** on the redirect guards against
+  CSRF, mix-up attacks, and account mismatches.
+- **Independent nonce tracking** for PDS and authorization server
+  ensures nonce rotation is handled correctly per endpoint.
+
+## Use with Android
+
+See the [`atproto-oauth` skill](https://github.com/kikin81/atproto-kotlin/blob/main/skills/atproto-oauth/SKILL.md)
+for a complete Android walkthrough: hosting the client-metadata JSON,
+configuring the AndroidManifest intent filter, implementing an
+encrypted `OAuthSessionStore`, driving the flow from a ViewModel, and
+capturing the Custom Tabs redirect. A working reference app lives at
+[`samples/android`](https://github.com/kikin81/atproto-kotlin/tree/main/samples/android).
+
+# Package io.github.kikin81.atproto.oauth
+
+`AtOAuth` flow orchestrator, `DpopAuthProvider`, `OAuthSession(Store)`,
+`DpopSigner`, and the exceptions thrown when a session expires or a
+step in the OAuth flow fails.

--- a/at-protocol-oauth/build.gradle.kts
+++ b/at-protocol-oauth/build.gradle.kts
@@ -9,6 +9,12 @@ kotlin {
     jvmToolchain(17)
 }
 
+dokka {
+    dokkaSourceSets.configureEach {
+        includes.from("MODULE.md")
+    }
+}
+
 dependencies {
     implementation(project(":at-protocol-runtime"))
     implementation(libs.kotlinx.serialization.json)

--- a/at-protocol-runtime/MODULE.md
+++ b/at-protocol-runtime/MODULE.md
@@ -1,0 +1,46 @@
+# Module at-protocol-runtime
+
+Hand-written base module for the AT Protocol Kotlin SDK. Kotlin
+Multiplatform (JVM + iOS) library that every generated model and
+service depends on.
+
+## What's in here
+
+- **Typed value classes** for every AT Protocol string format: `Did`,
+  `Handle`, `AtIdentifier`, `AtUri`, `Cid`, `Datetime`, `Nsid`,
+  `RecordKey`, `Language`. Use these instead of raw strings — they're
+  zero-overhead and prevent mixing.
+- **`AtField<T>`** — three-state optionality (`Missing` / `Null` /
+  `Defined`) for mutation payloads where "absent" and "null" are
+  distinct wire states (e.g. `putPreferences`).
+- **`OpenUnion` infrastructure** — base types and serializers for
+  sealed-interface unions with a `$type` discriminator and an
+  `Unknown` fallback for forward compatibility.
+- **`XrpcClient`** — Ktor-backed client wrapping a caller-supplied
+  `HttpClient`. Exposes `query()` for GETs, `procedure()` for POSTs.
+  Generated `*Service` classes wrap this; prefer those for lexicon
+  endpoints.
+- **`AuthProvider`** — pluggable auth interface. `NoAuth` for
+  unauthenticated calls; bearer-token and DPoP implementations live
+  in consumer modules (e.g. `at-protocol-oauth`).
+- **`paginate()` / `paginatePages()`** — generic Flow builders for
+  cursor-paginated endpoints. Generated `*Flow()` / `*PageFlow()`
+  extensions on service classes call these under the hood.
+- **Record encode/decode helpers** — `encodeRecord()` injects `$type`
+  for mutation payloads; `decodeRecord<T>()` extracts typed records
+  from `JsonObject` values on the wire.
+
+## Typical consumers
+
+- **at-protocol-models** — declares `api(project(":at-protocol-runtime"))`
+  so every downstream project transitively picks up the runtime types.
+- **at-protocol-oauth** — builds on `AuthProvider` and `XrpcClient`.
+- **Application code** — usually never touches `XrpcClient` directly;
+  constructs `<Namespace>Service(client)` from `at-protocol-models`.
+
+# Package io.github.kikin81.atproto.runtime
+
+Core runtime primitives: value classes, `AtField`, open-union base types,
+`XrpcClient`, auth provider interface, pagination Flow builders, and
+record encode/decode helpers. Everything here is hand-written — this
+is the stable, non-generated surface the SDK builds on.

--- a/at-protocol-runtime/build.gradle.kts
+++ b/at-protocol-runtime/build.gradle.kts
@@ -14,6 +14,15 @@ plugins {
 // healthy on Linux — iOS consumers wait for a macOS-hosted release job.
 val isMacHost = System.getProperty("os.name").lowercase().contains("mac")
 
+// Attach the module-level MODULE.md to every Dokka source set so the
+// landing page and per-module pages include hand-written prose
+// alongside the generated symbol reference.
+dokka {
+    dokkaSourceSets.configureEach {
+        includes.from("MODULE.md")
+    }
+}
+
 kotlin {
     jvmToolchain(17)
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,6 +17,16 @@ dependencies {
     dokka(project(":at-protocol-oauth"))
 }
 
+// Attach a top-level MODULE.md to the aggregated multi-module Dokka
+// publication so the landing page at build/dokka/html/index.html
+// carries a project overview + quick-start snippet instead of just
+// three bare module links.
+dokka {
+    dokkaPublications.html {
+        includes.from("MODULE.md")
+    }
+}
+
 allprojects {
     group = "io.github.kikin81.atproto"
 }


### PR DESCRIPTION
## Summary

Minimum-upgrade for the [Dokka API reference](https://kikin81.github.io/atproto-kotlin/api/): four `MODULE.md` files give the landing page and each module index real prose instead of a bare list of links.

- `MODULE.md` at the repo root — project overview + quick-start Gradle + `XrpcClient` snippet
- `at-protocol-runtime/MODULE.md` — what's in the hand-written base (value classes, `AtField`, `XrpcClient`, `AuthProvider`, pagination)
- `at-protocol-models/MODULE.md` — what the generator emits, regeneration workflow, don't-edit warning
- `at-protocol-oauth/MODULE.md` — `AtOAuth` flow, `DpopAuthProvider`, security properties, link to the `atproto-oauth` skill + sample app

Wired via `dokka.dokkaSourceSets.configureEach { includes.from("MODULE.md") }` in each subproject and `dokka.dokkaPublications.html { includes.from("MODULE.md") }` at the root for the aggregated publication.

No custom CSS, logo, or landing-page redesign. Just paragraph-level context.

## Verification

Ran `./gradlew :dokkaGeneratePublicationHtml --no-configuration-cache` locally:

- Landing page at `build/dokka/html/index.html` contains the quick-start block and references all three modules
- Each `build/dokka/html/at-protocol-*/index.html` includes its MODULE.md description
- No regressions — Dokka build succeeds, `:dokkaGenerateModuleHtml` runs for each module

## Test plan

- [ ] After merge, the release workflow publishes to GitHub Pages at https://kikin81.github.io/atproto-kotlin/api/; verify landing page shows new content
- [ ] Spot-check that Maven Central javadoc JARs (generated by `dokkaGenerateModuleHtml` for each module) also include the MODULE.md prose
- [ ] Verify `./gradlew build` still succeeds in CI (no task wiring regressions)