### PR TITLE
docs(openspec): scope sample-replies-threading change

### DIFF
--- a/openspec/changes/sample-replies-threading/design.md
+++ b/openspec/changes/sample-replies-threading/design.md
@@ -1,0 +1,235 @@
+## Overview
+
+Add thread reading and reply composition to the Android sample. Pure
+consumer-side work — the library already emits every type and
+procedure required.
+
+## Screen model
+
+Current screens (via `showCompose: Boolean` in `MainActivity`):
+
+1. **Login** (logged-out)
+2. **Feed** (logged-in, default)
+3. **Compose** (logged-in, when `showCompose == true`)
+
+New screen:
+
+4. **Thread** (logged-in, when a thread URI is selected)
+
+The sample is single-activity / single-composition state. Promote the
+navigation state in `MainActivity` from `Boolean showCompose` to a
+sealed interface so we can encode the thread selection:
+
+```kotlin
+sealed interface LoggedInScreen {
+    data object Feed : LoggedInScreen
+    data class Thread(val rootUri: AtUri) : LoggedInScreen
+    data class Compose(val replyTo: PostView? = null) : LoggedInScreen
+}
+```
+
+`MainActivity` holds a `var screen by remember { mutableStateOf<LoggedInScreen>(Feed) }`
+and switches on it. Back handlers return to `Feed`.
+
+Jetpack Navigation is out of scope — the state-machine approach keeps
+parity with the current code and avoids pulling in nav-compose.
+
+## Thread data loading
+
+```kotlin
+FeedService(client).getPostThread(
+    GetPostThreadRequest(uri = rootUri, depth = 6, parentHeight = 4),
+)
+```
+
+Response is `GetPostThreadResponse(thread: GetPostThreadResponseThread)`
+where the union has four arms:
+
+- `ThreadViewPost` — normal case, recursive: `post: PostView`,
+  `parent: ThreadViewPostParent?`, `replies: List<ThreadViewPostReply>?`.
+- `NotFoundPost` — deleted / unreachable.
+- `BlockedPost` — block in the way.
+- `ThreadViewPostUnknown` — unknown `$type`.
+
+For the first three non-happy arms, render a centered placeholder:
+
+- `NotFoundPost` → "This post was deleted."
+- `BlockedPost` → "This post is unavailable."
+- `ThreadViewPostUnknown` → "Thread unavailable."
+
+## Thread rendering (happy path)
+
+`ThreadViewPost` is a recursive tree. Flatten for a scrollable screen:
+
+### Ancestors
+
+Walk `thread.parent` up via its own union (same arms) to build a list
+of ancestor posts from root down to the focused post's direct parent.
+Render each ancestor as a compact row: author handle, short text
+excerpt, muted styling. Stop walking when a non-`ThreadViewPost` arm
+appears — render a "Context unavailable" line and break.
+
+### Focused post
+
+Render the focused `ThreadViewPost.post` prominently: full text,
+embeds, action row (Like / Reply / Delete if own). Action button set
+is richer than in the feed — Reply is new.
+
+### Replies
+
+Render `thread.replies` as a flat `LazyColumn`. Each reply is a
+normal post row (reuse `PostRow` composable) with a left-border indent
+(single depth — no deeper nesting in v1). Handle non-happy arms
+per-row with the same placeholders.
+
+## Reply composition
+
+### `ComposeViewModel` changes
+
+Today:
+
+```kotlin
+class ComposeViewModel @Inject constructor(
+    private val oauth: AtOAuth,
+    private val sessionStore: OAuthSessionStore,
+) : ViewModel() {
+    fun createPost() { /* builds Post(text, createdAt) */ }
+}
+```
+
+Change to accept optional reply context:
+
+```kotlin
+class ComposeViewModel @Inject constructor(
+    private val oauth: AtOAuth,
+    private val sessionStore: OAuthSessionStore,
+) : ViewModel() {
+
+    private var replyTo: PostView? = null
+
+    fun setReplyTo(post: PostView?) {
+        replyTo = post
+    }
+
+    fun createPost() {
+        val post = Post(
+            text = _text.value.trim(),
+            createdAt = datetimeNow(),
+            reply = replyTo?.let { buildReplyRef(it) },
+        )
+        /* ... createRecord call as today ... */
+    }
+
+    private fun buildReplyRef(target: PostView): ReplyRef {
+        // Parent is the post we're replying to.
+        val parent = StrongRef(uri = target.uri, cid = target.cid)
+
+        // Root: if the target itself is a reply, inherit its thread root.
+        // Otherwise the target IS the root.
+        val targetRecord = runCatching {
+            target.record.decodeRecord<Post>()
+        }.getOrNull()
+        val root = targetRecord?.reply?.root ?: parent
+
+        return ReplyRef(parent = parent, root = root)
+    }
+}
+```
+
+**Root resolution**: AT Protocol requires the reply's `root` to be the
+thread's originating post, not just the direct parent. The spec
+enforces this server-side. Cheap client implementation: decode the
+target's `record: JsonObject` to a typed `Post` and read its
+`reply.root` — if the target was itself a reply, that's the root;
+otherwise the target post is the root. Wrapped in `runCatching`
+because decode may fail for records with unknown fields.
+
+### `ComposeScreen` changes
+
+Show a compact "Replying to @handle" banner above the text field when
+`replyTo != null`. A small "Cancel reply" link clears the reply state
+and continues as a top-level post (or returns to feed — designer call;
+default: clear and stay on compose).
+
+### Entry points
+
+- **Thread screen** — Reply button on focused post opens `Compose(replyTo = focusedPost)`
+- **Thread screen** — Reply button on each reply row opens `Compose(replyTo = replyPost)`
+- **Feed screen** — no reply button directly; user taps post → thread
+  screen → reply. Keeps the feed uncluttered.
+
+## Open-union arm handling
+
+All thread-related unions expose these arms to handle:
+
+| Union | Happy arm | Other arms |
+|---|---|---|
+| `GetPostThreadResponseThread` | `ThreadViewPost` | `NotFoundPost`, `BlockedPost`, `ThreadViewPostUnknown` |
+| `ThreadViewPostParent` | `ThreadViewPost` | `NotFoundPost`, `BlockedPost`, `ThreadViewPostParentUnknown` |
+| `ThreadViewPostReply` | `ThreadViewPost` | `NotFoundPost`, `BlockedPost`, `ThreadViewPostReplyUnknown` |
+
+Every `when` branch on these MUST handle its `*Unknown` arm. Add a
+single helper:
+
+```kotlin
+private fun renderPlaceholder(arm: Any): String = when (arm) {
+    is NotFoundPost -> "This post was deleted."
+    is BlockedPost -> "This post is unavailable."
+    else -> "Thread unavailable."
+}
+```
+
+## Optimistic UI for replies
+
+Out of scope. After `createRecord` succeeds in `ComposeViewModel`, the
+app navigates back to `ThreadScreen` which triggers a fresh
+`getPostThread` call. Simpler than optimistic insertion, acceptable
+latency (~500ms).
+
+## Error handling
+
+- **Thread fetch failure**: red banner with "Retry" button in
+  `ThreadScreen`. Standard `runCatching` pattern used elsewhere in
+  the sample.
+- **Reply post failure**: existing `ComposeViewModel` error flow
+  (surface to UI, keep text populated so user can retry).
+- **`getPostThread` returns non-happy arm at the root URI**: show the
+  placeholder and a "Back" button.
+
+## Testing
+
+### Unit tests
+
+- `ThreadViewModel.loadThread` with a canned `GetPostThreadResponse`
+  containing a happy `ThreadViewPost` with 2 ancestors and 3 replies
+  → UI state contains all 5 posts in the correct order.
+- `ThreadViewModel.loadThread` with `NotFoundPost` at the root → UI
+  state is a `Unavailable` placeholder state.
+- `ThreadViewModel.loadThread` with `ThreadViewPostUnknown` at the
+  root → UI state is the generic-unavailable placeholder.
+- `ComposeViewModel.createPost` with a `replyTo` that is a
+  top-level post → resulting `Post.reply.root == Post.reply.parent`.
+- `ComposeViewModel.createPost` with a `replyTo` that itself is a
+  reply (its own `record.reply` is set) → resulting `Post.reply.root`
+  equals the ancestor's root, not the direct parent.
+
+### MockEngine fixture
+
+Add a `thread_happy.json` and `thread_not_found.json` fixture pair
+under `samples/android/src/test/resources/fixtures/thread/`. Match
+the existing fixture style from the `sample-repost-embeds` work.
+
+## Non-goals
+
+- **Rich text facets** (mentions, links, hashtags in composed text) —
+  separate change.
+- **Image / video embeds in replies** — text-only MVP. Ship image
+  embeds in a dedicated follow-up.
+- **Deep nesting in replies UI** — single-depth indent only. Infinite
+  nesting requires a design call about collapse/expand.
+- **Optimistic reply insertion** — refetch on success is sufficient.
+- **Deep-linking to thread URIs from outside the app** — no intent
+  filter for `at://` URIs or HTTPS bsky.app URLs.
+- **Push notifications when a reply arrives** — separate capability.
+- **Thread pagination** (long threads > `depth/parentHeight` default)
+  — reuses library defaults; deeper threads truncate.

--- a/openspec/changes/sample-replies-threading/proposal.md
+++ b/openspec/changes/sample-replies-threading/proposal.md
@@ -1,0 +1,69 @@
+## Why
+
+The Android sample app currently lets a user scroll a feed, like posts,
+compose a new top-level post, and delete their own posts. The single
+biggest feature a real client needs next is **threading**: tapping a
+post to see the replies, and writing a reply that targets a specific
+post in a thread.
+
+Everything required is already in the library:
+
+- `FeedService.getPostThread(GetPostThreadRequest(uri))` is
+  generator-emitted and returns a `GetPostThreadResponse` whose
+  `thread` is an open union over `ThreadViewPost`, `NotFoundPost`,
+  `BlockedPost`, and `ThreadViewPostUnknown`.
+- `Post.reply: ReplyRef?` is the existing mutation field for creating
+  a reply, with `StrongRef` entries for the thread root and the direct
+  parent.
+- The `ComposeViewModel` already creates `Post` records via
+  `RepoService.createRecord` + `encodeRecord()`.
+
+So the work is pure sample-app wiring: navigation, a thread screen, a
+"reply" entry point that hydrates the existing compose flow with the
+right `ReplyRef`. No new capability on the runtime, generator, or
+models side.
+
+## What Changes
+
+- **New `ThreadScreen` + `ThreadViewModel`** in the Android sample.
+  Loads a post thread via `FeedService.getPostThread(uri)` and renders
+  ancestors → focused post → flat reply list.
+- **Feed tap navigates to thread.** Tapping a post in `FeedScreen`
+  opens `ThreadScreen` for that post's URI.
+- **Reply entry point.** A "Reply" button on the focused post (and on
+  each reply in the thread) opens `ComposeScreen` prefilled with the
+  target post as `replyTo`.
+- **`ComposeViewModel` gains `replyTo: PostView?` mode.** When set,
+  the Post it creates includes a correctly-constructed `ReplyRef`
+  (parent = the replied-to post; root = the replied-to post's
+  existing thread root, falling back to the parent itself for
+  top-level replies).
+- **Open-union dispatch for thread arms.** `NotFoundPost`,
+  `BlockedPost`, and `ThreadViewPostUnknown` render placeholders
+  instead of crashing.
+- **Deprecation banner removed**. The existing `Requirement: Sample
+  SHALL authenticate via the generated createSession procedure` in
+  `android-sample` spec is historical — the sample migrated to OAuth
+  long ago but the requirement wasn't updated. Not in this change's
+  scope to remove; flagged for a future cleanup.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `android-sample`: gains thread-reading and reply-composition
+  requirements.
+
+## Impact
+
+- **New files**: `ThreadScreen.kt`, `ThreadViewModel.kt` under
+  `samples/android/.../ui/`.
+- **Modified files**: `FeedScreen.kt` (tap handler), `MainActivity.kt`
+  (navigation case for thread), `ComposeScreen.kt` +
+  `ComposeViewModel.kt` (accept `replyTo`), plus tests.
+- **No library-level changes.** Runtime, generator, models, OAuth are
+  untouched.
+- **Breaking changes**: none. The sample isn't published.
+- **Test additions**: `ThreadViewModel` unit tests with MockEngine
+  against canned `getPostThread` responses covering each open-union
+  arm.

--- a/openspec/changes/sample-replies-threading/specs/android-sample/spec.md
+++ b/openspec/changes/sample-replies-threading/specs/android-sample/spec.md
@@ -1,0 +1,175 @@
+## ADDED Requirements
+
+### Requirement: Sample SHALL load a thread via getPostThread when a feed post is tapped
+
+The sample SHALL wire a tap handler on every feed row that navigates
+to a thread screen for that post's URI. The thread screen SHALL call
+`FeedService.getPostThread(GetPostThreadRequest(uri = postUri))` via
+the authenticated `XrpcClient` and render the response.
+
+#### Scenario: Feed tap opens the thread screen
+
+- **GIVEN** the user is on the feed screen with posts loaded
+- **WHEN** the user taps a post row
+- **THEN** the sample navigates to `ThreadScreen` with that post's
+  URI
+- **AND** `FeedService.getPostThread` is called with the tapped
+  post's URI
+- **AND** the thread screen shows a loading indicator until the
+  response arrives
+
+### Requirement: Thread screen SHALL render ancestors, focused post, and replies
+
+For a happy-path `ThreadViewPost` response, the thread screen SHALL
+render three sections in order: ancestors (root post down to the
+focused post's direct parent), the focused post itself with emphasis,
+and the focused post's direct replies as a flat list.
+
+Ancestor walking SHALL follow `ThreadViewPost.parent` recursively
+through the `ThreadViewPostParent` union until either a root post
+(no parent) or a non-`ThreadViewPost` arm is reached.
+
+#### Scenario: Thread with one ancestor and two replies renders correctly
+
+- **GIVEN** `getPostThread` returns a `ThreadViewPost` whose
+  `parent` is a `ThreadViewPost` (the thread root) and whose
+  `replies` is a list of two `ThreadViewPost` items
+- **WHEN** the user is on the thread screen
+- **THEN** the screen displays four post cards in order: ancestor,
+  focused post (highlighted), reply 1, reply 2
+- **AND** each reply is visually distinguished from the focused
+  post (e.g. indented or depth-marked)
+
+### Requirement: Thread screen SHALL render placeholders for non-happy thread union arms
+
+The thread screen SHALL handle every arm of the
+`GetPostThreadResponseThread`, `ThreadViewPostParent`, and
+`ThreadViewPostReply` unions. For non-happy arms:
+
+- `NotFoundPost` → "This post was deleted."
+- `BlockedPost` → "This post is unavailable."
+- `*Unknown` → "Thread unavailable."
+
+Placeholders SHALL be rendered in the same slot as the post they
+replace so the thread's structural order is preserved.
+
+#### Scenario: Thread root is a NotFoundPost
+
+- **GIVEN** `getPostThread` returns `thread = NotFoundPost(...)`
+- **WHEN** the thread screen finishes loading
+- **THEN** the screen displays the "This post was deleted."
+  placeholder centered with a "Back" button
+- **AND** does not crash or throw
+
+#### Scenario: A reply in the list is a BlockedPost
+
+- **GIVEN** `getPostThread` returns a `ThreadViewPost` with a
+  `replies` list containing two `ThreadViewPost` replies and one
+  `BlockedPost`
+- **WHEN** the thread screen renders
+- **THEN** the blocked entry's slot shows the "This post is
+  unavailable." placeholder rather than a post card
+
+#### Scenario: Root arm is ThreadViewPostUnknown
+
+- **GIVEN** `getPostThread` returns a `thread` of the
+  `ThreadViewPostUnknown` arm
+- **WHEN** the thread screen renders
+- **THEN** the screen displays the generic "Thread unavailable."
+  placeholder and does not attempt to load ancestors or replies
+
+### Requirement: Sample SHALL support composing replies with correct ReplyRef
+
+The compose screen SHALL accept an optional `replyTo: PostView`
+context. When set, `ComposeViewModel.createPost` SHALL construct
+`Post.reply` as a `ReplyRef` where:
+
+- `parent` is a `StrongRef` over `replyTo.uri` + `replyTo.cid`
+- `root` is the value of `replyTo`'s own `record.reply.root` if
+  `replyTo` is itself a reply; otherwise `root` equals `parent`
+
+#### Scenario: Replying to a top-level post
+
+- **GIVEN** a `PostView` that is not itself a reply (its decoded
+  `Post` has `reply == null`)
+- **WHEN** the user taps Reply, enters text, and taps Post
+- **THEN** the created `Post` has
+  `reply.parent.uri == replyTo.uri`,
+  `reply.parent.cid == replyTo.cid`,
+  and `reply.root == reply.parent`
+- **AND** `createRecord` is called with this record
+
+#### Scenario: Replying to a reply preserves the thread root
+
+- **GIVEN** a `PostView` whose decoded `Post.reply.root` points at
+  a different post (i.e. it's a nested reply)
+- **WHEN** the user submits a reply
+- **THEN** the created `Post.reply.root` equals the original
+  thread's root (from the `replyTo`'s own `record.reply.root`)
+- **AND** `reply.parent` equals the direct `replyTo`, not the root
+
+### Requirement: Thread screen SHALL expose Reply entry points for each post
+
+The thread screen SHALL render a "Reply" action on the focused post
+and on every reply row that renders as a happy `ThreadViewPost`.
+Tapping "Reply" SHALL open the compose screen with the tapped post
+as `replyTo`. Placeholder arms (`NotFoundPost`, `BlockedPost`,
+`*Unknown`) SHALL NOT render a Reply action.
+
+#### Scenario: Reply button on focused post
+
+- **WHEN** the user is on the thread screen and taps Reply on the
+  focused post
+- **THEN** the sample navigates to the compose screen
+- **AND** the compose screen displays a "Replying to @handle" banner
+- **AND** submitting the compose creates a Post whose `reply.parent`
+  is the focused post's `StrongRef`
+
+#### Scenario: Reply button omitted on blocked arms
+
+- **GIVEN** a reply row in the thread screen rendered from a
+  `BlockedPost` placeholder
+- **WHEN** the user inspects the action row on that placeholder
+- **THEN** no Reply action is present
+
+### Requirement: Sample SHALL refetch the thread after a successful reply
+
+The sample SHALL, on successful reply creation (when
+`ComposeViewModel.createPost` returns from `createRecord` without
+error while a `replyTo` context was set), navigate back to the thread
+screen for the reply's root URI and SHALL trigger a fresh
+`getPostThread` call. Optimistic insertion of the new reply into the
+existing UI state is NOT required in v1.
+
+#### Scenario: Successful reply triggers thread refetch
+
+- **GIVEN** the user is on the compose screen with a `replyTo` context
+- **WHEN** `createPost` returns successfully
+- **THEN** the sample navigates to the thread screen for the thread's
+  root URI
+- **AND** a fresh `getPostThread` call is issued
+- **AND** the new reply appears in the refreshed reply list (assuming
+  server consistency)
+
+### Requirement: Sample SHALL unit-test thread rendering and reply construction
+
+The sample module SHALL include JUnit 5 tests that cover:
+
+1. `ThreadViewModel` with canned `GetPostThreadResponse` fixtures
+   for happy path, `NotFoundPost` root, and `*Unknown` root arms.
+2. `ComposeViewModel.buildReplyRef` (or equivalent) with a
+   top-level target (verifies `root == parent`) and with a nested
+   target (verifies `root` inherits from the target's
+   `record.reply.root`).
+
+Tests SHALL use MockEngine (Ktor) for HTTP and live under
+`samples/android/src/test/`.
+
+#### Scenario: Canned fixture drives ThreadViewModel
+
+- **GIVEN** a JSON fixture `thread_happy.json` under
+  `samples/android/src/test/resources/fixtures/thread/`
+- **WHEN** `ThreadViewModel.loadThread(uri)` runs against a
+  MockEngine that returns that fixture
+- **THEN** the emitted UI state contains the expected ancestor,
+  focused, and reply posts in the expected order

--- a/openspec/changes/sample-replies-threading/tasks.md
+++ b/openspec/changes/sample-replies-threading/tasks.md
@@ -1,0 +1,131 @@
+## 1. Navigation state refactor
+
+- [ ] 1.1 Introduce `sealed interface LoggedInScreen` with `Feed`,
+      `Thread(rootUri: AtUri)`, and `Compose(replyTo: PostView? = null)`
+      variants in `MainActivity.kt`
+- [ ] 1.2 Replace `var showCompose by mutableStateOf(false)` with
+      `var screen by mutableStateOf<LoggedInScreen>(Feed)`
+- [ ] 1.3 Route each screen variant to its composable in the `when`
+      block; wire back-handlers to return to `Feed`
+
+## 2. Thread screen
+
+- [ ] 2.1 Create `ThreadViewModel` (`@HiltViewModel`) with
+      `uiState: StateFlow<ThreadUiState>` and a `loadThread(uri: AtUri)`
+      entry point that calls
+      `FeedService(client).getPostThread(GetPostThreadRequest(uri))`
+- [ ] 2.2 Define `ThreadUiState` as a sealed interface:
+      `Loading`, `Loaded(ancestors, focused, replies)`,
+      `Unavailable(message)`, `Error(message)`
+- [ ] 2.3 Handle all four arms of `GetPostThreadResponseThread`:
+      `ThreadViewPost` → populate `Loaded`; `NotFoundPost` /
+      `BlockedPost` / `ThreadViewPostUnknown` → populate
+      `Unavailable` with the matching placeholder string
+- [ ] 2.4 Ancestor walk: recurse up `ThreadViewPost.parent` handling
+      its own union arms; stop at root or first non-happy arm
+- [ ] 2.5 Replies: flatten `ThreadViewPost.replies` once (no deeper
+      recursion in v1); each entry dispatches over
+      `ThreadViewPostReply` arms, happy becomes a `ReplyRow` model,
+      non-happy becomes a `PlaceholderRow`
+- [ ] 2.6 Create `ThreadScreen` composable: `LazyColumn` with
+      ancestors block, focused post block (styled prominently),
+      replies list; placeholder composable for unavailable arms
+- [ ] 2.7 Reuse `PostRow` for ancestors and replies; extract a
+      `FocusedPostCard` composable for the prominent center slot
+- [ ] 2.8 Add a "Back" button to the thread screen that returns to
+      `Feed`
+
+## 3. Feed tap → thread
+
+- [ ] 3.1 `FeedScreen` accepts an `onPostTap: (AtUri) -> Unit`
+      callback
+- [ ] 3.2 `MainActivity` passes a callback that sets
+      `screen = Thread(uri)` on the tapped post's URI
+- [ ] 3.3 `PostRow` wires `Modifier.clickable { onPostTap(post.uri) }`
+      at the row level (but not on action buttons, to avoid swallowing
+      Like/Reply taps)
+
+## 4. Reply composition
+
+- [ ] 4.1 Extend `ComposeViewModel` with a private `replyTo: PostView?`
+      and a `setReplyTo(post: PostView?)` method
+- [ ] 4.2 Add a private `buildReplyRef(target: PostView): ReplyRef`
+      helper that constructs `parent = StrongRef(target.uri, target.cid)`
+      and resolves `root` from `target.record.decodeRecord<Post>()?.reply?.root`
+      with fallback to `parent`
+- [ ] 4.3 Wrap the decode in `runCatching` so records with unknown
+      fields don't crash reply construction
+- [ ] 4.4 In `createPost`, include `reply = replyTo?.let { buildReplyRef(it) }`
+      on the constructed `Post`
+- [ ] 4.5 `ComposeScreen` accepts a nullable `replyTo: PostView?`
+      parameter and renders a "Replying to @handle" banner when set
+- [ ] 4.6 Banner includes a "Cancel reply" link that calls
+      `viewModel.setReplyTo(null)` and hides the banner, continuing
+      as a top-level post
+
+## 5. Reply entry points
+
+- [ ] 5.1 `FocusedPostCard` includes a Reply action alongside Like /
+      Delete (if own)
+- [ ] 5.2 `ReplyRow` (the reply entries in the thread list) includes
+      a Reply action
+- [ ] 5.3 Placeholder rows for `NotFoundPost` / `BlockedPost` /
+      `*Unknown` do NOT render a Reply action
+- [ ] 5.4 Tapping Reply sets `screen = Compose(replyTo = post)` and
+      calls `composeViewModel.setReplyTo(post)` so the banner and
+      submission logic pick it up
+
+## 6. Post-reply refetch
+
+- [ ] 6.1 `ComposeViewModel.posted` (existing `SharedFlow<Boolean>`)
+      already emits true on success; `ComposeScreen` collects it and
+      calls a supplied `onPosted` callback
+- [ ] 6.2 When `replyTo != null` at submission time, route `onPosted`
+      to navigate to `Thread(rootUri = replyTo's root)` instead of
+      back to `Feed`
+- [ ] 6.3 The thread screen's `ThreadViewModel` re-triggers
+      `loadThread` whenever `rootUri` changes (already the default
+      for a fresh `Thread(...)` screen state)
+
+## 7. Tests
+
+- [ ] 7.1 Add `thread_happy.json` fixture under
+      `samples/android/src/test/resources/fixtures/thread/` covering
+      a post with one ancestor and three replies
+- [ ] 7.2 Add `thread_not_found.json` fixture with `thread` as
+      `NotFoundPost`
+- [ ] 7.3 Add `thread_unknown.json` fixture with `thread` as a
+      `ThreadViewPostUnknown` arm (unknown `$type`)
+- [ ] 7.4 `ThreadViewModelTest`: happy fixture → `Loaded` state
+      with correct ancestor/focused/reply ordering
+- [ ] 7.5 `ThreadViewModelTest`: not-found fixture → `Unavailable`
+      state with "This post was deleted." message
+- [ ] 7.6 `ThreadViewModelTest`: unknown fixture → `Unavailable`
+      state with "Thread unavailable." message
+- [ ] 7.7 `ComposeViewModelReplyTest`: `buildReplyRef` with a
+      top-level `PostView` → `root == parent`
+- [ ] 7.8 `ComposeViewModelReplyTest`: `buildReplyRef` with a
+      `PostView` whose decoded `Post.reply.root` is set → produced
+      `root` matches the source root, not the direct parent
+- [ ] 7.9 Run `./gradlew :samples:android:testDebugUnitTest` and
+      confirm all new tests pass alongside existing ones
+
+## 8. Build + manual verification
+
+- [ ] 8.1 `./gradlew :samples:android:assembleDebug` builds
+- [ ] 8.2 `./gradlew spotlessCheck` passes
+- [ ] 8.3 Manual test on device: log in, tap a post in the feed,
+      verify thread loads with ancestors + replies, tap Reply,
+      submit a reply, verify the thread refreshes with your new
+      reply visible
+- [ ] 8.4 Manual test: tap a post whose author has since deleted it
+      (or force by stubbing) — verify "This post was deleted."
+      renders
+
+## 9. Archive
+
+- [ ] 9.1 `openspec status --change sample-replies-threading` reports
+      4/4 artifacts complete
+- [ ] 9.2 Archive change to
+      `openspec/changes/archive/<date>-sample-replies-threading/` and
+      sync the delta into `openspec/specs/android-sample/`


### PR DESCRIPTION
## Summary

Scopes the next sample-app feature — **tap a post to see its thread, compose replies with correct `ReplyRef`** — as an OpenSpec change under `openspec/changes/sample-replies-threading/`.

Pure consumer-side work. The library already emits `getPostThread`, `ReplyRef`, and `StrongRef`; no runtime, generator, or models changes in the implementation.

## Key design decisions

- **Navigation state becomes a sealed `LoggedInScreen`** (`Feed` / `Thread(rootUri)` / `Compose(replyTo)`) instead of the current `var showCompose: Boolean`. Simplest shape that carries both the selected thread URI and optional reply context without pulling in nav-compose.
- **`buildReplyRef` resolves thread root correctly.** AT Protocol requires `reply.root` to be the thread originator, not just the direct parent. Implementation decodes the target's `record: JsonObject` to a typed `Post` and reads `Post.reply?.root`; falls back to the target itself for top-level targets. Wrapped in `runCatching` for resilience.
- **Flat replies with depth-1 indent.** No infinite nesting in v1 — that's a design call about collapse/expand semantics that's deferred.
- **Refetch after reply success.** Cheaper than optimistic insertion and acceptable latency.
- **Reply actions on happy arms only.** `NotFoundPost` / `BlockedPost` / `*Unknown` don't expose a Reply button.

## Non-goals (deferred)

- Rich text facets (mentions, links, hashtags)
- Image / video embeds in replies (text-only MVP)
- Deeper reply nesting beyond depth-1 indent
- Optimistic reply insertion
- Deep-linking from external URLs
- Push notifications

## Test plan

- [ ] `openspec status --change sample-replies-threading` reports 4/4 artifacts complete
- [ ] `openspec validate sample-replies-threading` passes (did locally)
- [ ] Scope feels right — seven requirements across thread loading, placeholder rendering, reply construction, entry points, refetch, and tests