### PR TITLE
fix(release): run Dokka after semantic-release version bump

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -157,19 +157,6 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
 
-      - name: Generate API docs
-        run: ./gradlew :generator:generateModels :dokkaGeneratePublicationHtml --no-configuration-cache
-
-      - name: Stage API docs for GitHub Pages
-        run: |
-          rm -rf docs/api
-          cp -r build/dokka/html docs/api
-
-      - uses: stefanzweifel/git-auto-commit-action@v5
-        with:
-          commit_message: "docs: update API documentation [skip ci]"
-          file_pattern: "docs/api/**"
-
       - id: release
         uses: open-turo/actions-jvm/release@v2
         env:
@@ -182,3 +169,20 @@ jobs:
         with:
           github-token: ${{ secrets.RELEASE_PAT }}
           checkout-repo: false
+
+      # Regenerate API docs AFTER semantic-release bumps gradle.properties,
+      # so the Dokka-embedded `library-version` label matches the just-published
+      # artifacts. On non-release pushes (chore/docs/etc.), semantic-release is
+      # a no-op and Dokka reads the current released version — still correct.
+      - name: Generate API docs
+        run: ./gradlew :generator:generateModels :dokkaGeneratePublicationHtml --no-configuration-cache
+
+      - name: Stage API docs for GitHub Pages
+        run: |
+          rm -rf docs/api
+          cp -r build/dokka/html docs/api
+
+      - uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "docs: update API documentation [skip ci]"
+          file_pattern: "docs/api/**"

--- a/openspec/changes/reorder-release-dokka-step/design.md
+++ b/openspec/changes/reorder-release-dokka-step/design.md
@@ -1,0 +1,263 @@
+## Overview
+
+Reorder the `release` job in `.github/workflows/release.yaml` so Dokka
+runs after semantic-release has bumped `gradle.properties`. The result:
+the published docs always carry the same version label as the JARs
+shipped in the same release.
+
+## Current state
+
+```
+release:
+  needs: [lint, test, build]
+  steps:
+    - Checkout                                      gradle.properties = OLD
+    - Set up Node.js
+    - Install lexicon corpus
+    - Set up JDK
+    - Setup Android SDK
+    - Setup Gradle
+
+    - Generate API docs                             ← reads OLD version  ❌
+      run: ./gradlew :generator:generateModels :dokkaGeneratePublicationHtml
+
+    - Stage API docs for GitHub Pages
+      run: rm -rf docs/api && cp -r build/dokka/html docs/api
+
+    - uses: stefanzweifel/git-auto-commit-action@v5
+      with:
+        commit_message: "docs: update API documentation [skip ci]"
+        file_pattern: "docs/api/**"
+
+    - id: release                                   ← bumps gradle.properties,
+      uses: open-turo/actions-jvm/release@v2         creates tag, runs publish
+```
+
+## Target state
+
+```
+release:
+  needs: [lint, test, build]
+  steps:
+    - Checkout
+    - Set up Node.js
+    - Install lexicon corpus
+    - Set up JDK
+    - Setup Android SDK
+    - Setup Gradle
+
+    - id: release                                   ← bumps gradle.properties
+      uses: open-turo/actions-jvm/release@v2          on release-worthy commits
+
+    - Generate API docs                             ← reads NEW version  ✅
+      run: ./gradlew :generator:generateModels :dokkaGeneratePublicationHtml
+
+    - Stage API docs for GitHub Pages
+      run: rm -rf docs/api && cp -r build/dokka/html docs/api
+
+    - uses: stefanzweifel/git-auto-commit-action@v5
+      with:
+        commit_message: "docs: update API documentation [skip ci]"
+        file_pattern: "docs/api/**"
+```
+
+Four steps moved as a block. No other changes.
+
+## Why we're confident: evidence from the v5.0.0 release
+
+A legitimate concern when proposing this reorder: **does semantic-release
+actually mutate `gradle.properties` on the runner's filesystem during the
+release step, or does it only compute the next version in memory and
+pass it to gradle as a flag?** If the latter, the reorder wouldn't help
+— Dokka would still read the pre-bump version.
+
+Evidence from run #24793397775 (the feat! v5.0.0 release) shows the
+former. Key timestamps extracted from the `Release` job logs:
+
+```
+17:49:03  semantic-release "prepare" phase starts
+17:49:03  [@semantic-release/git] "Found 1 file(s) to commit"
+17:49:04  [@semantic-release/git] commits + pushes to origin
+17:49:04  [@semantic-release/git] "Prepared Git release: v5.0.0"
+17:49:06  Created tag v5.0.0
+17:49:07  Published GitHub release
+17:49:07  [gradle-semantic-release-plugin] "publish" phase starts
+          → ./gradlew publish  (reads gradle.properties from disk)
+```
+
+Inspecting the resulting commit confirms the on-disk mutation:
+
+```
+$ git show e81bfdd6 --stat
+ gradle.properties | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+$ git show e81bfdd6 -- gradle.properties
+-version = 4.9.0
++version = 5.0.0
+```
+
+The semantic-release plugin chain is:
+
+```
+@semantic-release/github
+gradle-semantic-release-plugin
+@semantic-release/git
+@semantic-release/exec
+```
+
+`gradle-semantic-release-plugin` writes the new version into
+`gradle.properties`. `@semantic-release/git` then stages, commits, and
+pushes that change — all during the `prepare` hook, before the `publish`
+hook runs `./gradlew publish`. The commit becomes part of the working
+tree on the runner, so **any step after the release step reads the
+bumped version**.
+
+An independent corroboration: when the `chore/cleanup-post-v5-release`
+PR (#18) merged, `release.yaml` ran its unconditional "Generate API
+docs" step against a `gradle.properties` that already carried
+`version = 5.0.0` (from the prior release's commit on main). Dokka
+generated docs with the correct label and the auto-commit pushed them.
+The live site flipped from `4.9.0` to `5.0.0` without any further
+intervention. That confirms the Gradle-side mechanics work; the reorder
+generalizes this to the release push itself.
+
+## Why the Gradle side already supports this
+
+Each `./gradlew` invocation re-reads `gradle.properties` on configuration.
+`Project.version` is not cached across invocations. Semantic-release
+commits the bumped `gradle.properties` to the working tree (via its
+`@semantic-release/exec` / `gradle-semantic-release-plugin` step) before
+returning. So any subsequent Gradle command sees the new version.
+
+No Dokka plugin configuration changes are needed. `runtime/build.gradle.kts`,
+`models/build.gradle.kts`, `oauth/build.gradle.kts`, and the root
+`build.gradle.kts` stay untouched.
+
+## Why simple reorder over parameter-passing
+
+Two viable approaches:
+
+### A — Simple reorder (chosen)
+
+Move Dokka after semantic-release. Dokka reads the bumped
+`gradle.properties`.
+
+### B — Dry-run + `-Pversion=<next>`
+
+Run semantic-release in dry-run mode first to compute the next version,
+pass it explicitly to Dokka via `-Pversion=<next>`, then run the real
+release:
+
+```
+steps:
+  - Dry-run semantic-release, capture next-version output
+  - ./gradlew :dokkaGeneratePublicationHtml -Pversion=<next>
+  - Stage + commit docs
+  - Real semantic-release
+```
+
+This decouples Dokka from `gradle.properties` state entirely.
+
+**Why A wins**:
+
+- **Simplicity**: one block of YAML moved. B adds a new "dry-run"
+  invocation of semantic-release plus output parsing, which roughly
+  doubles the step count.
+- **Matches what the build already does**: Gradle already reads
+  `Project.version` from `gradle.properties`. B introduces a second
+  source of truth (the CLI flag) that conflicts with the first.
+- **B's theoretical advantage doesn't matter here**: B lets you
+  regenerate docs for a failed release. But if the release itself fails,
+  regenerating docs with the "would-have-been" version is misleading —
+  consumers would see docs for a version that doesn't exist on Central.
+  A's behavior (fail docs together with the release, publish both on
+  success) is the desired coupling.
+
+If we ever need to publish docs for dev snapshots or pre-release tags
+without a real Central release, B becomes more interesting. Not
+applicable today.
+
+## Failure modes
+
+### Docs generation fails after a successful release
+
+Under the current ordering, a Dokka failure blocks semantic-release and
+the JARs never ship. After the reorder, the JARs ship first and Dokka
+failure leaves the docs site at its previous state.
+
+**Why this trade is the right direction**:
+
+- The artifacts on Maven Central are the product of record. A release
+  that successfully publishes JARs should not be blocked by a docs
+  failure — consumers care about the JARs first, docs second.
+- A docs failure is highly visible (CI goes red, docs site stays stale)
+  and recoverable: push a trivial `docs:` commit (or re-run the
+  workflow), and the unconditional regeneration step runs again.
+- The current ordering has a worse failure mode that has already bitten:
+  a successful docs step ships docs labeled with the wrong version.
+  Visible only on careful inspection, not flagged by CI.
+
+### Semantic-release step fails
+
+No change. Release job fails, docs not regenerated, JARs not published.
+Same as today.
+
+### Non-release push (only `chore:` / `docs:` / `test:` / `refactor:`
+commits since last tag)
+
+No change. `open-turo/actions-jvm/release` is a no-op:
+`gradle.properties` is untouched. Dokka still runs in the reordered
+step, reads the current released version, and the auto-commit
+regenerates `docs/api/` to reflect whatever content changes warranted
+the push. Docs stay in sync.
+
+### Concurrent pushes to `main`
+
+No change. GitHub Actions queues workflow runs per-ref for
+`git-auto-commit-action` invocations to avoid `git push` race
+conditions. If we ever need stronger guarantees, a `concurrency: main`
+block on the job is the standard fix.
+
+## Idempotency and re-runs
+
+The reordered pipeline is safe to re-run:
+
+- Re-running after a successful end-to-end run: semantic-release sees
+  the just-created tag, computes no new release, exits cleanly. Dokka
+  regenerates from current `gradle.properties` (still the just-bumped
+  version). Auto-commit either finds no diff (no commit created) or
+  commits trivial drift.
+- Re-running after a partial failure (release succeeded, Dokka failed):
+  same as the non-release path above. `gradle.properties` is already at
+  the new version. Dokka regenerates. Docs catch up.
+
+## Test plan
+
+### Cannot be fully tested without a real release
+
+The correct behavior only manifests on a push that bumps a version.
+`feat:` / `fix:` / `BREAKING CHANGE:` commits trigger it;
+`chore:` / `docs:` / etc. don't. A local test of the YAML change
+cannot replicate `open-turo/actions-jvm/release`'s gradle.properties
+mutation because that action is GHA-only.
+
+### Pre-merge verification
+
+- [ ] Run `actionlint` locally on the edited `release.yaml` (or rely on
+  the workflow's own Lint GitHub Actions workflow files hook).
+- [ ] Visually confirm the four Dokka-related steps follow (not
+  precede) the `id: release` step.
+- [ ] Confirm no other step reads `build/dokka/html` or `docs/api/`
+  between the Dokka generation and the auto-commit.
+
+### Post-merge verification
+
+- [ ] Next release-triggering push to `main`: inspect the workflow run
+  and confirm `open-turo/actions-jvm/release` runs before the
+  "Generate API docs" step.
+- [ ] After that release: `curl -s https://kikin81.github.io/atproto-kotlin/api/ | grep library-version`
+  shows the same version as `git describe --tags` on `main`.
+- [ ] After one subsequent non-release push (e.g., a `chore:` or
+  `docs:` PR merge): site still shows the last released version,
+  not a stale one.

--- a/openspec/changes/reorder-release-dokka-step/proposal.md
+++ b/openspec/changes/reorder-release-dokka-step/proposal.md
@@ -1,0 +1,73 @@
+## Why
+
+The release pipeline generates Dokka HTML docs **before** semantic-release
+bumps `gradle.properties`, then publishes both artifacts together. The
+result: every release ships docs labeled with the *previous* version.
+
+```
+release.yaml (current):
+  1. checkout              gradle.properties = 4.9.0
+  2. ./gradlew :dokkaGeneratePublicationHtml   ← reads 4.9.0  ❌
+  3. git-auto-commit docs/api                  ← commits 4.9.0 label
+  4. open-turo/actions-jvm/release             ← bumps to 5.0.0, publishes JARs
+```
+
+Maven Central correctly ships `io.github.kikin81.atproto:runtime:5.0.0`,
+but the Dokka HTML at `https://kikin81.github.io/atproto-kotlin/api/`
+renders a `<div class="library-version">4.9.0</div>`. This mismatch has
+existed since the docs workflow landed — it was not noticed on prior
+minor bumps (4.8.0 docs say 4.7.0 is less visually alarming) but became
+obvious when 5.0.0 docs said 4.9.0 after the
+[rename-maven-artifacts](../archive/) shipped.
+
+Fixing this is a ~10-line change to one file.
+
+## What Changes
+
+- **Reorder `.github/workflows/release.yaml`**: move the four steps that
+  generate + stage + commit Dokka HTML (currently steps 3–6 of the
+  `release` job) to run **after** the `open-turo/actions-jvm/release`
+  step. Semantic-release commits the bumped `gradle.properties` to the
+  working tree before returning, so any `./gradlew` invocation
+  afterwards reads the bumped version.
+- **No Gradle changes**: the Dokka configuration in
+  `runtime/build.gradle.kts`, `models/build.gradle.kts`,
+  `oauth/build.gradle.kts`, and the root `build.gradle.kts` is
+  unchanged. `Project.version` is read fresh each invocation, so the
+  Gradle side already supports this.
+- **No changes to non-release pushes**: pushes with only `chore:` /
+  `docs:` / `test:` / `refactor:` commits continue to regenerate docs
+  unconditionally — semantic-release is a no-op on those pushes, so
+  `gradle.properties` is untouched and Dokka reads the current released
+  version. Docs stay fresh.
+
+## Capabilities
+
+### New Capabilities
+
+_(none)_
+
+### Modified Capabilities
+
+- `sdk-documentation`: adds a requirement that the documentation site's
+  version label match the version of the Maven Central artifacts shipped
+  in the same release. The existing requirement that release deploys
+  docs to GitHub Pages is strengthened — "matching the released version"
+  is now an enforced property, not an incidental one.
+
+## Impact
+
+- **Files touched**: `.github/workflows/release.yaml` only. Roughly 10
+  lines moved, no new YAML structure, no new action dependencies.
+- **First release affected**: the next release after this change lands.
+  Existing 5.0.0 docs remain incorrect (already shipped) until either
+  the next release regenerates them, or a manual `docs:` commit
+  triggers the release workflow's unconditional regeneration step. The
+  cleanup PR that fixed the 5.0.0 label did the latter.
+- **Release duration**: unchanged. Same steps, reordered.
+- **Failure-mode shift**: if Dokka generation fails, the shift means the
+  Maven Central publish already succeeded — stale docs instead of a
+  blocked release. See design.md for the rationale; this is the
+  desirable failure mode.
+- **Breaking changes**: none. Internal pipeline only, no effect on
+  consumers.

--- a/openspec/changes/reorder-release-dokka-step/specs/sdk-documentation/spec.md
+++ b/openspec/changes/reorder-release-dokka-step/specs/sdk-documentation/spec.md
@@ -1,0 +1,48 @@
+## ADDED Requirements
+
+### Requirement: Published documentation version label SHALL match the release tag
+
+The system SHALL ensure the Dokka-generated documentation site at
+`https://kikin81.github.io/atproto-kotlin/api/` renders a
+`library-version` label that matches the Git tag cut by semantic-release
+in the same release workflow run. This requirement applies to every
+release that bumps the version — `feat:`, `fix:`, and any commit
+carrying a `BREAKING CHANGE:` footer.
+
+To satisfy this, Dokka generation in the release workflow SHALL run
+**after** semantic-release has mutated `gradle.properties` to the new
+version, so that the `Project.version` Gradle reads at Dokka-generate
+time is the post-bump value.
+
+#### Scenario: Release cuts version and docs match
+
+- **WHEN** `main` receives a push containing a `feat:` commit that
+  semantic-release classifies as a minor bump from 5.0.0 to 5.1.0
+- **AND** the `release.yaml` workflow runs to completion
+- **THEN** the Git tag `v5.1.0` is created
+- **AND** Maven Central receives `io.github.kikin81.atproto:{runtime,models,oauth}:5.1.0`
+- **AND** `curl -s https://kikin81.github.io/atproto-kotlin/api/ | grep library-version`
+  renders `5.1.0` — not `5.0.0` or any other prior version
+
+#### Scenario: Non-release push regenerates docs without version drift
+
+- **WHEN** `main` receives a push containing only `chore:` or `docs:`
+  commits since the last release
+- **AND** the `release.yaml` workflow runs the Dokka generation step
+  (which runs on every push to `main`)
+- **THEN** semantic-release is a no-op, no new tag is created
+- **AND** the docs regeneration reads the existing (last-released)
+  version from `gradle.properties`
+- **AND** the docs site's `library-version` label continues to show
+  that last-released version — not stale, not prematurely bumped
+
+#### Scenario: Failed release leaves docs intact
+
+- **WHEN** the `release.yaml` workflow fails during semantic-release
+  (e.g., network error reaching Maven Central's staging endpoint)
+- **THEN** no new Git tag is created
+- **AND** `gradle.properties` is not committed with a bump
+- **AND** the subsequent Dokka generation step does not run (the job
+  fails)
+- **AND** the docs site retains its last-good state (the version label
+  for the last successful release)

--- a/openspec/changes/reorder-release-dokka-step/tasks.md
+++ b/openspec/changes/reorder-release-dokka-step/tasks.md
@@ -1,0 +1,36 @@
+## 1. Edit release.yaml
+
+- [ ] 1.1 Open `.github/workflows/release.yaml`, locate the `release` job
+- [ ] 1.2 Identify the block of four contiguous steps under the `release` job that handle Dokka:
+  - `name: Generate API docs` (runs `./gradlew :generator:generateModels :dokkaGeneratePublicationHtml --no-configuration-cache`)
+  - `name: Stage API docs for GitHub Pages` (runs `rm -rf docs/api && cp -r build/dokka/html docs/api`)
+  - `uses: stefanzweifel/git-auto-commit-action@v5` (commit message `"docs: update API documentation [skip ci]"`, file pattern `"docs/api/**"`)
+- [ ] 1.3 Move those three steps as a block to immediately **after** the `id: release` step (`uses: open-turo/actions-jvm/release@v2`)
+- [ ] 1.4 Leave all setup steps (Checkout, Node, Install lexicon corpus, JDK, Android SDK, Gradle) in their current position and order. They precede everything.
+- [ ] 1.5 Leave the `id: release` step's `env:` and `with:` blocks untouched — the inputs to open-turo/actions-jvm/release do not change.
+- [ ] 1.6 No changes to the `lint`, `test`, or `build` gate jobs.
+
+## 2. Local static verification
+
+- [ ] 2.1 `actionlint .github/workflows/release.yaml` passes (or rely on the pre-commit `Lint GitHub Actions workflow files` hook when committing)
+- [ ] 2.2 Visually confirm in the edited YAML: the "Generate API docs" step now comes after the "id: release" step, and the three-step Dokka block stays contiguous
+- [ ] 2.3 No other step in the job references `build/dokka/html` or `docs/api/` between Dokka generation and the auto-commit
+
+## 3. Commit + PR
+
+- [ ] 3.1 Branch `fix/release-dokka-ordering` off `main`
+- [ ] 3.2 Commit as `fix(release): run Dokka after semantic-release version bump`
+- [ ] 3.3 Open PR; CI lint/test/build jobs should pass without changes (they don't touch the release job)
+- [ ] 3.4 Merge to `main`. **This merge itself will not trigger the fix** — it's a `fix:` commit which is a patch bump by semantic-release convention, but the bumping runs via the unchanged ordering on this merge. The reorder takes effect on **subsequent** pushes.
+
+## 4. Post-merge verification on next release
+
+- [ ] 4.1 On the next release-triggering push to `main` (any `feat:`/`fix:`/`BREAKING CHANGE:` commit), inspect the workflow run in the GitHub Actions UI and confirm the step order matches the new YAML
+- [ ] 4.2 After the release completes, curl the docs site and grep for `library-version`; confirm the label matches the tag cut in that release
+- [ ] 4.3 On a subsequent non-release push (e.g., a `chore:` or `docs:` PR), confirm docs regenerate but the `library-version` label stays at the last released version — not bumped, not stale
+- [ ] 4.4 Archive this change with `openspec archive reorder-release-dokka-step` once 4.1–4.3 pass
+
+## 5. Optional cleanups (out of scope for this change)
+
+- Add `concurrency: main` to the release job if we start seeing `git push` races from simultaneous pushes (none observed today; left as a follow-up if needed).
+- Consider moving the Dokka step into its own dependent job (`docs: needs: [release]`) for stronger isolation. Current inline arrangement is adequate for a single-writer pipeline.


### PR DESCRIPTION
## Summary

- Moves the "Generate API docs" + "Stage API docs" + `git-auto-commit-action` block to run **after** `open-turo/actions-jvm/release` in the `release` job of `.github/workflows/release.yaml`.
- Fixes the pre-existing bug where Dokka embedded a `library-version` label one release behind the published artifacts (4.9.0 docs for the 5.0.0 release — visible on the 5.0.0 bump because majors are eye-catching; silently wrong on prior minor bumps).
- Preserves unconditional docs regeneration on non-release pushes (`chore:` / `docs:` / etc.) — those leave `gradle.properties` untouched, so Dokka correctly reads the last-released version.

## Why this works (evidence)

Traced from run #24793397775 (the v5.0.0 release) `Release` job logs: during semantic-release's `prepare` phase, `@semantic-release/git` commits the bumped `gradle.properties` to the runner's working tree **and** pushes to origin. The subsequent `./gradlew publish` (inside the same release step) reads that bumped version from disk. So any `./gradlew` invocation after the release step also reads the bumped version.

Full timing + commit-diff evidence in `openspec/changes/reorder-release-dokka-step/design.md` under "Why we're confident: evidence from the v5.0.0 release".

## Why simple reorder (not `-Pversion=<next>` from a dry-run)

Both approaches work; the reorder is 10 lines of YAML moved, no new plumbing. Coupling Dokka failures to release failures is the right direction: if Dokka fails after a reorder, JARs are already published and stale docs are a recoverable issue; under the old order, a Dokka failure would block the JAR release entirely. Detailed trade-off in design.md.

## OpenSpec

Proposal, design, tasks, and `sdk-documentation` spec delta under `openspec/changes/reorder-release-dokka-step/`.

## Test plan

- [ ] CI lint/test/build pass (they don't touch the release job — should be a no-op for gates)
- [ ] Post-merge: next release-triggering push confirms step order in the workflow run UI
- [ ] Post-release: `curl -s https://kikin81.github.io/atproto-kotlin/api/ | grep library-version` shows the just-released version
- [ ] Post-subsequent-chore-push: docs regenerate without version drift (label stays at last release)
- [ ] Archive `reorder-release-dokka-step` once all the above verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)