### PR TITLE
feat(samples/android): enable edge-to-edge on all screens

### DIFF
--- a/samples/android/src/main/AndroidManifest.xml
+++ b/samples/android/src/main/AndroidManifest.xml
@@ -15,7 +15,8 @@
             android:name=".MainActivity"
             android:exported="true"
             android:launchMode="singleTask"
-            android:theme="@style/Theme.BlueskySample">
+            android:theme="@style/Theme.BlueskySample"
+            android:windowSoftInputMode="adjustResize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/samples/android/src/main/kotlin/io/github/kikin81/atproto/samples/bluesky/MainActivity.kt
+++ b/samples/android/src/main/kotlin/io/github/kikin81/atproto/samples/bluesky/MainActivity.kt
@@ -6,6 +6,7 @@ import android.os.Bundle
 import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
 import androidx.browser.customtabs.CustomTabsIntent
 import androidx.compose.foundation.isSystemInDarkTheme
@@ -46,6 +47,10 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        // Draws behind status + navigation bars and auto-manages system-bar
+        // icon contrast per theme. Paired with android:windowSoftInputMode=
+        // "adjustResize" so the IME resizes the Activity instead of panning.
+        enableEdgeToEdge()
         setContent {
             BlueskySampleTheme {
                 Surface(modifier = Modifier.fillMaxSize()) {

--- a/samples/android/src/main/kotlin/io/github/kikin81/atproto/samples/bluesky/ui/ComposeScreen.kt
+++ b/samples/android/src/main/kotlin/io/github/kikin81/atproto/samples/bluesky/ui/ComposeScreen.kt
@@ -4,10 +4,13 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -66,10 +69,16 @@ fun ComposeScreen(
                 },
             )
         },
+        // safeDrawing expands to include the IME when the keyboard opens,
+        // so innerPadding automatically keeps the text field visible above
+        // the keyboard. consumeWindowInsets on the column prevents any
+        // nested consumer from double-applying these insets.
+        contentWindowInsets = WindowInsets.safeDrawing,
     ) { padding ->
         Column(
             Modifier
                 .padding(padding)
+                .consumeWindowInsets(padding)
                 .fillMaxSize()
                 .padding(16.dp),
         ) {

--- a/samples/android/src/main/kotlin/io/github/kikin81/atproto/samples/bluesky/ui/FeedScreen.kt
+++ b/samples/android/src/main/kotlin/io/github/kikin81/atproto/samples/bluesky/ui/FeedScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -100,51 +101,62 @@ fun FeedScreen(
             }
         },
     ) { padding ->
-        Box(modifier = Modifier.padding(padding).fillMaxSize()) {
-            when (val s = state) {
-                FeedUiState.Loading -> {
-                    Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                        CircularProgressIndicator()
+        // Per edge-to-edge guidance: don't apply innerPadding to the parent
+        // Box (would clip the list from scrolling under the system bars).
+        // Lists use contentPadding; Loading/Error centered states apply
+        // padding themselves so they sit within the safe area.
+        when (val s = state) {
+            FeedUiState.Loading -> {
+                Box(
+                    Modifier.fillMaxSize().padding(padding),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    CircularProgressIndicator()
+                }
+            }
+            is FeedUiState.Error -> {
+                Column(
+                    Modifier.fillMaxSize().padding(padding).padding(24.dp),
+                    verticalArrangement = Arrangement.Center,
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                ) {
+                    Text("Failed to load timeline", style = MaterialTheme.typography.titleMedium)
+                    Spacer(Modifier.height(8.dp))
+                    Text(s.message, style = MaterialTheme.typography.bodySmall)
+                    Spacer(Modifier.height(16.dp))
+                    Button(onClick = { viewModel.onEvent(FeedEvent.Retry) }) { Text("Retry") }
+                }
+            }
+            is FeedUiState.Loaded -> {
+                val listState = rememberLazyListState()
+                val shouldLoadMore by remember {
+                    derivedStateOf {
+                        val last = listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index
+                        val total = listState.layoutInfo.totalItemsCount
+                        last != null && total > 0 && last >= total - 3
                     }
                 }
-                is FeedUiState.Error -> {
-                    Column(
-                        Modifier.fillMaxSize().padding(24.dp),
-                        verticalArrangement = Arrangement.Center,
-                        horizontalAlignment = Alignment.CenterHorizontally,
-                    ) {
-                        Text("Failed to load timeline", style = MaterialTheme.typography.titleMedium)
-                        Spacer(Modifier.height(8.dp))
-                        Text(s.message, style = MaterialTheme.typography.bodySmall)
-                        Spacer(Modifier.height(16.dp))
-                        Button(onClick = { viewModel.onEvent(FeedEvent.Retry) }) { Text("Retry") }
+                LaunchedEffect(listState) {
+                    snapshotFlow { shouldLoadMore }.collect { near ->
+                        if (near) viewModel.onEvent(FeedEvent.LoadMore)
                     }
                 }
-                is FeedUiState.Loaded -> {
-                    val listState = rememberLazyListState()
-                    val shouldLoadMore by remember {
-                        derivedStateOf {
-                            val last = listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index
-                            val total = listState.layoutInfo.totalItemsCount
-                            last != null && total > 0 && last >= total - 3
-                        }
-                    }
-                    LaunchedEffect(listState) {
-                        snapshotFlow { shouldLoadMore }.collect { near ->
-                            if (near) viewModel.onEvent(FeedEvent.LoadMore)
-                        }
-                    }
-                    LazyColumn(state = listState, modifier = Modifier.fillMaxSize()) {
-                        items(s.feed) { entry ->
-                            PostRow(
-                                entry = entry,
-                                isOwnPost = entry.post.author.did.raw == currentDid,
-                                onLikeToggle = { viewModel.onEvent(FeedEvent.ToggleLike(entry.post)) },
-                                onDelete = { viewModel.onEvent(FeedEvent.DeletePost(entry.post)) },
-                                onTap = { onPostTap(entry.post.uri) },
-                            )
-                            HorizontalDivider()
-                        }
+                LazyColumn(
+                    state = listState,
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .consumeWindowInsets(padding),
+                    contentPadding = padding,
+                ) {
+                    items(s.feed) { entry ->
+                        PostRow(
+                            entry = entry,
+                            isOwnPost = entry.post.author.did.raw == currentDid,
+                            onLikeToggle = { viewModel.onEvent(FeedEvent.ToggleLike(entry.post)) },
+                            onDelete = { viewModel.onEvent(FeedEvent.DeletePost(entry.post)) },
+                            onTap = { onPostTap(entry.post.uri) },
+                        )
+                        HorizontalDivider()
                     }
                 }
             }

--- a/samples/android/src/main/kotlin/io/github/kikin81/atproto/samples/bluesky/ui/LoginScreen.kt
+++ b/samples/android/src/main/kotlin/io/github/kikin81/atproto/samples/bluesky/ui/LoginScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Button
@@ -32,7 +33,14 @@ fun LoginScreen(
     var handle by remember { mutableStateOf("") }
 
     Column(
-        modifier = Modifier.fillMaxSize().padding(24.dp),
+        // safeDrawingPadding includes system bars + IME, so the handle
+        // input stays above the keyboard when focused and above the
+        // navigation bar when idle. No Scaffold here — this screen is
+        // a centered single-column layout.
+        modifier = Modifier
+            .fillMaxSize()
+            .safeDrawingPadding()
+            .padding(24.dp),
         verticalArrangement = Arrangement.Center,
     ) {
         Text(

--- a/samples/android/src/main/kotlin/io/github/kikin81/atproto/samples/bluesky/ui/ThreadScreen.kt
+++ b/samples/android/src/main/kotlin/io/github/kikin81/atproto/samples/bluesky/ui/ThreadScreen.kt
@@ -4,8 +4,10 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -72,43 +74,49 @@ fun ThreadScreen(
             )
         },
     ) { padding ->
-        Box(modifier = Modifier.padding(padding).fillMaxSize()) {
-            when (val s = state) {
-                ThreadUiState.Loading -> {
-                    Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                        CircularProgressIndicator()
-                    }
+        // innerPadding is pushed into the LazyColumn's contentPadding so the
+        // thread scrolls behind the system bars; centered Loading / Error /
+        // Unavailable states apply padding themselves to sit within the
+        // safe area.
+        when (val s = state) {
+            ThreadUiState.Loading -> {
+                Box(
+                    Modifier.fillMaxSize().padding(padding),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    CircularProgressIndicator()
                 }
-                is ThreadUiState.Error -> {
-                    Column(
-                        Modifier.fillMaxSize().padding(24.dp),
-                        verticalArrangement = Arrangement.Center,
-                        horizontalAlignment = Alignment.CenterHorizontally,
-                    ) {
-                        Text("Failed to load thread", style = MaterialTheme.typography.titleMedium)
-                        Spacer(Modifier.height(8.dp))
-                        Text(s.message, style = MaterialTheme.typography.bodySmall)
-                        Spacer(Modifier.height(16.dp))
-                        Button(onClick = { viewModel.onEvent(ThreadEvent.Retry) }) { Text("Retry") }
-                    }
-                }
-                is ThreadUiState.Unavailable -> {
-                    Column(
-                        Modifier.fillMaxSize().padding(24.dp),
-                        verticalArrangement = Arrangement.Center,
-                        horizontalAlignment = Alignment.CenterHorizontally,
-                    ) {
-                        Text(s.message, style = MaterialTheme.typography.titleMedium)
-                        Spacer(Modifier.height(16.dp))
-                        Button(onClick = onBack) { Text("Back") }
-                    }
-                }
-                is ThreadUiState.Loaded -> LoadedThread(
-                    state = s,
-                    currentDid = currentDid,
-                    onReply = onReply,
-                )
             }
+            is ThreadUiState.Error -> {
+                Column(
+                    Modifier.fillMaxSize().padding(padding).padding(24.dp),
+                    verticalArrangement = Arrangement.Center,
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                ) {
+                    Text("Failed to load thread", style = MaterialTheme.typography.titleMedium)
+                    Spacer(Modifier.height(8.dp))
+                    Text(s.message, style = MaterialTheme.typography.bodySmall)
+                    Spacer(Modifier.height(16.dp))
+                    Button(onClick = { viewModel.onEvent(ThreadEvent.Retry) }) { Text("Retry") }
+                }
+            }
+            is ThreadUiState.Unavailable -> {
+                Column(
+                    Modifier.fillMaxSize().padding(padding).padding(24.dp),
+                    verticalArrangement = Arrangement.Center,
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                ) {
+                    Text(s.message, style = MaterialTheme.typography.titleMedium)
+                    Spacer(Modifier.height(16.dp))
+                    Button(onClick = onBack) { Text("Back") }
+                }
+            }
+            is ThreadUiState.Loaded -> LoadedThread(
+                state = s,
+                currentDid = currentDid,
+                onReply = onReply,
+                contentPadding = padding,
+            )
         }
     }
 }
@@ -118,8 +126,14 @@ private fun LoadedThread(
     state: ThreadUiState.Loaded,
     currentDid: String?,
     onReply: (PostView) -> Unit,
+    contentPadding: PaddingValues,
 ) {
-    LazyColumn(modifier = Modifier.fillMaxSize()) {
+    LazyColumn(
+        modifier = Modifier
+            .fillMaxSize()
+            .consumeWindowInsets(contentPadding),
+        contentPadding = contentPadding,
+    ) {
         if (state.ancestorsTruncated) {
             item { ContextUnavailableRow() }
         }


### PR DESCRIPTION
## Summary

Applies the Google [`android/skills` edge-to-edge](https://github.com/android/skills/tree/main/jetpack-compose/edge-to-edge) workflow to the sample app. The app now draws behind the status and navigation bars, with system-bar-aware inset handling on every screen and IME-safe text fields.

**Branch base:** `feat/sample-replies-threading` (PR #13). Contains the threading work as a dependency — the new `ThreadScreen` needs the same inset treatment, so this lands on top rather than against `main`. Once #13 merges, this PR rebases cleanly.

## Changes per skill checklist

| Skill checklist item | How this PR satisfies it |
|---|---|
| Every Activity calls `enableEdgeToEdge()` | `MainActivity.onCreate` calls it before `setContent` |
| `adjustResize` set in AndroidManifest | `android:windowSoftInputMode=\"adjustResize\"` on the MainActivity |
| TextFields have IME-aware parents | `LoginScreen` uses `Modifier.safeDrawingPadding()`; `ComposeScreen`'s Scaffold uses `contentWindowInsets = WindowInsets.safeDrawing` + `consumeWindowInsets(padding)` on the inner Column |
| Lists draw away from system bars via `contentPadding` | `FeedScreen` + `ThreadScreen` `LazyColumn`s use `contentPadding = padding` and `Modifier.consumeWindowInsets(padding)`. The parent Box's `Modifier.padding(padding)` (which would clip the list) is gone |
| FABs draw above nav bars | `FeedScreen`'s FAB is inside Scaffold, which manages its own insets |
| Project builds | `./gradlew :samples:android:assembleDebug` green, 11 unit tests green, `spotlessCheck` green |

## Design calls

- **Used the `ComponentActivity` `enableEdgeToEdge` variant** (not `WindowCompat`) so system-bar icon colors auto-adjust to theme. No manual `isAppearanceLightStatusBars` / `isAppearanceLightNavigationBars` SideEffect needed.
- **Loading / Error / Unavailable states explicitly apply `innerPadding`** so their centered content sits in the safe area. The list case gets `contentPadding` instead, per skill guidance to avoid double-padding.
- **No bottom bar anywhere**, so the `window.isNavigationBarContrastEnforced = false` recommendation from the skill doesn't apply.
- **Didn't touch the theme file.** The `enableEdgeToEdge()` call handles everything we need for this app.

## Test plan (maintainer device smoke)

- [ ] Feed screen: content scrolls visibly behind the status bar and navigation bar; FAB sits above the nav bar
- [ ] Tap a post → Thread screen: same behavior, ancestor + focused + replies all reachable
- [ ] Login screen: tap the handle field → IME opens, field stays above keyboard, not clipped
- [ ] Compose screen: same for the post text field
- [ ] Gesture navigation (Android 10+) and three-button navigation both look correct (translucent nav scrim on three-button via `enableEdgeToEdge` default)
- [ ] Light theme and dark theme both show legible system-bar icons