### PR TITLE
feat(ci): adopt kotlinx-binary-compatibility-validator

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -78,6 +78,14 @@ jobs:
       - name: Android sample unit tests
         run: ./gradlew :samples:android:testDebugUnitTest
 
+      # Track public API surface for :runtime, :models, :oauth via the
+      # kotlinx-binary-compatibility-validator plugin. Fails if any
+      # change to public symbols isn't accompanied by an updated
+      # <module>/api/<module>.api dump (for example, `runtime/api/runtime.api`;
+      # regenerate with `./gradlew apiDump`).
+      - name: Public API surface check
+        run: ./gradlew apiCheck
+
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,17 @@ repos:
       - id: check-merge-conflict
       - id: check-added-large-files
         args: ["--maxkb=500"]
+        # api/*.api dumps from kotlinx-binary-compatibility-validator scale
+        # with the published API surface. :models in particular tracks every
+        # generated lexicon type, so its dump is intentionally large (~900 KB).
+        exclude: '^[^/]+/api/.*\.api$'
       - id: end-of-file-fixer
+        # apiDump from kotlinx-binary-compatibility-validator emits one
+        # trailing blank line after the final closing brace. This hook
+        # collapses that to a single newline, after which the next
+        # apiCheck regenerates the blank and fails — so .api files have
+        # to opt out of the normalization.
+        exclude: '^[^/]+/api/.*\.api$'
       - id: trailing-whitespace
       - id: mixed-line-ending
         args: ["--fix=lf"]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,6 +98,32 @@ before committing. No wildcard imports. No max line length. Compose
 `@Composable` function naming is disabled (lowercase-friendly helper names
 are fine).
 
+## Public API surface
+
+The `:runtime`, `:models`, and `:oauth` modules track every public symbol
+via [kotlinx-binary-compatibility-validator](https://github.com/Kotlin/binary-compatibility-validator).
+Each module owns its dump under `<module>/api/<module>.api` (for example,
+`runtime/api/runtime.api`, `models/api/models.api`, `oauth/api/oauth.api`)
+and these text files are under version control; CI runs `./gradlew apiCheck`
+and fails on any unexpected diff.
+
+If your change intentionally adds, removes, or modifies a public symbol,
+regenerate the dumps and commit them alongside the code:
+
+```bash
+./gradlew apiDump
+git add runtime/api oauth/api models/api
+```
+
+The diff in `api/*.api` becomes a clear review signal — reviewers can
+see exactly what entered or left the public surface without spelunking
+through the source.
+
+`:compose` and `:compose-material3` aren't tracked yet (Android library
+modules need explicit per-module wiring; tracked separately). `:generator`
+and `:samples:android` are intentionally excluded — neither is consumed
+externally, so their public surface is internal.
+
 ## Lexicon updates
 
 Upstream AT Protocol lexicons are bumped automatically. A scheduled

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,6 +11,27 @@ plugins {
     alias(libs.plugins.vanniktech.maven.publish) apply false
     alias(libs.plugins.ksp) apply false
     alias(libs.plugins.hilt) apply false
+    alias(libs.plugins.binary.compatibility.validator)
+}
+
+// kotlinx binary-compatibility-validator dumps each published module's
+// public API to api/<module>.api text files. CI runs `apiCheck` (wired
+// into the `check` lifecycle) and fails on any unexpected diff. To
+// intentionally change public API, run `./gradlew apiDump` and commit
+// the regenerated api/*.api files alongside the code change.
+//
+// :generator and :samples:android are excluded — neither is consumed
+// by downstream code, so their public surface is internal.
+//
+// klib validation is disabled because iOS targets are conditionally
+// declared only on macOS hosts (see runtime/build.gradle.kts) and
+// Linux CI publishes JVM-only. When iOS publishing lands, flip this
+// flag to validate iOS klibs alongside JVM.
+apiValidation {
+    ignoredProjects += listOf("generator", "android")
+    klib {
+        enabled = false
+    }
 }
 
 dependencies {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,7 @@ spotless = "8.4.0"
 ktlint = "1.4.1"
 dokka = "2.2.0"
 vanniktech-maven-publish = "0.36.0"
+binary-compatibility-validator = "0.18.0"
 
 # Android sample
 agp = "9.2.1"
@@ -72,3 +73,4 @@ vanniktech-maven-publish = { id = "com.vanniktech.maven.publish", version.ref = 
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
+binary-compatibility-validator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version.ref = "binary-compatibility-validator" }

--- a/models/api/models.api
+++ b/models/api/models.api
@@ -1,0 +1,11254 @@
+public final class io/github/kikin81/atproto/app/bsky/actor/ActorService {
+	public fun <init> (Lio/github/kikin81/atproto/runtime/XrpcClient;)V
+	public final fun getPreferences (Lio/github/kikin81/atproto/app/bsky/actor/GetPreferencesRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getPreferences$default (Lio/github/kikin81/atproto/app/bsky/actor/ActorService;Lio/github/kikin81/atproto/app/bsky/actor/GetPreferencesRequest;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getProfile (Lio/github/kikin81/atproto/app/bsky/actor/GetProfileRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getProfiles (Lio/github/kikin81/atproto/app/bsky/actor/GetProfilesRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getSuggestions (Lio/github/kikin81/atproto/app/bsky/actor/GetSuggestionsRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getSuggestions$default (Lio/github/kikin81/atproto/app/bsky/actor/ActorService;Lio/github/kikin81/atproto/app/bsky/actor/GetSuggestionsRequest;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun putPreferences (Lio/github/kikin81/atproto/app/bsky/actor/PutPreferencesRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun searchActors (Lio/github/kikin81/atproto/app/bsky/actor/SearchActorsRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun searchActors$default (Lio/github/kikin81/atproto/app/bsky/actor/ActorService;Lio/github/kikin81/atproto/app/bsky/actor/SearchActorsRequest;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun searchActorsTypeahead (Lio/github/kikin81/atproto/app/bsky/actor/SearchActorsTypeaheadRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun searchActorsTypeahead$default (Lio/github/kikin81/atproto/app/bsky/actor/ActorService;Lio/github/kikin81/atproto/app/bsky/actor/SearchActorsTypeaheadRequest;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/ActorServiceKt {
+	public static final fun searchActorsFlow (Lio/github/kikin81/atproto/app/bsky/actor/ActorService;Lio/github/kikin81/atproto/app/bsky/actor/SearchActorsRequest;)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun searchActorsFlow$default (Lio/github/kikin81/atproto/app/bsky/actor/ActorService;Lio/github/kikin81/atproto/app/bsky/actor/SearchActorsRequest;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun searchActorsPageFlow (Lio/github/kikin81/atproto/app/bsky/actor/ActorService;Lio/github/kikin81/atproto/app/bsky/actor/SearchActorsRequest;)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun searchActorsPageFlow$default (Lio/github/kikin81/atproto/app/bsky/actor/ActorService;Lio/github/kikin81/atproto/app/bsky/actor/SearchActorsRequest;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun suggestionsFlow (Lio/github/kikin81/atproto/app/bsky/actor/ActorService;Lio/github/kikin81/atproto/app/bsky/actor/GetSuggestionsRequest;)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun suggestionsFlow$default (Lio/github/kikin81/atproto/app/bsky/actor/ActorService;Lio/github/kikin81/atproto/app/bsky/actor/GetSuggestionsRequest;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun suggestionsPageFlow (Lio/github/kikin81/atproto/app/bsky/actor/ActorService;Lio/github/kikin81/atproto/app/bsky/actor/GetSuggestionsRequest;)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun suggestionsPageFlow$default (Lio/github/kikin81/atproto/app/bsky/actor/ActorService;Lio/github/kikin81/atproto/app/bsky/actor/GetSuggestionsRequest;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/AdultContentPref {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/actor/AdultContentPref$Companion;
+	public fun <init> (Z)V
+	public final fun component1 ()Z
+	public final fun copy (Z)Lio/github/kikin81/atproto/app/bsky/actor/AdultContentPref;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/actor/AdultContentPref;ZILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/actor/AdultContentPref;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEnabled ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/actor/AdultContentPref$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/actor/AdultContentPref$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/actor/AdultContentPref;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/actor/AdultContentPref;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/AdultContentPref$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/BskyAppProgressGuide {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/actor/BskyAppProgressGuide$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/actor/BskyAppProgressGuide;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/actor/BskyAppProgressGuide;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/actor/BskyAppProgressGuide;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getGuide ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/actor/BskyAppProgressGuide$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/actor/BskyAppProgressGuide$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/actor/BskyAppProgressGuide;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/actor/BskyAppProgressGuide;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/BskyAppProgressGuide$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/BskyAppStatePref {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/actor/BskyAppStatePref$Companion;
+	public fun <init> ()V
+	public fun <init> (Lio/github/kikin81/atproto/app/bsky/actor/BskyAppProgressGuide;Ljava/util/List;Ljava/util/List;)V
+	public synthetic fun <init> (Lio/github/kikin81/atproto/app/bsky/actor/BskyAppProgressGuide;Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/app/bsky/actor/BskyAppProgressGuide;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/util/List;
+	public final fun copy (Lio/github/kikin81/atproto/app/bsky/actor/BskyAppProgressGuide;Ljava/util/List;Ljava/util/List;)Lio/github/kikin81/atproto/app/bsky/actor/BskyAppStatePref;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/actor/BskyAppStatePref;Lio/github/kikin81/atproto/app/bsky/actor/BskyAppProgressGuide;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/actor/BskyAppStatePref;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActiveProgressGuide ()Lio/github/kikin81/atproto/app/bsky/actor/BskyAppProgressGuide;
+	public final fun getNuxs ()Ljava/util/List;
+	public final fun getQueuedNudges ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/actor/BskyAppStatePref$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/actor/BskyAppStatePref$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/actor/BskyAppStatePref;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/actor/BskyAppStatePref;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/BskyAppStatePref$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/ContentLabelPref {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/actor/ContentLabelPref$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2-4riKzFA ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy-kXxhK74 (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/actor/ContentLabelPref;
+	public static synthetic fun copy-kXxhK74$default (Lio/github/kikin81/atproto/app/bsky/actor/ContentLabelPref;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/actor/ContentLabelPref;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getLabel ()Ljava/lang/String;
+	public final fun getLabelerDid-4riKzFA ()Ljava/lang/String;
+	public final fun getVisibility ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/actor/ContentLabelPref$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/actor/ContentLabelPref$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/actor/ContentLabelPref;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/actor/ContentLabelPref;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/ContentLabelPref$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/DeclaredAgePref {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/actor/DeclaredAgePref$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;)V
+	public synthetic fun <init> (Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Boolean;
+	public final fun component2 ()Ljava/lang/Boolean;
+	public final fun component3 ()Ljava/lang/Boolean;
+	public final fun copy (Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;)Lio/github/kikin81/atproto/app/bsky/actor/DeclaredAgePref;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/actor/DeclaredAgePref;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/actor/DeclaredAgePref;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public final fun isOverAge13 ()Ljava/lang/Boolean;
+	public final fun isOverAge16 ()Ljava/lang/Boolean;
+	public final fun isOverAge18 ()Ljava/lang/Boolean;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/actor/DeclaredAgePref$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/actor/DeclaredAgePref$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/actor/DeclaredAgePref;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/actor/DeclaredAgePref;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/DeclaredAgePref$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/FeedViewPref {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/actor/FeedViewPref$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/lang/Boolean;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/Boolean;
+	public final fun component3 ()Ljava/lang/Boolean;
+	public final fun component4 ()Ljava/lang/Long;
+	public final fun component5 ()Ljava/lang/Boolean;
+	public final fun component6 ()Ljava/lang/Boolean;
+	public final fun copy (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/lang/Boolean;)Lio/github/kikin81/atproto/app/bsky/actor/FeedViewPref;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/actor/FeedViewPref;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/lang/Boolean;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/actor/FeedViewPref;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFeed ()Ljava/lang/String;
+	public final fun getHideQuotePosts ()Ljava/lang/Boolean;
+	public final fun getHideReplies ()Ljava/lang/Boolean;
+	public final fun getHideRepliesByLikeCount ()Ljava/lang/Long;
+	public final fun getHideRepliesByUnfollowed ()Ljava/lang/Boolean;
+	public final fun getHideReposts ()Ljava/lang/Boolean;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/actor/FeedViewPref$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/actor/FeedViewPref$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/actor/FeedViewPref;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/actor/FeedViewPref;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/FeedViewPref$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/GetPreferencesRequest {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/actor/GetPreferencesRequest$Companion;
+	public fun <init> ()V
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/actor/GetPreferencesRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/actor/GetPreferencesRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/actor/GetPreferencesRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/actor/GetPreferencesRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/GetPreferencesRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/GetPreferencesResponse {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/actor/GetPreferencesResponse$Companion;
+	public fun <init> (Lkotlinx/serialization/json/JsonObject;)V
+	public final fun component1 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy (Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/app/bsky/actor/GetPreferencesResponse;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/actor/GetPreferencesResponse;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/actor/GetPreferencesResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPreferences ()Lkotlinx/serialization/json/JsonObject;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/actor/GetPreferencesResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/actor/GetPreferencesResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/actor/GetPreferencesResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/actor/GetPreferencesResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/GetPreferencesResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/GetProfileRequest {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/actor/GetProfileRequest$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-mlEIfv0 ()Ljava/lang/String;
+	public final fun copy-6PA111I (Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/actor/GetProfileRequest;
+	public static synthetic fun copy-6PA111I$default (Lio/github/kikin81/atproto/app/bsky/actor/GetProfileRequest;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/actor/GetProfileRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActor-mlEIfv0 ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/actor/GetProfileRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/actor/GetProfileRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/actor/GetProfileRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/actor/GetProfileRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/GetProfileRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/GetProfilesRequest {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/actor/GetProfilesRequest$Companion;
+	public fun <init> (Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lio/github/kikin81/atproto/app/bsky/actor/GetProfilesRequest;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/actor/GetProfilesRequest;Ljava/util/List;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/actor/GetProfilesRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActors ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/actor/GetProfilesRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/actor/GetProfilesRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/actor/GetProfilesRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/actor/GetProfilesRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/GetProfilesRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/GetProfilesResponse {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/actor/GetProfilesResponse$Companion;
+	public fun <init> (Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lio/github/kikin81/atproto/app/bsky/actor/GetProfilesResponse;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/actor/GetProfilesResponse;Ljava/util/List;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/actor/GetProfilesResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getProfiles ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/actor/GetProfilesResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/actor/GetProfilesResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/actor/GetProfilesResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/actor/GetProfilesResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/GetProfilesResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/GetSuggestionsRequest {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/actor/GetSuggestionsRequest$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Long;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Long;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/Long;
+	public final fun copy (Ljava/lang/String;Ljava/lang/Long;)Lio/github/kikin81/atproto/app/bsky/actor/GetSuggestionsRequest;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/actor/GetSuggestionsRequest;Ljava/lang/String;Ljava/lang/Long;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/actor/GetSuggestionsRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCursor ()Ljava/lang/String;
+	public final fun getLimit ()Ljava/lang/Long;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/actor/GetSuggestionsRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/actor/GetSuggestionsRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/actor/GetSuggestionsRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/actor/GetSuggestionsRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/GetSuggestionsRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/GetSuggestionsResponse {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/actor/GetSuggestionsResponse$Companion;
+	public fun <init> (Ljava/util/List;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/Long;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/util/List;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/actor/GetSuggestionsResponse;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/actor/GetSuggestionsResponse;Ljava/util/List;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/actor/GetSuggestionsResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActors ()Ljava/util/List;
+	public final fun getCursor ()Ljava/lang/String;
+	public final fun getRecId ()Ljava/lang/Long;
+	public final fun getRecIdStr ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/actor/GetSuggestionsResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/actor/GetSuggestionsResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/actor/GetSuggestionsResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/actor/GetSuggestionsResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/GetSuggestionsResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/HiddenPostsPref {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/actor/HiddenPostsPref$Companion;
+	public fun <init> (Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lio/github/kikin81/atproto/app/bsky/actor/HiddenPostsPref;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/actor/HiddenPostsPref;Ljava/util/List;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/actor/HiddenPostsPref;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getItems ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/actor/HiddenPostsPref$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/actor/HiddenPostsPref$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/actor/HiddenPostsPref;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/actor/HiddenPostsPref;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/HiddenPostsPref$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/InterestsPref {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/actor/InterestsPref$Companion;
+	public fun <init> (Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lio/github/kikin81/atproto/app/bsky/actor/InterestsPref;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/actor/InterestsPref;Ljava/util/List;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/actor/InterestsPref;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getTags ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/actor/InterestsPref$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/actor/InterestsPref$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/actor/InterestsPref;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/actor/InterestsPref;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/InterestsPref$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/KnownFollowers {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/actor/KnownFollowers$Companion;
+	public fun <init> (JLjava/util/List;)V
+	public final fun component1 ()J
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (JLjava/util/List;)Lio/github/kikin81/atproto/app/bsky/actor/KnownFollowers;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/actor/KnownFollowers;JLjava/util/List;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/actor/KnownFollowers;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCount ()J
+	public final fun getFollowers ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/actor/KnownFollowers$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/actor/KnownFollowers$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/actor/KnownFollowers;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/actor/KnownFollowers;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/KnownFollowers$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/LabelerPrefItem {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/actor/LabelerPrefItem$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-UyB9Nic ()Ljava/lang/String;
+	public final fun copy-OoJ1cAE (Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/actor/LabelerPrefItem;
+	public static synthetic fun copy-OoJ1cAE$default (Lio/github/kikin81/atproto/app/bsky/actor/LabelerPrefItem;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/actor/LabelerPrefItem;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDid-UyB9Nic ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/actor/LabelerPrefItem$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/actor/LabelerPrefItem$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/actor/LabelerPrefItem;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/actor/LabelerPrefItem;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/LabelerPrefItem$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/LabelersPref {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/actor/LabelersPref$Companion;
+	public fun <init> (Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lio/github/kikin81/atproto/app/bsky/actor/LabelersPref;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/actor/LabelersPref;Ljava/util/List;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/actor/LabelersPref;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getLabelers ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/actor/LabelersPref$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/actor/LabelersPref$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/actor/LabelersPref;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/actor/LabelersPref;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/LabelersPref$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/LiveEventPreferences {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/actor/LiveEventPreferences$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;Ljava/lang/Boolean;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/lang/Boolean;
+	public final fun copy (Ljava/util/List;Ljava/lang/Boolean;)Lio/github/kikin81/atproto/app/bsky/actor/LiveEventPreferences;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/actor/LiveEventPreferences;Ljava/util/List;Ljava/lang/Boolean;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/actor/LiveEventPreferences;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getHiddenFeedIds ()Ljava/util/List;
+	public final fun getHideAllFeeds ()Ljava/lang/Boolean;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/actor/LiveEventPreferences$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/actor/LiveEventPreferences$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/actor/LiveEventPreferences;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/actor/LiveEventPreferences;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/LiveEventPreferences$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/MutedWord {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/actor/MutedWord$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2-G5DCnlA ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy-ckG_V5M (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/actor/MutedWord;
+	public static synthetic fun copy-ckG_V5M$default (Lio/github/kikin81/atproto/app/bsky/actor/MutedWord;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/actor/MutedWord;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActorTarget ()Ljava/lang/String;
+	public final fun getExpiresAt-G5DCnlA ()Ljava/lang/String;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getTargets ()Ljava/util/List;
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/actor/MutedWord$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/actor/MutedWord$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/actor/MutedWord;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/actor/MutedWord;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/MutedWord$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/MutedWordsPref {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/actor/MutedWordsPref$Companion;
+	public fun <init> (Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lio/github/kikin81/atproto/app/bsky/actor/MutedWordsPref;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/actor/MutedWordsPref;Ljava/util/List;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/actor/MutedWordsPref;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getItems ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/actor/MutedWordsPref$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/actor/MutedWordsPref$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/actor/MutedWordsPref;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/actor/MutedWordsPref;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/MutedWordsPref$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/Nux {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/actor/Nux$Companion;
+	public synthetic fun <init> (ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3-G5DCnlA ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy-_xG5BKc (ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/actor/Nux;
+	public static synthetic fun copy-_xG5BKc$default (Lio/github/kikin81/atproto/app/bsky/actor/Nux;ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/actor/Nux;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCompleted ()Z
+	public final fun getData ()Ljava/lang/String;
+	public final fun getExpiresAt-G5DCnlA ()Ljava/lang/String;
+	public final fun getId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/actor/Nux$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/actor/Nux$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/actor/Nux;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/actor/Nux;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/Nux$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/PersonalDetailsPref {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/actor/PersonalDetailsPref$Companion;
+	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-G5DCnlA ()Ljava/lang/String;
+	public final fun copy-hp3wcX0 (Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/actor/PersonalDetailsPref;
+	public static synthetic fun copy-hp3wcX0$default (Lio/github/kikin81/atproto/app/bsky/actor/PersonalDetailsPref;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/actor/PersonalDetailsPref;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBirthDate-G5DCnlA ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/actor/PersonalDetailsPref$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/actor/PersonalDetailsPref$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/actor/PersonalDetailsPref;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/actor/PersonalDetailsPref;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/PersonalDetailsPref$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/PostInteractionSettingsPref {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/actor/PostInteractionSettingsPref$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;Ljava/util/List;)Lio/github/kikin81/atproto/app/bsky/actor/PostInteractionSettingsPref;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/actor/PostInteractionSettingsPref;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/actor/PostInteractionSettingsPref;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPostgateEmbeddingRules ()Ljava/util/List;
+	public final fun getThreadgateAllowRules ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/actor/PostInteractionSettingsPref$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/actor/PostInteractionSettingsPref$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/actor/PostInteractionSettingsPref;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/actor/PostInteractionSettingsPref;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/PostInteractionSettingsPref$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class io/github/kikin81/atproto/app/bsky/actor/PostInteractionSettingsPrefPostgateEmbeddingRulesUnion : io/github/kikin81/atproto/runtime/OpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/actor/PostInteractionSettingsPrefPostgateEmbeddingRulesUnion$Companion;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/PostInteractionSettingsPrefPostgateEmbeddingRulesUnion$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/PostInteractionSettingsPrefPostgateEmbeddingRulesUnion$Unknown : io/github/kikin81/atproto/app/bsky/actor/PostInteractionSettingsPrefPostgateEmbeddingRulesUnion, io/github/kikin81/atproto/runtime/UnknownOpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/actor/PostInteractionSettingsPrefPostgateEmbeddingRulesUnion$Unknown$Companion;
+	public fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/app/bsky/actor/PostInteractionSettingsPrefPostgateEmbeddingRulesUnion$Unknown;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/actor/PostInteractionSettingsPrefPostgateEmbeddingRulesUnion$Unknown;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/actor/PostInteractionSettingsPrefPostgateEmbeddingRulesUnion$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getRaw ()Lkotlinx/serialization/json/JsonObject;
+	public fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/PostInteractionSettingsPrefPostgateEmbeddingRulesUnion$Unknown$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/PostInteractionSettingsPrefPostgateEmbeddingRulesUnionSerializer : io/github/kikin81/atproto/runtime/OpenUnionSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/actor/PostInteractionSettingsPrefPostgateEmbeddingRulesUnionSerializer;
+	public fun selectKnownDeserializer (Ljava/lang/String;)Lkotlinx/serialization/KSerializer;
+	public fun selectKnownSerializer (Lio/github/kikin81/atproto/app/bsky/actor/PostInteractionSettingsPrefPostgateEmbeddingRulesUnion;)Lkotlinx/serialization/KSerializer;
+	public synthetic fun selectKnownSerializer (Lio/github/kikin81/atproto/runtime/OpenUnionMember;)Lkotlinx/serialization/KSerializer;
+	public fun unknownSerializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/PostInteractionSettingsPrefPostgateEmbeddingRulesUnionUnknownSerializer : io/github/kikin81/atproto/runtime/UnknownMemberSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/actor/PostInteractionSettingsPrefPostgateEmbeddingRulesUnionUnknownSerializer;
+	public fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/app/bsky/actor/PostInteractionSettingsPrefPostgateEmbeddingRulesUnion$Unknown;
+	public synthetic fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/runtime/UnknownOpenUnionMember;
+}
+
+public abstract interface class io/github/kikin81/atproto/app/bsky/actor/PostInteractionSettingsPrefThreadgateAllowRulesUnion : io/github/kikin81/atproto/runtime/OpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/actor/PostInteractionSettingsPrefThreadgateAllowRulesUnion$Companion;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/PostInteractionSettingsPrefThreadgateAllowRulesUnion$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/PostInteractionSettingsPrefThreadgateAllowRulesUnion$Unknown : io/github/kikin81/atproto/app/bsky/actor/PostInteractionSettingsPrefThreadgateAllowRulesUnion, io/github/kikin81/atproto/runtime/UnknownOpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/actor/PostInteractionSettingsPrefThreadgateAllowRulesUnion$Unknown$Companion;
+	public fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/app/bsky/actor/PostInteractionSettingsPrefThreadgateAllowRulesUnion$Unknown;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/actor/PostInteractionSettingsPrefThreadgateAllowRulesUnion$Unknown;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/actor/PostInteractionSettingsPrefThreadgateAllowRulesUnion$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getRaw ()Lkotlinx/serialization/json/JsonObject;
+	public fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/PostInteractionSettingsPrefThreadgateAllowRulesUnion$Unknown$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/PostInteractionSettingsPrefThreadgateAllowRulesUnionSerializer : io/github/kikin81/atproto/runtime/OpenUnionSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/actor/PostInteractionSettingsPrefThreadgateAllowRulesUnionSerializer;
+	public fun selectKnownDeserializer (Ljava/lang/String;)Lkotlinx/serialization/KSerializer;
+	public fun selectKnownSerializer (Lio/github/kikin81/atproto/app/bsky/actor/PostInteractionSettingsPrefThreadgateAllowRulesUnion;)Lkotlinx/serialization/KSerializer;
+	public synthetic fun selectKnownSerializer (Lio/github/kikin81/atproto/runtime/OpenUnionMember;)Lkotlinx/serialization/KSerializer;
+	public fun unknownSerializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/PostInteractionSettingsPrefThreadgateAllowRulesUnionUnknownSerializer : io/github/kikin81/atproto/runtime/UnknownMemberSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/actor/PostInteractionSettingsPrefThreadgateAllowRulesUnionUnknownSerializer;
+	public fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/app/bsky/actor/PostInteractionSettingsPrefThreadgateAllowRulesUnion$Unknown;
+	public synthetic fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/runtime/UnknownOpenUnionMember;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/Profile {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/actor/Profile$Companion;
+	public fun <init> ()V
+	public fun <init> (Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;)V
+	public synthetic fun <init> (Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun component10 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun component2 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun component3 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun component4 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun component5 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun component6 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun component7 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun component8 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun component9 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun copy (Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;)Lio/github/kikin81/atproto/app/bsky/actor/Profile;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/actor/Profile;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/actor/Profile;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAvatar ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun getBanner ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun getCreatedAt ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun getDescription ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun getDisplayName ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun getJoinedViaStarterPack ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun getLabels ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun getPinnedPost ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun getPronouns ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun getWebsite ()Lio/github/kikin81/atproto/runtime/AtField;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/actor/Profile$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/actor/Profile$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/actor/Profile;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/actor/Profile;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/Profile$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/ProfileAssociated {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/actor/ProfileAssociated$Companion;
+	public fun <init> ()V
+	public fun <init> (Lio/github/kikin81/atproto/app/bsky/actor/ProfileAssociatedActivitySubscription;Lio/github/kikin81/atproto/app/bsky/actor/ProfileAssociatedChat;Ljava/lang/Long;Lio/github/kikin81/atproto/app/bsky/actor/ProfileAssociatedGerm;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Long;)V
+	public synthetic fun <init> (Lio/github/kikin81/atproto/app/bsky/actor/ProfileAssociatedActivitySubscription;Lio/github/kikin81/atproto/app/bsky/actor/ProfileAssociatedChat;Ljava/lang/Long;Lio/github/kikin81/atproto/app/bsky/actor/ProfileAssociatedGerm;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Long;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/app/bsky/actor/ProfileAssociatedActivitySubscription;
+	public final fun component2 ()Lio/github/kikin81/atproto/app/bsky/actor/ProfileAssociatedChat;
+	public final fun component3 ()Ljava/lang/Long;
+	public final fun component4 ()Lio/github/kikin81/atproto/app/bsky/actor/ProfileAssociatedGerm;
+	public final fun component5 ()Ljava/lang/Boolean;
+	public final fun component6 ()Ljava/lang/Long;
+	public final fun component7 ()Ljava/lang/Long;
+	public final fun copy (Lio/github/kikin81/atproto/app/bsky/actor/ProfileAssociatedActivitySubscription;Lio/github/kikin81/atproto/app/bsky/actor/ProfileAssociatedChat;Ljava/lang/Long;Lio/github/kikin81/atproto/app/bsky/actor/ProfileAssociatedGerm;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Long;)Lio/github/kikin81/atproto/app/bsky/actor/ProfileAssociated;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/actor/ProfileAssociated;Lio/github/kikin81/atproto/app/bsky/actor/ProfileAssociatedActivitySubscription;Lio/github/kikin81/atproto/app/bsky/actor/ProfileAssociatedChat;Ljava/lang/Long;Lio/github/kikin81/atproto/app/bsky/actor/ProfileAssociatedGerm;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Long;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/actor/ProfileAssociated;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActivitySubscription ()Lio/github/kikin81/atproto/app/bsky/actor/ProfileAssociatedActivitySubscription;
+	public final fun getChat ()Lio/github/kikin81/atproto/app/bsky/actor/ProfileAssociatedChat;
+	public final fun getFeedgens ()Ljava/lang/Long;
+	public final fun getGerm ()Lio/github/kikin81/atproto/app/bsky/actor/ProfileAssociatedGerm;
+	public final fun getLabeler ()Ljava/lang/Boolean;
+	public final fun getLists ()Ljava/lang/Long;
+	public final fun getStarterPacks ()Ljava/lang/Long;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/actor/ProfileAssociated$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/actor/ProfileAssociated$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/actor/ProfileAssociated;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/actor/ProfileAssociated;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/ProfileAssociated$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/ProfileAssociatedActivitySubscription {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/actor/ProfileAssociatedActivitySubscription$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/actor/ProfileAssociatedActivitySubscription;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/actor/ProfileAssociatedActivitySubscription;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/actor/ProfileAssociatedActivitySubscription;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAllowSubscriptions ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/actor/ProfileAssociatedActivitySubscription$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/actor/ProfileAssociatedActivitySubscription$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/actor/ProfileAssociatedActivitySubscription;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/actor/ProfileAssociatedActivitySubscription;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/ProfileAssociatedActivitySubscription$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/ProfileAssociatedChat {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/actor/ProfileAssociatedChat$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/actor/ProfileAssociatedChat;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/actor/ProfileAssociatedChat;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/actor/ProfileAssociatedChat;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAllowIncoming ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/actor/ProfileAssociatedChat$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/actor/ProfileAssociatedChat$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/actor/ProfileAssociatedChat;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/actor/ProfileAssociatedChat;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/ProfileAssociatedChat$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/ProfileAssociatedGerm {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/actor/ProfileAssociatedGerm$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-jMNtXP8 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy-VG3K5EY (Ljava/lang/String;Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/actor/ProfileAssociatedGerm;
+	public static synthetic fun copy-VG3K5EY$default (Lio/github/kikin81/atproto/app/bsky/actor/ProfileAssociatedGerm;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/actor/ProfileAssociatedGerm;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMessageMeUrl-jMNtXP8 ()Ljava/lang/String;
+	public final fun getShowButtonTo ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/actor/ProfileAssociatedGerm$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/actor/ProfileAssociatedGerm$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/actor/ProfileAssociatedGerm;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/actor/ProfileAssociatedGerm;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/ProfileAssociatedGerm$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class io/github/kikin81/atproto/app/bsky/actor/ProfileLabelsUnion : io/github/kikin81/atproto/runtime/OpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/actor/ProfileLabelsUnion$Companion;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/ProfileLabelsUnion$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/ProfileLabelsUnion$Unknown : io/github/kikin81/atproto/app/bsky/actor/ProfileLabelsUnion, io/github/kikin81/atproto/runtime/UnknownOpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/actor/ProfileLabelsUnion$Unknown$Companion;
+	public fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/app/bsky/actor/ProfileLabelsUnion$Unknown;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/actor/ProfileLabelsUnion$Unknown;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/actor/ProfileLabelsUnion$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getRaw ()Lkotlinx/serialization/json/JsonObject;
+	public fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/ProfileLabelsUnion$Unknown$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/ProfileLabelsUnionSerializer : io/github/kikin81/atproto/runtime/OpenUnionSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/actor/ProfileLabelsUnionSerializer;
+	public fun selectKnownDeserializer (Ljava/lang/String;)Lkotlinx/serialization/KSerializer;
+	public fun selectKnownSerializer (Lio/github/kikin81/atproto/app/bsky/actor/ProfileLabelsUnion;)Lkotlinx/serialization/KSerializer;
+	public synthetic fun selectKnownSerializer (Lio/github/kikin81/atproto/runtime/OpenUnionMember;)Lkotlinx/serialization/KSerializer;
+	public fun unknownSerializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/ProfileLabelsUnionUnknownSerializer : io/github/kikin81/atproto/runtime/UnknownMemberSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/actor/ProfileLabelsUnionUnknownSerializer;
+	public fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/app/bsky/actor/ProfileLabelsUnion$Unknown;
+	public synthetic fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/runtime/UnknownOpenUnionMember;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/ProfileView {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/actor/ProfileView$Companion;
+	public synthetic fun <init> (Lio/github/kikin81/atproto/app/bsky/actor/ProfileAssociated;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/actor/StatusView;Lio/github/kikin81/atproto/app/bsky/actor/VerificationState;Lio/github/kikin81/atproto/app/bsky/actor/ViewerState;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lio/github/kikin81/atproto/app/bsky/actor/ProfileAssociated;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/actor/StatusView;Lio/github/kikin81/atproto/app/bsky/actor/VerificationState;Lio/github/kikin81/atproto/app/bsky/actor/ViewerState;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/app/bsky/actor/ProfileAssociated;
+	public final fun component10 ()Ljava/util/List;
+	public final fun component11 ()Ljava/lang/String;
+	public final fun component12 ()Lio/github/kikin81/atproto/app/bsky/actor/StatusView;
+	public final fun component13 ()Lio/github/kikin81/atproto/app/bsky/actor/VerificationState;
+	public final fun component14 ()Lio/github/kikin81/atproto/app/bsky/actor/ViewerState;
+	public final fun component2-Eo6btPk ()Ljava/lang/String;
+	public final fun component3-G5DCnlA ()Ljava/lang/String;
+	public final fun component4 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6-UyB9Nic ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8-3bGGrYM ()Ljava/lang/String;
+	public final fun component9-G5DCnlA ()Ljava/lang/String;
+	public final fun copy-B1KgFHg (Lio/github/kikin81/atproto/app/bsky/actor/ProfileAssociated;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/actor/StatusView;Lio/github/kikin81/atproto/app/bsky/actor/VerificationState;Lio/github/kikin81/atproto/app/bsky/actor/ViewerState;)Lio/github/kikin81/atproto/app/bsky/actor/ProfileView;
+	public static synthetic fun copy-B1KgFHg$default (Lio/github/kikin81/atproto/app/bsky/actor/ProfileView;Lio/github/kikin81/atproto/app/bsky/actor/ProfileAssociated;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/actor/StatusView;Lio/github/kikin81/atproto/app/bsky/actor/VerificationState;Lio/github/kikin81/atproto/app/bsky/actor/ViewerState;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/actor/ProfileView;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAssociated ()Lio/github/kikin81/atproto/app/bsky/actor/ProfileAssociated;
+	public final fun getAvatar-Eo6btPk ()Ljava/lang/String;
+	public final fun getCreatedAt-G5DCnlA ()Ljava/lang/String;
+	public final fun getDebug ()Lkotlinx/serialization/json/JsonObject;
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getDid-UyB9Nic ()Ljava/lang/String;
+	public final fun getDisplayName ()Ljava/lang/String;
+	public final fun getHandle-3bGGrYM ()Ljava/lang/String;
+	public final fun getIndexedAt-G5DCnlA ()Ljava/lang/String;
+	public final fun getLabels ()Ljava/util/List;
+	public final fun getPronouns ()Ljava/lang/String;
+	public final fun getStatus ()Lio/github/kikin81/atproto/app/bsky/actor/StatusView;
+	public final fun getVerification ()Lio/github/kikin81/atproto/app/bsky/actor/VerificationState;
+	public final fun getViewer ()Lio/github/kikin81/atproto/app/bsky/actor/ViewerState;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/actor/ProfileView$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/actor/ProfileView$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/actor/ProfileView;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/actor/ProfileView;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/ProfileView$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/ProfileViewBasic {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/actor/ProfileViewBasic$Companion;
+	public synthetic fun <init> (Lio/github/kikin81/atproto/app/bsky/actor/ProfileAssociated;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/actor/StatusView;Lio/github/kikin81/atproto/app/bsky/actor/VerificationState;Lio/github/kikin81/atproto/app/bsky/actor/ViewerState;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lio/github/kikin81/atproto/app/bsky/actor/ProfileAssociated;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/actor/StatusView;Lio/github/kikin81/atproto/app/bsky/actor/VerificationState;Lio/github/kikin81/atproto/app/bsky/actor/ViewerState;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/app/bsky/actor/ProfileAssociated;
+	public final fun component10 ()Lio/github/kikin81/atproto/app/bsky/actor/StatusView;
+	public final fun component11 ()Lio/github/kikin81/atproto/app/bsky/actor/VerificationState;
+	public final fun component12 ()Lio/github/kikin81/atproto/app/bsky/actor/ViewerState;
+	public final fun component2-Eo6btPk ()Ljava/lang/String;
+	public final fun component3-G5DCnlA ()Ljava/lang/String;
+	public final fun component4 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun component5-UyB9Nic ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7-3bGGrYM ()Ljava/lang/String;
+	public final fun component8 ()Ljava/util/List;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy-vvWHW3I (Lio/github/kikin81/atproto/app/bsky/actor/ProfileAssociated;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/actor/StatusView;Lio/github/kikin81/atproto/app/bsky/actor/VerificationState;Lio/github/kikin81/atproto/app/bsky/actor/ViewerState;)Lio/github/kikin81/atproto/app/bsky/actor/ProfileViewBasic;
+	public static synthetic fun copy-vvWHW3I$default (Lio/github/kikin81/atproto/app/bsky/actor/ProfileViewBasic;Lio/github/kikin81/atproto/app/bsky/actor/ProfileAssociated;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/actor/StatusView;Lio/github/kikin81/atproto/app/bsky/actor/VerificationState;Lio/github/kikin81/atproto/app/bsky/actor/ViewerState;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/actor/ProfileViewBasic;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAssociated ()Lio/github/kikin81/atproto/app/bsky/actor/ProfileAssociated;
+	public final fun getAvatar-Eo6btPk ()Ljava/lang/String;
+	public final fun getCreatedAt-G5DCnlA ()Ljava/lang/String;
+	public final fun getDebug ()Lkotlinx/serialization/json/JsonObject;
+	public final fun getDid-UyB9Nic ()Ljava/lang/String;
+	public final fun getDisplayName ()Ljava/lang/String;
+	public final fun getHandle-3bGGrYM ()Ljava/lang/String;
+	public final fun getLabels ()Ljava/util/List;
+	public final fun getPronouns ()Ljava/lang/String;
+	public final fun getStatus ()Lio/github/kikin81/atproto/app/bsky/actor/StatusView;
+	public final fun getVerification ()Lio/github/kikin81/atproto/app/bsky/actor/VerificationState;
+	public final fun getViewer ()Lio/github/kikin81/atproto/app/bsky/actor/ViewerState;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/actor/ProfileViewBasic$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/actor/ProfileViewBasic$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/actor/ProfileViewBasic;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/actor/ProfileViewBasic;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/ProfileViewBasic$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/ProfileViewDetailed {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/actor/ProfileViewDetailed$Companion;
+	public synthetic fun <init> (Lio/github/kikin81/atproto/app/bsky/actor/ProfileAssociated;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/graph/StarterPackViewBasic;Ljava/util/List;Lio/github/kikin81/atproto/com/atproto/repo/StrongRef;Ljava/lang/Long;Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/actor/StatusView;Lio/github/kikin81/atproto/app/bsky/actor/VerificationState;Lio/github/kikin81/atproto/app/bsky/actor/ViewerState;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lio/github/kikin81/atproto/app/bsky/actor/ProfileAssociated;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/graph/StarterPackViewBasic;Ljava/util/List;Lio/github/kikin81/atproto/com/atproto/repo/StrongRef;Ljava/lang/Long;Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/actor/StatusView;Lio/github/kikin81/atproto/app/bsky/actor/VerificationState;Lio/github/kikin81/atproto/app/bsky/actor/ViewerState;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/app/bsky/actor/ProfileAssociated;
+	public final fun component10 ()Ljava/lang/Long;
+	public final fun component11-3bGGrYM ()Ljava/lang/String;
+	public final fun component12-G5DCnlA ()Ljava/lang/String;
+	public final fun component13 ()Lio/github/kikin81/atproto/app/bsky/graph/StarterPackViewBasic;
+	public final fun component14 ()Ljava/util/List;
+	public final fun component15 ()Lio/github/kikin81/atproto/com/atproto/repo/StrongRef;
+	public final fun component16 ()Ljava/lang/Long;
+	public final fun component17 ()Ljava/lang/String;
+	public final fun component18 ()Lio/github/kikin81/atproto/app/bsky/actor/StatusView;
+	public final fun component19 ()Lio/github/kikin81/atproto/app/bsky/actor/VerificationState;
+	public final fun component2-Eo6btPk ()Ljava/lang/String;
+	public final fun component20 ()Lio/github/kikin81/atproto/app/bsky/actor/ViewerState;
+	public final fun component21-Eo6btPk ()Ljava/lang/String;
+	public final fun component3-Eo6btPk ()Ljava/lang/String;
+	public final fun component4-G5DCnlA ()Ljava/lang/String;
+	public final fun component5 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7-UyB9Nic ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Ljava/lang/Long;
+	public final fun copy-wXbmxcE (Lio/github/kikin81/atproto/app/bsky/actor/ProfileAssociated;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/graph/StarterPackViewBasic;Ljava/util/List;Lio/github/kikin81/atproto/com/atproto/repo/StrongRef;Ljava/lang/Long;Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/actor/StatusView;Lio/github/kikin81/atproto/app/bsky/actor/VerificationState;Lio/github/kikin81/atproto/app/bsky/actor/ViewerState;Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/actor/ProfileViewDetailed;
+	public static synthetic fun copy-wXbmxcE$default (Lio/github/kikin81/atproto/app/bsky/actor/ProfileViewDetailed;Lio/github/kikin81/atproto/app/bsky/actor/ProfileAssociated;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/graph/StarterPackViewBasic;Ljava/util/List;Lio/github/kikin81/atproto/com/atproto/repo/StrongRef;Ljava/lang/Long;Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/actor/StatusView;Lio/github/kikin81/atproto/app/bsky/actor/VerificationState;Lio/github/kikin81/atproto/app/bsky/actor/ViewerState;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/actor/ProfileViewDetailed;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAssociated ()Lio/github/kikin81/atproto/app/bsky/actor/ProfileAssociated;
+	public final fun getAvatar-Eo6btPk ()Ljava/lang/String;
+	public final fun getBanner-Eo6btPk ()Ljava/lang/String;
+	public final fun getCreatedAt-G5DCnlA ()Ljava/lang/String;
+	public final fun getDebug ()Lkotlinx/serialization/json/JsonObject;
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getDid-UyB9Nic ()Ljava/lang/String;
+	public final fun getDisplayName ()Ljava/lang/String;
+	public final fun getFollowersCount ()Ljava/lang/Long;
+	public final fun getFollowsCount ()Ljava/lang/Long;
+	public final fun getHandle-3bGGrYM ()Ljava/lang/String;
+	public final fun getIndexedAt-G5DCnlA ()Ljava/lang/String;
+	public final fun getJoinedViaStarterPack ()Lio/github/kikin81/atproto/app/bsky/graph/StarterPackViewBasic;
+	public final fun getLabels ()Ljava/util/List;
+	public final fun getPinnedPost ()Lio/github/kikin81/atproto/com/atproto/repo/StrongRef;
+	public final fun getPostsCount ()Ljava/lang/Long;
+	public final fun getPronouns ()Ljava/lang/String;
+	public final fun getStatus ()Lio/github/kikin81/atproto/app/bsky/actor/StatusView;
+	public final fun getVerification ()Lio/github/kikin81/atproto/app/bsky/actor/VerificationState;
+	public final fun getViewer ()Lio/github/kikin81/atproto/app/bsky/actor/ViewerState;
+	public final fun getWebsite-Eo6btPk ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/actor/ProfileViewDetailed$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/actor/ProfileViewDetailed$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/actor/ProfileViewDetailed;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/actor/ProfileViewDetailed;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/ProfileViewDetailed$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/PutPreferencesRequest {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/actor/PutPreferencesRequest$Companion;
+	public fun <init> (Lkotlinx/serialization/json/JsonObject;)V
+	public final fun component1 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy (Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/app/bsky/actor/PutPreferencesRequest;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/actor/PutPreferencesRequest;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/actor/PutPreferencesRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPreferences ()Lkotlinx/serialization/json/JsonObject;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/actor/PutPreferencesRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/actor/PutPreferencesRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/actor/PutPreferencesRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/actor/PutPreferencesRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/PutPreferencesRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/SavedFeed {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/actor/SavedFeed$Companion;
+	public fun <init> (Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Z
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/actor/SavedFeed;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/actor/SavedFeed;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/actor/SavedFeed;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getId ()Ljava/lang/String;
+	public final fun getPinned ()Z
+	public final fun getType ()Ljava/lang/String;
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/actor/SavedFeed$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/actor/SavedFeed$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/actor/SavedFeed;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/actor/SavedFeed;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/SavedFeed$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/SavedFeedsPref {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/actor/SavedFeedsPref$Companion;
+	public fun <init> (Ljava/util/List;Ljava/util/List;Ljava/lang/Long;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;Ljava/lang/Long;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/lang/Long;
+	public final fun copy (Ljava/util/List;Ljava/util/List;Ljava/lang/Long;)Lio/github/kikin81/atproto/app/bsky/actor/SavedFeedsPref;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/actor/SavedFeedsPref;Ljava/util/List;Ljava/util/List;Ljava/lang/Long;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/actor/SavedFeedsPref;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPinned ()Ljava/util/List;
+	public final fun getSaved ()Ljava/util/List;
+	public final fun getTimelineIndex ()Ljava/lang/Long;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/actor/SavedFeedsPref$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/actor/SavedFeedsPref$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/actor/SavedFeedsPref;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/actor/SavedFeedsPref;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/SavedFeedsPref$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/SavedFeedsPrefV2 {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/actor/SavedFeedsPrefV2$Companion;
+	public fun <init> (Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lio/github/kikin81/atproto/app/bsky/actor/SavedFeedsPrefV2;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/actor/SavedFeedsPrefV2;Ljava/util/List;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/actor/SavedFeedsPrefV2;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getItems ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/actor/SavedFeedsPrefV2$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/actor/SavedFeedsPrefV2$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/actor/SavedFeedsPrefV2;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/actor/SavedFeedsPrefV2;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/SavedFeedsPrefV2$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/SearchActorsRequest {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/actor/SearchActorsRequest$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/Long;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/actor/SearchActorsRequest;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/actor/SearchActorsRequest;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/actor/SearchActorsRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCursor ()Ljava/lang/String;
+	public final fun getLimit ()Ljava/lang/Long;
+	public final fun getQ ()Ljava/lang/String;
+	public final fun getTerm ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/actor/SearchActorsRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/actor/SearchActorsRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/actor/SearchActorsRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/actor/SearchActorsRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/SearchActorsRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/SearchActorsResponse {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/actor/SearchActorsResponse$Companion;
+	public fun <init> (Ljava/util/List;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/util/List;Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/actor/SearchActorsResponse;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/actor/SearchActorsResponse;Ljava/util/List;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/actor/SearchActorsResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActors ()Ljava/util/List;
+	public final fun getCursor ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/actor/SearchActorsResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/actor/SearchActorsResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/actor/SearchActorsResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/actor/SearchActorsResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/SearchActorsResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/SearchActorsTypeaheadRequest {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/actor/SearchActorsTypeaheadRequest$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Long;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/actor/SearchActorsTypeaheadRequest;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/actor/SearchActorsTypeaheadRequest;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/actor/SearchActorsTypeaheadRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getLimit ()Ljava/lang/Long;
+	public final fun getQ ()Ljava/lang/String;
+	public final fun getTerm ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/actor/SearchActorsTypeaheadRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/actor/SearchActorsTypeaheadRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/actor/SearchActorsTypeaheadRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/actor/SearchActorsTypeaheadRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/SearchActorsTypeaheadRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/SearchActorsTypeaheadResponse {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/actor/SearchActorsTypeaheadResponse$Companion;
+	public fun <init> (Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lio/github/kikin81/atproto/app/bsky/actor/SearchActorsTypeaheadResponse;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/actor/SearchActorsTypeaheadResponse;Ljava/util/List;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/actor/SearchActorsTypeaheadResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActors ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/actor/SearchActorsTypeaheadResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/actor/SearchActorsTypeaheadResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/actor/SearchActorsTypeaheadResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/actor/SearchActorsTypeaheadResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/SearchActorsTypeaheadResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/Status {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/actor/Status$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-DnBUIck ()Ljava/lang/String;
+	public final fun component2 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun component3 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy-FnFYJuE (Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/actor/Status;
+	public static synthetic fun copy-FnFYJuE$default (Lio/github/kikin81/atproto/app/bsky/actor/Status;Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/actor/Status;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCreatedAt-DnBUIck ()Ljava/lang/String;
+	public final fun getDurationMinutes ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun getEmbed ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun getStatus ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/actor/Status$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/actor/Status$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/actor/Status;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/actor/Status;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/Status$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class io/github/kikin81/atproto/app/bsky/actor/StatusEmbedUnion : io/github/kikin81/atproto/runtime/OpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/actor/StatusEmbedUnion$Companion;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/StatusEmbedUnion$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/StatusEmbedUnion$Unknown : io/github/kikin81/atproto/app/bsky/actor/StatusEmbedUnion, io/github/kikin81/atproto/runtime/UnknownOpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/actor/StatusEmbedUnion$Unknown$Companion;
+	public fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/app/bsky/actor/StatusEmbedUnion$Unknown;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/actor/StatusEmbedUnion$Unknown;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/actor/StatusEmbedUnion$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getRaw ()Lkotlinx/serialization/json/JsonObject;
+	public fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/StatusEmbedUnion$Unknown$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/StatusEmbedUnionSerializer : io/github/kikin81/atproto/runtime/OpenUnionSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/actor/StatusEmbedUnionSerializer;
+	public fun selectKnownDeserializer (Ljava/lang/String;)Lkotlinx/serialization/KSerializer;
+	public fun selectKnownSerializer (Lio/github/kikin81/atproto/app/bsky/actor/StatusEmbedUnion;)Lkotlinx/serialization/KSerializer;
+	public synthetic fun selectKnownSerializer (Lio/github/kikin81/atproto/runtime/OpenUnionMember;)Lkotlinx/serialization/KSerializer;
+	public fun unknownSerializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/StatusEmbedUnionUnknownSerializer : io/github/kikin81/atproto/runtime/UnknownMemberSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/actor/StatusEmbedUnionUnknownSerializer;
+	public fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/app/bsky/actor/StatusEmbedUnion$Unknown;
+	public synthetic fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/runtime/UnknownOpenUnionMember;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/StatusView {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/actor/StatusView$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/actor/StatusViewEmbedUnion;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/actor/StatusViewEmbedUnion;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-eL7R55w ()Ljava/lang/String;
+	public final fun component2 ()Lio/github/kikin81/atproto/app/bsky/actor/StatusViewEmbedUnion;
+	public final fun component3-G5DCnlA ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/Boolean;
+	public final fun component5 ()Ljava/lang/Boolean;
+	public final fun component6 ()Ljava/util/List;
+	public final fun component7 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9-XX8z880 ()Ljava/lang/String;
+	public final fun copy-GsNHDRk (Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/actor/StatusViewEmbedUnion;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/actor/StatusView;
+	public static synthetic fun copy-GsNHDRk$default (Lio/github/kikin81/atproto/app/bsky/actor/StatusView;Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/actor/StatusViewEmbedUnion;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/actor/StatusView;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCid-eL7R55w ()Ljava/lang/String;
+	public final fun getEmbed ()Lio/github/kikin81/atproto/app/bsky/actor/StatusViewEmbedUnion;
+	public final fun getExpiresAt-G5DCnlA ()Ljava/lang/String;
+	public final fun getLabels ()Ljava/util/List;
+	public final fun getRecord ()Lkotlinx/serialization/json/JsonObject;
+	public final fun getStatus ()Ljava/lang/String;
+	public final fun getUri-XX8z880 ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun isActive ()Ljava/lang/Boolean;
+	public final fun isDisabled ()Ljava/lang/Boolean;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/actor/StatusView$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/actor/StatusView$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/actor/StatusView;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/actor/StatusView;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/StatusView$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class io/github/kikin81/atproto/app/bsky/actor/StatusViewEmbedUnion : io/github/kikin81/atproto/runtime/OpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/actor/StatusViewEmbedUnion$Companion;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/StatusViewEmbedUnion$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/StatusViewEmbedUnion$Unknown : io/github/kikin81/atproto/app/bsky/actor/StatusViewEmbedUnion, io/github/kikin81/atproto/runtime/UnknownOpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/actor/StatusViewEmbedUnion$Unknown$Companion;
+	public fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/app/bsky/actor/StatusViewEmbedUnion$Unknown;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/actor/StatusViewEmbedUnion$Unknown;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/actor/StatusViewEmbedUnion$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getRaw ()Lkotlinx/serialization/json/JsonObject;
+	public fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/StatusViewEmbedUnion$Unknown$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/StatusViewEmbedUnionSerializer : io/github/kikin81/atproto/runtime/OpenUnionSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/actor/StatusViewEmbedUnionSerializer;
+	public fun selectKnownDeserializer (Ljava/lang/String;)Lkotlinx/serialization/KSerializer;
+	public fun selectKnownSerializer (Lio/github/kikin81/atproto/app/bsky/actor/StatusViewEmbedUnion;)Lkotlinx/serialization/KSerializer;
+	public synthetic fun selectKnownSerializer (Lio/github/kikin81/atproto/runtime/OpenUnionMember;)Lkotlinx/serialization/KSerializer;
+	public fun unknownSerializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/StatusViewEmbedUnionUnknownSerializer : io/github/kikin81/atproto/runtime/UnknownMemberSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/actor/StatusViewEmbedUnionUnknownSerializer;
+	public fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/app/bsky/actor/StatusViewEmbedUnion$Unknown;
+	public synthetic fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/runtime/UnknownOpenUnionMember;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/ThreadViewPref {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/actor/ThreadViewPref$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/actor/ThreadViewPref;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/actor/ThreadViewPref;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/actor/ThreadViewPref;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getSort ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/actor/ThreadViewPref$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/actor/ThreadViewPref$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/actor/ThreadViewPref;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/actor/ThreadViewPref;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/ThreadViewPref$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/VerificationPrefs {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/actor/VerificationPrefs$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Boolean;)V
+	public synthetic fun <init> (Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Boolean;
+	public final fun copy (Ljava/lang/Boolean;)Lio/github/kikin81/atproto/app/bsky/actor/VerificationPrefs;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/actor/VerificationPrefs;Ljava/lang/Boolean;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/actor/VerificationPrefs;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getHideBadges ()Ljava/lang/Boolean;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/actor/VerificationPrefs$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/actor/VerificationPrefs$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/actor/VerificationPrefs;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/actor/VerificationPrefs;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/VerificationPrefs$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/VerificationState {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/actor/VerificationState$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/actor/VerificationState;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/actor/VerificationState;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/actor/VerificationState;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getTrustedVerifierStatus ()Ljava/lang/String;
+	public final fun getVerifications ()Ljava/util/List;
+	public final fun getVerifiedStatus ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/actor/VerificationState$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/actor/VerificationState$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/actor/VerificationState;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/actor/VerificationState;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/VerificationState$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/VerificationView {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/actor/VerificationView$Companion;
+	public synthetic fun <init> (Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-DnBUIck ()Ljava/lang/String;
+	public final fun component2 ()Z
+	public final fun component3-UyB9Nic ()Ljava/lang/String;
+	public final fun component4-GUXd3rc ()Ljava/lang/String;
+	public final fun copy-ZPm9goA (Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/actor/VerificationView;
+	public static synthetic fun copy-ZPm9goA$default (Lio/github/kikin81/atproto/app/bsky/actor/VerificationView;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/actor/VerificationView;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCreatedAt-DnBUIck ()Ljava/lang/String;
+	public final fun getIssuer-UyB9Nic ()Ljava/lang/String;
+	public final fun getUri-GUXd3rc ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun isValid ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/actor/VerificationView$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/actor/VerificationView$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/actor/VerificationView;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/actor/VerificationView;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/VerificationView$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/ViewerState {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/actor/ViewerState$Companion;
+	public synthetic fun <init> (Lio/github/kikin81/atproto/app/bsky/notification/ActivitySubscription;Ljava/lang/Boolean;Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/graph/ListViewBasic;Ljava/lang/String;Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/actor/KnownFollowers;Ljava/lang/Boolean;Lio/github/kikin81/atproto/app/bsky/graph/ListViewBasic;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lio/github/kikin81/atproto/app/bsky/notification/ActivitySubscription;Ljava/lang/Boolean;Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/graph/ListViewBasic;Ljava/lang/String;Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/actor/KnownFollowers;Ljava/lang/Boolean;Lio/github/kikin81/atproto/app/bsky/graph/ListViewBasic;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/app/bsky/notification/ActivitySubscription;
+	public final fun component2 ()Ljava/lang/Boolean;
+	public final fun component3-XX8z880 ()Ljava/lang/String;
+	public final fun component4 ()Lio/github/kikin81/atproto/app/bsky/graph/ListViewBasic;
+	public final fun component5-XX8z880 ()Ljava/lang/String;
+	public final fun component6-XX8z880 ()Ljava/lang/String;
+	public final fun component7 ()Lio/github/kikin81/atproto/app/bsky/actor/KnownFollowers;
+	public final fun component8 ()Ljava/lang/Boolean;
+	public final fun component9 ()Lio/github/kikin81/atproto/app/bsky/graph/ListViewBasic;
+	public final fun copy-kjj6U9E (Lio/github/kikin81/atproto/app/bsky/notification/ActivitySubscription;Ljava/lang/Boolean;Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/graph/ListViewBasic;Ljava/lang/String;Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/actor/KnownFollowers;Ljava/lang/Boolean;Lio/github/kikin81/atproto/app/bsky/graph/ListViewBasic;)Lio/github/kikin81/atproto/app/bsky/actor/ViewerState;
+	public static synthetic fun copy-kjj6U9E$default (Lio/github/kikin81/atproto/app/bsky/actor/ViewerState;Lio/github/kikin81/atproto/app/bsky/notification/ActivitySubscription;Ljava/lang/Boolean;Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/graph/ListViewBasic;Ljava/lang/String;Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/actor/KnownFollowers;Ljava/lang/Boolean;Lio/github/kikin81/atproto/app/bsky/graph/ListViewBasic;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/actor/ViewerState;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActivitySubscription ()Lio/github/kikin81/atproto/app/bsky/notification/ActivitySubscription;
+	public final fun getBlockedBy ()Ljava/lang/Boolean;
+	public final fun getBlocking-XX8z880 ()Ljava/lang/String;
+	public final fun getBlockingByList ()Lio/github/kikin81/atproto/app/bsky/graph/ListViewBasic;
+	public final fun getFollowedBy-XX8z880 ()Ljava/lang/String;
+	public final fun getFollowing-XX8z880 ()Ljava/lang/String;
+	public final fun getKnownFollowers ()Lio/github/kikin81/atproto/app/bsky/actor/KnownFollowers;
+	public final fun getMuted ()Ljava/lang/Boolean;
+	public final fun getMutedByList ()Lio/github/kikin81/atproto/app/bsky/graph/ListViewBasic;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/actor/ViewerState$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/actor/ViewerState$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/actor/ViewerState;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/actor/ViewerState;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/ViewerState$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/AspectRatio {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/embed/AspectRatio$Companion;
+	public fun <init> (JJ)V
+	public final fun component1 ()J
+	public final fun component2 ()J
+	public final fun copy (JJ)Lio/github/kikin81/atproto/app/bsky/embed/AspectRatio;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/embed/AspectRatio;JJILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/embed/AspectRatio;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getHeight ()J
+	public final fun getWidth ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/embed/AspectRatio$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/embed/AspectRatio$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/embed/AspectRatio;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/embed/AspectRatio;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/AspectRatio$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/External : io/github/kikin81/atproto/app/bsky/actor/StatusEmbedUnion, io/github/kikin81/atproto/app/bsky/embed/RecordWithMediaMediaUnion, io/github/kikin81/atproto/app/bsky/feed/PostEmbedUnion {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/embed/External$Companion;
+	public fun <init> (Lio/github/kikin81/atproto/app/bsky/embed/ExternalExternal;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/app/bsky/embed/ExternalExternal;
+	public final fun copy (Lio/github/kikin81/atproto/app/bsky/embed/ExternalExternal;)Lio/github/kikin81/atproto/app/bsky/embed/External;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/embed/External;Lio/github/kikin81/atproto/app/bsky/embed/ExternalExternal;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/embed/External;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getExternal ()Lio/github/kikin81/atproto/app/bsky/embed/ExternalExternal;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/embed/External$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/embed/External$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/embed/External;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/embed/External;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/External$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/ExternalExternal {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/embed/ExternalExternal$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4-jMNtXP8 ()Ljava/lang/String;
+	public final fun copy-2RW-_b8 (Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/embed/ExternalExternal;
+	public static synthetic fun copy-2RW-_b8$default (Lio/github/kikin81/atproto/app/bsky/embed/ExternalExternal;Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/embed/ExternalExternal;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getThumb ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun getTitle ()Ljava/lang/String;
+	public final fun getUri-jMNtXP8 ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/embed/ExternalExternal$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/embed/ExternalExternal$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/embed/ExternalExternal;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/embed/ExternalExternal;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/ExternalExternal$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/ExternalView : io/github/kikin81/atproto/app/bsky/actor/StatusViewEmbedUnion, io/github/kikin81/atproto/app/bsky/embed/RecordViewRecordEmbedsUnion, io/github/kikin81/atproto/app/bsky/embed/RecordWithMediaViewMediaUnion, io/github/kikin81/atproto/app/bsky/feed/PostViewEmbedUnion {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/embed/ExternalView$Companion;
+	public fun <init> (Lio/github/kikin81/atproto/app/bsky/embed/ExternalViewExternal;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/app/bsky/embed/ExternalViewExternal;
+	public final fun copy (Lio/github/kikin81/atproto/app/bsky/embed/ExternalViewExternal;)Lio/github/kikin81/atproto/app/bsky/embed/ExternalView;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/embed/ExternalView;Lio/github/kikin81/atproto/app/bsky/embed/ExternalViewExternal;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/embed/ExternalView;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getExternal ()Lio/github/kikin81/atproto/app/bsky/embed/ExternalViewExternal;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/embed/ExternalView$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/embed/ExternalView$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/embed/ExternalView;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/embed/ExternalView;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/ExternalView$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/ExternalViewExternal {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/embed/ExternalViewExternal$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2-Eo6btPk ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4-jMNtXP8 ()Ljava/lang/String;
+	public final fun copy-gl96lsk (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/embed/ExternalViewExternal;
+	public static synthetic fun copy-gl96lsk$default (Lio/github/kikin81/atproto/app/bsky/embed/ExternalViewExternal;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/embed/ExternalViewExternal;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getThumb-Eo6btPk ()Ljava/lang/String;
+	public final fun getTitle ()Ljava/lang/String;
+	public final fun getUri-jMNtXP8 ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/embed/ExternalViewExternal$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/embed/ExternalViewExternal$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/embed/ExternalViewExternal;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/embed/ExternalViewExternal;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/ExternalViewExternal$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/Images : io/github/kikin81/atproto/app/bsky/embed/RecordWithMediaMediaUnion, io/github/kikin81/atproto/app/bsky/feed/PostEmbedUnion {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/embed/Images$Companion;
+	public fun <init> (Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lio/github/kikin81/atproto/app/bsky/embed/Images;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/embed/Images;Ljava/util/List;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/embed/Images;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getImages ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/embed/Images$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/embed/Images$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/embed/Images;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/embed/Images;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/Images$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/ImagesImage {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/embed/ImagesImage$Companion;
+	public fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/Blob;)V
+	public synthetic fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/Blob;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun component3 ()Lio/github/kikin81/atproto/runtime/Blob;
+	public final fun copy (Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/Blob;)Lio/github/kikin81/atproto/app/bsky/embed/ImagesImage;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/embed/ImagesImage;Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/Blob;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/embed/ImagesImage;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAlt ()Ljava/lang/String;
+	public final fun getAspectRatio ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun getImage ()Lio/github/kikin81/atproto/runtime/Blob;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/embed/ImagesImage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/embed/ImagesImage$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/embed/ImagesImage;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/embed/ImagesImage;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/ImagesImage$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/ImagesView : io/github/kikin81/atproto/app/bsky/embed/RecordViewRecordEmbedsUnion, io/github/kikin81/atproto/app/bsky/embed/RecordWithMediaViewMediaUnion, io/github/kikin81/atproto/app/bsky/feed/PostViewEmbedUnion {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/embed/ImagesView$Companion;
+	public fun <init> (Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lio/github/kikin81/atproto/app/bsky/embed/ImagesView;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/embed/ImagesView;Ljava/util/List;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/embed/ImagesView;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getImages ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/embed/ImagesView$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/embed/ImagesView$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/embed/ImagesView;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/embed/ImagesView;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/ImagesView$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/ImagesViewImage {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/embed/ImagesViewImage$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/embed/AspectRatio;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/embed/AspectRatio;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/github/kikin81/atproto/app/bsky/embed/AspectRatio;
+	public final fun component3-jMNtXP8 ()Ljava/lang/String;
+	public final fun component4-jMNtXP8 ()Ljava/lang/String;
+	public final fun copy-1pRRTy0 (Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/embed/AspectRatio;Ljava/lang/String;Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/embed/ImagesViewImage;
+	public static synthetic fun copy-1pRRTy0$default (Lio/github/kikin81/atproto/app/bsky/embed/ImagesViewImage;Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/embed/AspectRatio;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/embed/ImagesViewImage;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAlt ()Ljava/lang/String;
+	public final fun getAspectRatio ()Lio/github/kikin81/atproto/app/bsky/embed/AspectRatio;
+	public final fun getFullsize-jMNtXP8 ()Ljava/lang/String;
+	public final fun getThumb-jMNtXP8 ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/embed/ImagesViewImage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/embed/ImagesViewImage$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/embed/ImagesViewImage;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/embed/ImagesViewImage;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/ImagesViewImage$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/Record : io/github/kikin81/atproto/app/bsky/feed/PostEmbedUnion, io/github/kikin81/atproto/chat/bsky/convo/MessageInputEmbedUnion {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/embed/Record$Companion;
+	public fun <init> (Lio/github/kikin81/atproto/com/atproto/repo/StrongRef;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/com/atproto/repo/StrongRef;
+	public final fun copy (Lio/github/kikin81/atproto/com/atproto/repo/StrongRef;)Lio/github/kikin81/atproto/app/bsky/embed/Record;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/embed/Record;Lio/github/kikin81/atproto/com/atproto/repo/StrongRef;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/embed/Record;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getRecord ()Lio/github/kikin81/atproto/com/atproto/repo/StrongRef;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/embed/Record$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/embed/Record$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/embed/Record;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/embed/Record;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/Record$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/RecordView : io/github/kikin81/atproto/app/bsky/embed/RecordViewRecordEmbedsUnion, io/github/kikin81/atproto/app/bsky/feed/PostViewEmbedUnion, io/github/kikin81/atproto/chat/bsky/convo/MessageViewEmbedUnion {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/embed/RecordView$Companion;
+	public fun <init> (Lio/github/kikin81/atproto/app/bsky/embed/RecordViewRecordUnion;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/app/bsky/embed/RecordViewRecordUnion;
+	public final fun copy (Lio/github/kikin81/atproto/app/bsky/embed/RecordViewRecordUnion;)Lio/github/kikin81/atproto/app/bsky/embed/RecordView;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/embed/RecordView;Lio/github/kikin81/atproto/app/bsky/embed/RecordViewRecordUnion;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/embed/RecordView;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getRecord ()Lio/github/kikin81/atproto/app/bsky/embed/RecordViewRecordUnion;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/embed/RecordView$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/embed/RecordView$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/embed/RecordView;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/embed/RecordView;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/RecordView$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/RecordViewBlocked : io/github/kikin81/atproto/app/bsky/embed/RecordViewRecordUnion {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/embed/RecordViewBlocked$Companion;
+	public synthetic fun <init> (Lio/github/kikin81/atproto/app/bsky/feed/BlockedAuthor;ZLjava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/app/bsky/feed/BlockedAuthor;
+	public final fun component2 ()Z
+	public final fun component3-GUXd3rc ()Ljava/lang/String;
+	public final fun copy-SUTmSSk (Lio/github/kikin81/atproto/app/bsky/feed/BlockedAuthor;ZLjava/lang/String;)Lio/github/kikin81/atproto/app/bsky/embed/RecordViewBlocked;
+	public static synthetic fun copy-SUTmSSk$default (Lio/github/kikin81/atproto/app/bsky/embed/RecordViewBlocked;Lio/github/kikin81/atproto/app/bsky/feed/BlockedAuthor;ZLjava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/embed/RecordViewBlocked;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAuthor ()Lio/github/kikin81/atproto/app/bsky/feed/BlockedAuthor;
+	public final fun getBlocked ()Z
+	public final fun getUri-GUXd3rc ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/embed/RecordViewBlocked$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/embed/RecordViewBlocked$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/embed/RecordViewBlocked;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/embed/RecordViewBlocked;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/RecordViewBlocked$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/RecordViewDetached : io/github/kikin81/atproto/app/bsky/embed/RecordViewRecordUnion {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/embed/RecordViewDetached$Companion;
+	public synthetic fun <init> (ZLjava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun component2-GUXd3rc ()Ljava/lang/String;
+	public final fun copy-HnpCerU (ZLjava/lang/String;)Lio/github/kikin81/atproto/app/bsky/embed/RecordViewDetached;
+	public static synthetic fun copy-HnpCerU$default (Lio/github/kikin81/atproto/app/bsky/embed/RecordViewDetached;ZLjava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/embed/RecordViewDetached;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDetached ()Z
+	public final fun getUri-GUXd3rc ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/embed/RecordViewDetached$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/embed/RecordViewDetached$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/embed/RecordViewDetached;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/embed/RecordViewDetached;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/RecordViewDetached$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/RecordViewNotFound : io/github/kikin81/atproto/app/bsky/embed/RecordViewRecordUnion {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/embed/RecordViewNotFound$Companion;
+	public synthetic fun <init> (ZLjava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun component2-GUXd3rc ()Ljava/lang/String;
+	public final fun copy-HnpCerU (ZLjava/lang/String;)Lio/github/kikin81/atproto/app/bsky/embed/RecordViewNotFound;
+	public static synthetic fun copy-HnpCerU$default (Lio/github/kikin81/atproto/app/bsky/embed/RecordViewNotFound;ZLjava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/embed/RecordViewNotFound;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getNotFound ()Z
+	public final fun getUri-GUXd3rc ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/embed/RecordViewNotFound$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/embed/RecordViewNotFound$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/embed/RecordViewNotFound;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/embed/RecordViewNotFound;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/RecordViewNotFound$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/RecordViewRecord : io/github/kikin81/atproto/app/bsky/embed/RecordViewRecordUnion {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/embed/RecordViewRecord$Companion;
+	public synthetic fun <init> (Lio/github/kikin81/atproto/app/bsky/actor/ProfileViewBasic;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lio/github/kikin81/atproto/app/bsky/actor/ProfileViewBasic;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/app/bsky/actor/ProfileViewBasic;
+	public final fun component10-GUXd3rc ()Ljava/lang/String;
+	public final fun component11 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun component2-LVDfoeI ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4-DnBUIck ()Ljava/lang/String;
+	public final fun component5 ()Ljava/util/List;
+	public final fun component6 ()Ljava/lang/Long;
+	public final fun component7 ()Ljava/lang/Long;
+	public final fun component8 ()Ljava/lang/Long;
+	public final fun component9 ()Ljava/lang/Long;
+	public final fun copy-5CpyY5E (Lio/github/kikin81/atproto/app/bsky/actor/ProfileViewBasic;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/app/bsky/embed/RecordViewRecord;
+	public static synthetic fun copy-5CpyY5E$default (Lio/github/kikin81/atproto/app/bsky/embed/RecordViewRecord;Lio/github/kikin81/atproto/app/bsky/actor/ProfileViewBasic;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/embed/RecordViewRecord;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAuthor ()Lio/github/kikin81/atproto/app/bsky/actor/ProfileViewBasic;
+	public final fun getCid-LVDfoeI ()Ljava/lang/String;
+	public final fun getEmbeds ()Ljava/util/List;
+	public final fun getIndexedAt-DnBUIck ()Ljava/lang/String;
+	public final fun getLabels ()Ljava/util/List;
+	public final fun getLikeCount ()Ljava/lang/Long;
+	public final fun getQuoteCount ()Ljava/lang/Long;
+	public final fun getReplyCount ()Ljava/lang/Long;
+	public final fun getRepostCount ()Ljava/lang/Long;
+	public final fun getUri-GUXd3rc ()Ljava/lang/String;
+	public final fun getValue ()Lkotlinx/serialization/json/JsonObject;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/embed/RecordViewRecord$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/embed/RecordViewRecord$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/embed/RecordViewRecord;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/embed/RecordViewRecord;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/RecordViewRecord$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class io/github/kikin81/atproto/app/bsky/embed/RecordViewRecordEmbedsUnion : io/github/kikin81/atproto/runtime/OpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/embed/RecordViewRecordEmbedsUnion$Companion;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/RecordViewRecordEmbedsUnion$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/RecordViewRecordEmbedsUnion$Unknown : io/github/kikin81/atproto/app/bsky/embed/RecordViewRecordEmbedsUnion, io/github/kikin81/atproto/runtime/UnknownOpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/embed/RecordViewRecordEmbedsUnion$Unknown$Companion;
+	public fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/app/bsky/embed/RecordViewRecordEmbedsUnion$Unknown;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/embed/RecordViewRecordEmbedsUnion$Unknown;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/embed/RecordViewRecordEmbedsUnion$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getRaw ()Lkotlinx/serialization/json/JsonObject;
+	public fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/RecordViewRecordEmbedsUnion$Unknown$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/RecordViewRecordEmbedsUnionSerializer : io/github/kikin81/atproto/runtime/OpenUnionSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/embed/RecordViewRecordEmbedsUnionSerializer;
+	public fun selectKnownDeserializer (Ljava/lang/String;)Lkotlinx/serialization/KSerializer;
+	public fun selectKnownSerializer (Lio/github/kikin81/atproto/app/bsky/embed/RecordViewRecordEmbedsUnion;)Lkotlinx/serialization/KSerializer;
+	public synthetic fun selectKnownSerializer (Lio/github/kikin81/atproto/runtime/OpenUnionMember;)Lkotlinx/serialization/KSerializer;
+	public fun unknownSerializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/RecordViewRecordEmbedsUnionUnknownSerializer : io/github/kikin81/atproto/runtime/UnknownMemberSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/embed/RecordViewRecordEmbedsUnionUnknownSerializer;
+	public fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/app/bsky/embed/RecordViewRecordEmbedsUnion$Unknown;
+	public synthetic fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/runtime/UnknownOpenUnionMember;
+}
+
+public abstract interface class io/github/kikin81/atproto/app/bsky/embed/RecordViewRecordUnion : io/github/kikin81/atproto/runtime/OpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/embed/RecordViewRecordUnion$Companion;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/RecordViewRecordUnion$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/RecordViewRecordUnion$Unknown : io/github/kikin81/atproto/app/bsky/embed/RecordViewRecordUnion, io/github/kikin81/atproto/runtime/UnknownOpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/embed/RecordViewRecordUnion$Unknown$Companion;
+	public fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/app/bsky/embed/RecordViewRecordUnion$Unknown;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/embed/RecordViewRecordUnion$Unknown;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/embed/RecordViewRecordUnion$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getRaw ()Lkotlinx/serialization/json/JsonObject;
+	public fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/RecordViewRecordUnion$Unknown$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/RecordViewRecordUnionSerializer : io/github/kikin81/atproto/runtime/OpenUnionSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/embed/RecordViewRecordUnionSerializer;
+	public fun selectKnownDeserializer (Ljava/lang/String;)Lkotlinx/serialization/KSerializer;
+	public fun selectKnownSerializer (Lio/github/kikin81/atproto/app/bsky/embed/RecordViewRecordUnion;)Lkotlinx/serialization/KSerializer;
+	public synthetic fun selectKnownSerializer (Lio/github/kikin81/atproto/runtime/OpenUnionMember;)Lkotlinx/serialization/KSerializer;
+	public fun unknownSerializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/RecordViewRecordUnionUnknownSerializer : io/github/kikin81/atproto/runtime/UnknownMemberSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/embed/RecordViewRecordUnionUnknownSerializer;
+	public fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/app/bsky/embed/RecordViewRecordUnion$Unknown;
+	public synthetic fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/runtime/UnknownOpenUnionMember;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/RecordWithMedia : io/github/kikin81/atproto/app/bsky/feed/PostEmbedUnion {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/embed/RecordWithMedia$Companion;
+	public fun <init> (Lio/github/kikin81/atproto/app/bsky/embed/RecordWithMediaMediaUnion;Lio/github/kikin81/atproto/app/bsky/embed/Record;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/app/bsky/embed/RecordWithMediaMediaUnion;
+	public final fun component2 ()Lio/github/kikin81/atproto/app/bsky/embed/Record;
+	public final fun copy (Lio/github/kikin81/atproto/app/bsky/embed/RecordWithMediaMediaUnion;Lio/github/kikin81/atproto/app/bsky/embed/Record;)Lio/github/kikin81/atproto/app/bsky/embed/RecordWithMedia;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/embed/RecordWithMedia;Lio/github/kikin81/atproto/app/bsky/embed/RecordWithMediaMediaUnion;Lio/github/kikin81/atproto/app/bsky/embed/Record;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/embed/RecordWithMedia;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMedia ()Lio/github/kikin81/atproto/app/bsky/embed/RecordWithMediaMediaUnion;
+	public final fun getRecord ()Lio/github/kikin81/atproto/app/bsky/embed/Record;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/embed/RecordWithMedia$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/embed/RecordWithMedia$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/embed/RecordWithMedia;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/embed/RecordWithMedia;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/RecordWithMedia$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class io/github/kikin81/atproto/app/bsky/embed/RecordWithMediaMediaUnion : io/github/kikin81/atproto/runtime/OpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/embed/RecordWithMediaMediaUnion$Companion;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/RecordWithMediaMediaUnion$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/RecordWithMediaMediaUnion$Unknown : io/github/kikin81/atproto/app/bsky/embed/RecordWithMediaMediaUnion, io/github/kikin81/atproto/runtime/UnknownOpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/embed/RecordWithMediaMediaUnion$Unknown$Companion;
+	public fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/app/bsky/embed/RecordWithMediaMediaUnion$Unknown;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/embed/RecordWithMediaMediaUnion$Unknown;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/embed/RecordWithMediaMediaUnion$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getRaw ()Lkotlinx/serialization/json/JsonObject;
+	public fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/RecordWithMediaMediaUnion$Unknown$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/RecordWithMediaMediaUnionSerializer : io/github/kikin81/atproto/runtime/OpenUnionSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/embed/RecordWithMediaMediaUnionSerializer;
+	public fun selectKnownDeserializer (Ljava/lang/String;)Lkotlinx/serialization/KSerializer;
+	public fun selectKnownSerializer (Lio/github/kikin81/atproto/app/bsky/embed/RecordWithMediaMediaUnion;)Lkotlinx/serialization/KSerializer;
+	public synthetic fun selectKnownSerializer (Lio/github/kikin81/atproto/runtime/OpenUnionMember;)Lkotlinx/serialization/KSerializer;
+	public fun unknownSerializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/RecordWithMediaMediaUnionUnknownSerializer : io/github/kikin81/atproto/runtime/UnknownMemberSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/embed/RecordWithMediaMediaUnionUnknownSerializer;
+	public fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/app/bsky/embed/RecordWithMediaMediaUnion$Unknown;
+	public synthetic fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/runtime/UnknownOpenUnionMember;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/RecordWithMediaView : io/github/kikin81/atproto/app/bsky/embed/RecordViewRecordEmbedsUnion, io/github/kikin81/atproto/app/bsky/feed/PostViewEmbedUnion {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/embed/RecordWithMediaView$Companion;
+	public fun <init> (Lio/github/kikin81/atproto/app/bsky/embed/RecordWithMediaViewMediaUnion;Lio/github/kikin81/atproto/app/bsky/embed/RecordView;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/app/bsky/embed/RecordWithMediaViewMediaUnion;
+	public final fun component2 ()Lio/github/kikin81/atproto/app/bsky/embed/RecordView;
+	public final fun copy (Lio/github/kikin81/atproto/app/bsky/embed/RecordWithMediaViewMediaUnion;Lio/github/kikin81/atproto/app/bsky/embed/RecordView;)Lio/github/kikin81/atproto/app/bsky/embed/RecordWithMediaView;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/embed/RecordWithMediaView;Lio/github/kikin81/atproto/app/bsky/embed/RecordWithMediaViewMediaUnion;Lio/github/kikin81/atproto/app/bsky/embed/RecordView;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/embed/RecordWithMediaView;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMedia ()Lio/github/kikin81/atproto/app/bsky/embed/RecordWithMediaViewMediaUnion;
+	public final fun getRecord ()Lio/github/kikin81/atproto/app/bsky/embed/RecordView;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/embed/RecordWithMediaView$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/embed/RecordWithMediaView$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/embed/RecordWithMediaView;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/embed/RecordWithMediaView;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/RecordWithMediaView$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class io/github/kikin81/atproto/app/bsky/embed/RecordWithMediaViewMediaUnion : io/github/kikin81/atproto/runtime/OpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/embed/RecordWithMediaViewMediaUnion$Companion;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/RecordWithMediaViewMediaUnion$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/RecordWithMediaViewMediaUnion$Unknown : io/github/kikin81/atproto/app/bsky/embed/RecordWithMediaViewMediaUnion, io/github/kikin81/atproto/runtime/UnknownOpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/embed/RecordWithMediaViewMediaUnion$Unknown$Companion;
+	public fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/app/bsky/embed/RecordWithMediaViewMediaUnion$Unknown;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/embed/RecordWithMediaViewMediaUnion$Unknown;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/embed/RecordWithMediaViewMediaUnion$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getRaw ()Lkotlinx/serialization/json/JsonObject;
+	public fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/RecordWithMediaViewMediaUnion$Unknown$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/RecordWithMediaViewMediaUnionSerializer : io/github/kikin81/atproto/runtime/OpenUnionSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/embed/RecordWithMediaViewMediaUnionSerializer;
+	public fun selectKnownDeserializer (Ljava/lang/String;)Lkotlinx/serialization/KSerializer;
+	public fun selectKnownSerializer (Lio/github/kikin81/atproto/app/bsky/embed/RecordWithMediaViewMediaUnion;)Lkotlinx/serialization/KSerializer;
+	public synthetic fun selectKnownSerializer (Lio/github/kikin81/atproto/runtime/OpenUnionMember;)Lkotlinx/serialization/KSerializer;
+	public fun unknownSerializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/RecordWithMediaViewMediaUnionUnknownSerializer : io/github/kikin81/atproto/runtime/UnknownMemberSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/embed/RecordWithMediaViewMediaUnionUnknownSerializer;
+	public fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/app/bsky/embed/RecordWithMediaViewMediaUnion$Unknown;
+	public synthetic fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/runtime/UnknownOpenUnionMember;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/Video : io/github/kikin81/atproto/app/bsky/embed/RecordWithMediaMediaUnion, io/github/kikin81/atproto/app/bsky/feed/PostEmbedUnion {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/embed/Video$Companion;
+	public fun <init> (Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/Blob;)V
+	public synthetic fun <init> (Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/Blob;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun component2 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun component3 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun component4 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun component5 ()Lio/github/kikin81/atproto/runtime/Blob;
+	public final fun copy (Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/Blob;)Lio/github/kikin81/atproto/app/bsky/embed/Video;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/embed/Video;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/Blob;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/embed/Video;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAlt ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun getAspectRatio ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun getCaptions ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun getPresentation ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun getVideo ()Lio/github/kikin81/atproto/runtime/Blob;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/embed/Video$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/embed/Video$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/embed/Video;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/embed/Video;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/Video$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/VideoCaption {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/embed/VideoCaption$Companion;
+	public synthetic fun <init> (Lio/github/kikin81/atproto/runtime/Blob;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/runtime/Blob;
+	public final fun component2-JI_oZ4A ()Ljava/lang/String;
+	public final fun copy-2jZb1e0 (Lio/github/kikin81/atproto/runtime/Blob;Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/embed/VideoCaption;
+	public static synthetic fun copy-2jZb1e0$default (Lio/github/kikin81/atproto/app/bsky/embed/VideoCaption;Lio/github/kikin81/atproto/runtime/Blob;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/embed/VideoCaption;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFile ()Lio/github/kikin81/atproto/runtime/Blob;
+	public final fun getLang-JI_oZ4A ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/embed/VideoCaption$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/embed/VideoCaption$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/embed/VideoCaption;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/embed/VideoCaption;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/VideoCaption$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/VideoView : io/github/kikin81/atproto/app/bsky/embed/RecordViewRecordEmbedsUnion, io/github/kikin81/atproto/app/bsky/embed/RecordWithMediaViewMediaUnion, io/github/kikin81/atproto/app/bsky/feed/PostViewEmbedUnion {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/embed/VideoView$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/embed/AspectRatio;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/embed/AspectRatio;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/github/kikin81/atproto/app/bsky/embed/AspectRatio;
+	public final fun component3-LVDfoeI ()Ljava/lang/String;
+	public final fun component4-jMNtXP8 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6-Eo6btPk ()Ljava/lang/String;
+	public final fun copy-Q4R8qfI (Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/embed/AspectRatio;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/embed/VideoView;
+	public static synthetic fun copy-Q4R8qfI$default (Lio/github/kikin81/atproto/app/bsky/embed/VideoView;Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/embed/AspectRatio;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/embed/VideoView;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAlt ()Ljava/lang/String;
+	public final fun getAspectRatio ()Lio/github/kikin81/atproto/app/bsky/embed/AspectRatio;
+	public final fun getCid-LVDfoeI ()Ljava/lang/String;
+	public final fun getPlaylist-jMNtXP8 ()Ljava/lang/String;
+	public final fun getPresentation ()Ljava/lang/String;
+	public final fun getThumbnail-Eo6btPk ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/embed/VideoView$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/embed/VideoView$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/embed/VideoView;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/embed/VideoView;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/VideoView$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/BlockedAuthor {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/BlockedAuthor$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/actor/ViewerState;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/actor/ViewerState;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-UyB9Nic ()Ljava/lang/String;
+	public final fun component2 ()Lio/github/kikin81/atproto/app/bsky/actor/ViewerState;
+	public final fun copy-5mRca5A (Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/actor/ViewerState;)Lio/github/kikin81/atproto/app/bsky/feed/BlockedAuthor;
+	public static synthetic fun copy-5mRca5A$default (Lio/github/kikin81/atproto/app/bsky/feed/BlockedAuthor;Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/actor/ViewerState;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/feed/BlockedAuthor;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDid-UyB9Nic ()Ljava/lang/String;
+	public final fun getViewer ()Lio/github/kikin81/atproto/app/bsky/actor/ViewerState;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/feed/BlockedAuthor$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/feed/BlockedAuthor$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/feed/BlockedAuthor;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/feed/BlockedAuthor;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/BlockedAuthor$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/BlockedPost : io/github/kikin81/atproto/app/bsky/feed/GetPostThreadResponseThreadUnion, io/github/kikin81/atproto/app/bsky/feed/ReplyRefParentUnion, io/github/kikin81/atproto/app/bsky/feed/ReplyRefRootUnion, io/github/kikin81/atproto/app/bsky/feed/ThreadViewPostParentUnion, io/github/kikin81/atproto/app/bsky/feed/ThreadViewPostRepliesUnion {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/BlockedPost$Companion;
+	public synthetic fun <init> (Lio/github/kikin81/atproto/app/bsky/feed/BlockedAuthor;ZLjava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/app/bsky/feed/BlockedAuthor;
+	public final fun component2 ()Z
+	public final fun component3-GUXd3rc ()Ljava/lang/String;
+	public final fun copy-SUTmSSk (Lio/github/kikin81/atproto/app/bsky/feed/BlockedAuthor;ZLjava/lang/String;)Lio/github/kikin81/atproto/app/bsky/feed/BlockedPost;
+	public static synthetic fun copy-SUTmSSk$default (Lio/github/kikin81/atproto/app/bsky/feed/BlockedPost;Lio/github/kikin81/atproto/app/bsky/feed/BlockedAuthor;ZLjava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/feed/BlockedPost;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAuthor ()Lio/github/kikin81/atproto/app/bsky/feed/BlockedAuthor;
+	public final fun getBlocked ()Z
+	public final fun getUri-GUXd3rc ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/feed/BlockedPost$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/feed/BlockedPost$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/feed/BlockedPost;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/feed/BlockedPost;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/BlockedPost$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/FeedService {
+	public fun <init> (Lio/github/kikin81/atproto/runtime/XrpcClient;)V
+	public final fun getAuthorFeed (Lio/github/kikin81/atproto/app/bsky/feed/GetAuthorFeedRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getFeed (Lio/github/kikin81/atproto/app/bsky/feed/GetFeedRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getFeedGenerator (Lio/github/kikin81/atproto/app/bsky/feed/GetFeedGeneratorRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getLikes (Lio/github/kikin81/atproto/app/bsky/feed/GetLikesRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getPostThread (Lio/github/kikin81/atproto/app/bsky/feed/GetPostThreadRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getPosts (Lio/github/kikin81/atproto/app/bsky/feed/GetPostsRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getRepostedBy (Lio/github/kikin81/atproto/app/bsky/feed/GetRepostedByRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getTimeline (Lio/github/kikin81/atproto/app/bsky/feed/GetTimelineRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getTimeline$default (Lio/github/kikin81/atproto/app/bsky/feed/FeedService;Lio/github/kikin81/atproto/app/bsky/feed/GetTimelineRequest;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun searchPosts (Lio/github/kikin81/atproto/app/bsky/feed/SearchPostsRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/FeedServiceKt {
+	public static final fun authorFeedFlow (Lio/github/kikin81/atproto/app/bsky/feed/FeedService;Lio/github/kikin81/atproto/app/bsky/feed/GetAuthorFeedRequest;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun authorFeedPageFlow (Lio/github/kikin81/atproto/app/bsky/feed/FeedService;Lio/github/kikin81/atproto/app/bsky/feed/GetAuthorFeedRequest;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun feedFlow (Lio/github/kikin81/atproto/app/bsky/feed/FeedService;Lio/github/kikin81/atproto/app/bsky/feed/GetFeedRequest;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun feedPageFlow (Lio/github/kikin81/atproto/app/bsky/feed/FeedService;Lio/github/kikin81/atproto/app/bsky/feed/GetFeedRequest;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun likesFlow (Lio/github/kikin81/atproto/app/bsky/feed/FeedService;Lio/github/kikin81/atproto/app/bsky/feed/GetLikesRequest;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun likesPageFlow (Lio/github/kikin81/atproto/app/bsky/feed/FeedService;Lio/github/kikin81/atproto/app/bsky/feed/GetLikesRequest;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun repostedByFlow (Lio/github/kikin81/atproto/app/bsky/feed/FeedService;Lio/github/kikin81/atproto/app/bsky/feed/GetRepostedByRequest;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun repostedByPageFlow (Lio/github/kikin81/atproto/app/bsky/feed/FeedService;Lio/github/kikin81/atproto/app/bsky/feed/GetRepostedByRequest;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun searchPostsFlow (Lio/github/kikin81/atproto/app/bsky/feed/FeedService;Lio/github/kikin81/atproto/app/bsky/feed/SearchPostsRequest;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun searchPostsPageFlow (Lio/github/kikin81/atproto/app/bsky/feed/FeedService;Lio/github/kikin81/atproto/app/bsky/feed/SearchPostsRequest;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun timelineFlow (Lio/github/kikin81/atproto/app/bsky/feed/FeedService;Lio/github/kikin81/atproto/app/bsky/feed/GetTimelineRequest;)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun timelineFlow$default (Lio/github/kikin81/atproto/app/bsky/feed/FeedService;Lio/github/kikin81/atproto/app/bsky/feed/GetTimelineRequest;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun timelinePageFlow (Lio/github/kikin81/atproto/app/bsky/feed/FeedService;Lio/github/kikin81/atproto/app/bsky/feed/GetTimelineRequest;)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun timelinePageFlow$default (Lio/github/kikin81/atproto/app/bsky/feed/FeedService;Lio/github/kikin81/atproto/app/bsky/feed/GetTimelineRequest;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/FeedViewPost {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/FeedViewPost$Companion;
+	public fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/feed/PostView;Lio/github/kikin81/atproto/app/bsky/feed/FeedViewPostReasonUnion;Lio/github/kikin81/atproto/app/bsky/feed/ReplyRef;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/feed/PostView;Lio/github/kikin81/atproto/app/bsky/feed/FeedViewPostReasonUnion;Lio/github/kikin81/atproto/app/bsky/feed/ReplyRef;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/github/kikin81/atproto/app/bsky/feed/PostView;
+	public final fun component3 ()Lio/github/kikin81/atproto/app/bsky/feed/FeedViewPostReasonUnion;
+	public final fun component4 ()Lio/github/kikin81/atproto/app/bsky/feed/ReplyRef;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/feed/PostView;Lio/github/kikin81/atproto/app/bsky/feed/FeedViewPostReasonUnion;Lio/github/kikin81/atproto/app/bsky/feed/ReplyRef;Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/feed/FeedViewPost;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/feed/FeedViewPost;Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/feed/PostView;Lio/github/kikin81/atproto/app/bsky/feed/FeedViewPostReasonUnion;Lio/github/kikin81/atproto/app/bsky/feed/ReplyRef;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/feed/FeedViewPost;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFeedContext ()Ljava/lang/String;
+	public final fun getPost ()Lio/github/kikin81/atproto/app/bsky/feed/PostView;
+	public final fun getReason ()Lio/github/kikin81/atproto/app/bsky/feed/FeedViewPostReasonUnion;
+	public final fun getReply ()Lio/github/kikin81/atproto/app/bsky/feed/ReplyRef;
+	public final fun getReqId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/feed/FeedViewPost$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/feed/FeedViewPost$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/feed/FeedViewPost;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/feed/FeedViewPost;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/FeedViewPost$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class io/github/kikin81/atproto/app/bsky/feed/FeedViewPostReasonUnion : io/github/kikin81/atproto/runtime/OpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/FeedViewPostReasonUnion$Companion;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/FeedViewPostReasonUnion$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/FeedViewPostReasonUnion$Unknown : io/github/kikin81/atproto/app/bsky/feed/FeedViewPostReasonUnion, io/github/kikin81/atproto/runtime/UnknownOpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/FeedViewPostReasonUnion$Unknown$Companion;
+	public fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/app/bsky/feed/FeedViewPostReasonUnion$Unknown;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/feed/FeedViewPostReasonUnion$Unknown;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/feed/FeedViewPostReasonUnion$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getRaw ()Lkotlinx/serialization/json/JsonObject;
+	public fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/FeedViewPostReasonUnion$Unknown$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/FeedViewPostReasonUnionSerializer : io/github/kikin81/atproto/runtime/OpenUnionSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/feed/FeedViewPostReasonUnionSerializer;
+	public fun selectKnownDeserializer (Ljava/lang/String;)Lkotlinx/serialization/KSerializer;
+	public fun selectKnownSerializer (Lio/github/kikin81/atproto/app/bsky/feed/FeedViewPostReasonUnion;)Lkotlinx/serialization/KSerializer;
+	public synthetic fun selectKnownSerializer (Lio/github/kikin81/atproto/runtime/OpenUnionMember;)Lkotlinx/serialization/KSerializer;
+	public fun unknownSerializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/FeedViewPostReasonUnionUnknownSerializer : io/github/kikin81/atproto/runtime/UnknownMemberSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/feed/FeedViewPostReasonUnionUnknownSerializer;
+	public fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/app/bsky/feed/FeedViewPostReasonUnion$Unknown;
+	public synthetic fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/runtime/UnknownOpenUnionMember;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/Generator {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/Generator$Companion;
+	public synthetic fun <init> (Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun component2 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun component3 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun component4-DnBUIck ()Ljava/lang/String;
+	public final fun component5 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun component6 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun component7-UyB9Nic ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun copy-05ybG00 (Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;)Lio/github/kikin81/atproto/app/bsky/feed/Generator;
+	public static synthetic fun copy-05ybG00$default (Lio/github/kikin81/atproto/app/bsky/feed/Generator;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/feed/Generator;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAcceptsInteractions ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun getAvatar ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun getContentMode ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun getCreatedAt-DnBUIck ()Ljava/lang/String;
+	public final fun getDescription ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun getDescriptionFacets ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun getDid-UyB9Nic ()Ljava/lang/String;
+	public final fun getDisplayName ()Ljava/lang/String;
+	public final fun getLabels ()Lio/github/kikin81/atproto/runtime/AtField;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/feed/Generator$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/feed/Generator$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/feed/Generator;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/feed/Generator;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/Generator$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class io/github/kikin81/atproto/app/bsky/feed/GeneratorLabelsUnion : io/github/kikin81/atproto/runtime/OpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/GeneratorLabelsUnion$Companion;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/GeneratorLabelsUnion$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/GeneratorLabelsUnion$Unknown : io/github/kikin81/atproto/app/bsky/feed/GeneratorLabelsUnion, io/github/kikin81/atproto/runtime/UnknownOpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/GeneratorLabelsUnion$Unknown$Companion;
+	public fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/app/bsky/feed/GeneratorLabelsUnion$Unknown;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/feed/GeneratorLabelsUnion$Unknown;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/feed/GeneratorLabelsUnion$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getRaw ()Lkotlinx/serialization/json/JsonObject;
+	public fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/GeneratorLabelsUnion$Unknown$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/GeneratorLabelsUnionSerializer : io/github/kikin81/atproto/runtime/OpenUnionSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/feed/GeneratorLabelsUnionSerializer;
+	public fun selectKnownDeserializer (Ljava/lang/String;)Lkotlinx/serialization/KSerializer;
+	public fun selectKnownSerializer (Lio/github/kikin81/atproto/app/bsky/feed/GeneratorLabelsUnion;)Lkotlinx/serialization/KSerializer;
+	public synthetic fun selectKnownSerializer (Lio/github/kikin81/atproto/runtime/OpenUnionMember;)Lkotlinx/serialization/KSerializer;
+	public fun unknownSerializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/GeneratorLabelsUnionUnknownSerializer : io/github/kikin81/atproto/runtime/UnknownMemberSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/feed/GeneratorLabelsUnionUnknownSerializer;
+	public fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/app/bsky/feed/GeneratorLabelsUnion$Unknown;
+	public synthetic fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/runtime/UnknownOpenUnionMember;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/GeneratorView : io/github/kikin81/atproto/app/bsky/embed/RecordViewRecordUnion {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/GeneratorView$Companion;
+	public synthetic fun <init> (Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/actor/ProfileView;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/Long;Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/feed/GeneratorViewerState;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/actor/ProfileView;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/Long;Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/feed/GeneratorViewerState;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Boolean;
+	public final fun component10-DnBUIck ()Ljava/lang/String;
+	public final fun component11 ()Ljava/util/List;
+	public final fun component12 ()Ljava/lang/Long;
+	public final fun component13-GUXd3rc ()Ljava/lang/String;
+	public final fun component14 ()Lio/github/kikin81/atproto/app/bsky/feed/GeneratorViewerState;
+	public final fun component2-Eo6btPk ()Ljava/lang/String;
+	public final fun component3-LVDfoeI ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Lio/github/kikin81/atproto/app/bsky/actor/ProfileView;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/util/List;
+	public final fun component8-UyB9Nic ()Ljava/lang/String;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy-TvRc9eU (Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/actor/ProfileView;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/Long;Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/feed/GeneratorViewerState;)Lio/github/kikin81/atproto/app/bsky/feed/GeneratorView;
+	public static synthetic fun copy-TvRc9eU$default (Lio/github/kikin81/atproto/app/bsky/feed/GeneratorView;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/actor/ProfileView;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/Long;Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/feed/GeneratorViewerState;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/feed/GeneratorView;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAcceptsInteractions ()Ljava/lang/Boolean;
+	public final fun getAvatar-Eo6btPk ()Ljava/lang/String;
+	public final fun getCid-LVDfoeI ()Ljava/lang/String;
+	public final fun getContentMode ()Ljava/lang/String;
+	public final fun getCreator ()Lio/github/kikin81/atproto/app/bsky/actor/ProfileView;
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getDescriptionFacets ()Ljava/util/List;
+	public final fun getDid-UyB9Nic ()Ljava/lang/String;
+	public final fun getDisplayName ()Ljava/lang/String;
+	public final fun getIndexedAt-DnBUIck ()Ljava/lang/String;
+	public final fun getLabels ()Ljava/util/List;
+	public final fun getLikeCount ()Ljava/lang/Long;
+	public final fun getUri-GUXd3rc ()Ljava/lang/String;
+	public final fun getViewer ()Lio/github/kikin81/atproto/app/bsky/feed/GeneratorViewerState;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/feed/GeneratorView$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/feed/GeneratorView$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/feed/GeneratorView;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/feed/GeneratorView;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/GeneratorView$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/GeneratorViewerState {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/GeneratorViewerState$Companion;
+	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-XX8z880 ()Ljava/lang/String;
+	public final fun copy-c7AqoAI (Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/feed/GeneratorViewerState;
+	public static synthetic fun copy-c7AqoAI$default (Lio/github/kikin81/atproto/app/bsky/feed/GeneratorViewerState;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/feed/GeneratorViewerState;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getLike-XX8z880 ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/feed/GeneratorViewerState$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/feed/GeneratorViewerState$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/feed/GeneratorViewerState;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/feed/GeneratorViewerState;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/GeneratorViewerState$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/GetAuthorFeedRequest {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/GetAuthorFeedRequest$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Long;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Long;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-mlEIfv0 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/Boolean;
+	public final fun component5 ()Ljava/lang/Long;
+	public final fun copy-Z9mp-3I (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Long;)Lio/github/kikin81/atproto/app/bsky/feed/GetAuthorFeedRequest;
+	public static synthetic fun copy-Z9mp-3I$default (Lio/github/kikin81/atproto/app/bsky/feed/GetAuthorFeedRequest;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Long;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/feed/GetAuthorFeedRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActor-mlEIfv0 ()Ljava/lang/String;
+	public final fun getCursor ()Ljava/lang/String;
+	public final fun getFilter ()Ljava/lang/String;
+	public final fun getIncludePins ()Ljava/lang/Boolean;
+	public final fun getLimit ()Ljava/lang/Long;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/feed/GetAuthorFeedRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/feed/GetAuthorFeedRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/feed/GetAuthorFeedRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/feed/GetAuthorFeedRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/GetAuthorFeedRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/GetAuthorFeedResponse {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/GetAuthorFeedResponse$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;)Lio/github/kikin81/atproto/app/bsky/feed/GetAuthorFeedResponse;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/feed/GetAuthorFeedResponse;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/feed/GetAuthorFeedResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCursor ()Ljava/lang/String;
+	public final fun getFeed ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/feed/GetAuthorFeedResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/feed/GetAuthorFeedResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/feed/GetAuthorFeedResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/feed/GetAuthorFeedResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/GetAuthorFeedResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/GetFeedGeneratorRequest {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/GetFeedGeneratorRequest$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-GUXd3rc ()Ljava/lang/String;
+	public final fun copy-wvBT1Tk (Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/feed/GetFeedGeneratorRequest;
+	public static synthetic fun copy-wvBT1Tk$default (Lio/github/kikin81/atproto/app/bsky/feed/GetFeedGeneratorRequest;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/feed/GetFeedGeneratorRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFeed-GUXd3rc ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/feed/GetFeedGeneratorRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/feed/GetFeedGeneratorRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/feed/GetFeedGeneratorRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/feed/GetFeedGeneratorRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/GetFeedGeneratorRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/GetFeedGeneratorResponse {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/GetFeedGeneratorResponse$Companion;
+	public fun <init> (ZZLio/github/kikin81/atproto/app/bsky/feed/GeneratorView;)V
+	public final fun component1 ()Z
+	public final fun component2 ()Z
+	public final fun component3 ()Lio/github/kikin81/atproto/app/bsky/feed/GeneratorView;
+	public final fun copy (ZZLio/github/kikin81/atproto/app/bsky/feed/GeneratorView;)Lio/github/kikin81/atproto/app/bsky/feed/GetFeedGeneratorResponse;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/feed/GetFeedGeneratorResponse;ZZLio/github/kikin81/atproto/app/bsky/feed/GeneratorView;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/feed/GetFeedGeneratorResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getView ()Lio/github/kikin81/atproto/app/bsky/feed/GeneratorView;
+	public fun hashCode ()I
+	public final fun isOnline ()Z
+	public final fun isValid ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/feed/GetFeedGeneratorResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/feed/GetFeedGeneratorResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/feed/GetFeedGeneratorResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/feed/GetFeedGeneratorResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/GetFeedGeneratorResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/GetFeedRequest {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/GetFeedRequest$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2-GUXd3rc ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/Long;
+	public final fun copy-8bHy5hw (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;)Lio/github/kikin81/atproto/app/bsky/feed/GetFeedRequest;
+	public static synthetic fun copy-8bHy5hw$default (Lio/github/kikin81/atproto/app/bsky/feed/GetFeedRequest;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/feed/GetFeedRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCursor ()Ljava/lang/String;
+	public final fun getFeed-GUXd3rc ()Ljava/lang/String;
+	public final fun getLimit ()Ljava/lang/Long;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/feed/GetFeedRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/feed/GetFeedRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/feed/GetFeedRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/feed/GetFeedRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/GetFeedRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/GetFeedResponse {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/GetFeedResponse$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;)Lio/github/kikin81/atproto/app/bsky/feed/GetFeedResponse;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/feed/GetFeedResponse;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/feed/GetFeedResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCursor ()Ljava/lang/String;
+	public final fun getFeed ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/feed/GetFeedResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/feed/GetFeedResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/feed/GetFeedResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/feed/GetFeedResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/GetFeedResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/GetLikesLike {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/GetLikesLike$Companion;
+	public synthetic fun <init> (Lio/github/kikin81/atproto/app/bsky/actor/ProfileView;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/app/bsky/actor/ProfileView;
+	public final fun component2-DnBUIck ()Ljava/lang/String;
+	public final fun component3-DnBUIck ()Ljava/lang/String;
+	public final fun copy-Rwuc928 (Lio/github/kikin81/atproto/app/bsky/actor/ProfileView;Ljava/lang/String;Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/feed/GetLikesLike;
+	public static synthetic fun copy-Rwuc928$default (Lio/github/kikin81/atproto/app/bsky/feed/GetLikesLike;Lio/github/kikin81/atproto/app/bsky/actor/ProfileView;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/feed/GetLikesLike;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActor ()Lio/github/kikin81/atproto/app/bsky/actor/ProfileView;
+	public final fun getCreatedAt-DnBUIck ()Ljava/lang/String;
+	public final fun getIndexedAt-DnBUIck ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/feed/GetLikesLike$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/feed/GetLikesLike$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/feed/GetLikesLike;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/feed/GetLikesLike;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/GetLikesLike$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/GetLikesRequest {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/GetLikesRequest$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-eL7R55w ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/Long;
+	public final fun component4-GUXd3rc ()Ljava/lang/String;
+	public final fun copy-AI9TaXU (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/feed/GetLikesRequest;
+	public static synthetic fun copy-AI9TaXU$default (Lio/github/kikin81/atproto/app/bsky/feed/GetLikesRequest;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/feed/GetLikesRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCid-eL7R55w ()Ljava/lang/String;
+	public final fun getCursor ()Ljava/lang/String;
+	public final fun getLimit ()Ljava/lang/Long;
+	public final fun getUri-GUXd3rc ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/feed/GetLikesRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/feed/GetLikesRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/feed/GetLikesRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/feed/GetLikesRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/GetLikesRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/GetLikesResponse {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/GetLikesResponse$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-eL7R55w ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4-GUXd3rc ()Ljava/lang/String;
+	public final fun copy-AI9TaXU (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/feed/GetLikesResponse;
+	public static synthetic fun copy-AI9TaXU$default (Lio/github/kikin81/atproto/app/bsky/feed/GetLikesResponse;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/feed/GetLikesResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCid-eL7R55w ()Ljava/lang/String;
+	public final fun getCursor ()Ljava/lang/String;
+	public final fun getLikes ()Ljava/util/List;
+	public final fun getUri-GUXd3rc ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/feed/GetLikesResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/feed/GetLikesResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/feed/GetLikesResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/feed/GetLikesResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/GetLikesResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/GetPostThreadRequest {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/GetPostThreadRequest$Companion;
+	public synthetic fun <init> (Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Long;
+	public final fun component2 ()Ljava/lang/Long;
+	public final fun component3-GUXd3rc ()Ljava/lang/String;
+	public final fun copy-SUTmSSk (Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/feed/GetPostThreadRequest;
+	public static synthetic fun copy-SUTmSSk$default (Lio/github/kikin81/atproto/app/bsky/feed/GetPostThreadRequest;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/feed/GetPostThreadRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDepth ()Ljava/lang/Long;
+	public final fun getParentHeight ()Ljava/lang/Long;
+	public final fun getUri-GUXd3rc ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/feed/GetPostThreadRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/feed/GetPostThreadRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/feed/GetPostThreadRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/feed/GetPostThreadRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/GetPostThreadRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/GetPostThreadResponse {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/GetPostThreadResponse$Companion;
+	public fun <init> (Lio/github/kikin81/atproto/app/bsky/feed/GetPostThreadResponseThreadUnion;Lio/github/kikin81/atproto/app/bsky/feed/ThreadgateView;)V
+	public synthetic fun <init> (Lio/github/kikin81/atproto/app/bsky/feed/GetPostThreadResponseThreadUnion;Lio/github/kikin81/atproto/app/bsky/feed/ThreadgateView;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/app/bsky/feed/GetPostThreadResponseThreadUnion;
+	public final fun component2 ()Lio/github/kikin81/atproto/app/bsky/feed/ThreadgateView;
+	public final fun copy (Lio/github/kikin81/atproto/app/bsky/feed/GetPostThreadResponseThreadUnion;Lio/github/kikin81/atproto/app/bsky/feed/ThreadgateView;)Lio/github/kikin81/atproto/app/bsky/feed/GetPostThreadResponse;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/feed/GetPostThreadResponse;Lio/github/kikin81/atproto/app/bsky/feed/GetPostThreadResponseThreadUnion;Lio/github/kikin81/atproto/app/bsky/feed/ThreadgateView;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/feed/GetPostThreadResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getThread ()Lio/github/kikin81/atproto/app/bsky/feed/GetPostThreadResponseThreadUnion;
+	public final fun getThreadgate ()Lio/github/kikin81/atproto/app/bsky/feed/ThreadgateView;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/feed/GetPostThreadResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/feed/GetPostThreadResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/feed/GetPostThreadResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/feed/GetPostThreadResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/GetPostThreadResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class io/github/kikin81/atproto/app/bsky/feed/GetPostThreadResponseThreadUnion : io/github/kikin81/atproto/runtime/OpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/GetPostThreadResponseThreadUnion$Companion;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/GetPostThreadResponseThreadUnion$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/GetPostThreadResponseThreadUnion$Unknown : io/github/kikin81/atproto/app/bsky/feed/GetPostThreadResponseThreadUnion, io/github/kikin81/atproto/runtime/UnknownOpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/GetPostThreadResponseThreadUnion$Unknown$Companion;
+	public fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/app/bsky/feed/GetPostThreadResponseThreadUnion$Unknown;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/feed/GetPostThreadResponseThreadUnion$Unknown;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/feed/GetPostThreadResponseThreadUnion$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getRaw ()Lkotlinx/serialization/json/JsonObject;
+	public fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/GetPostThreadResponseThreadUnion$Unknown$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/GetPostThreadResponseThreadUnionSerializer : io/github/kikin81/atproto/runtime/OpenUnionSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/feed/GetPostThreadResponseThreadUnionSerializer;
+	public fun selectKnownDeserializer (Ljava/lang/String;)Lkotlinx/serialization/KSerializer;
+	public fun selectKnownSerializer (Lio/github/kikin81/atproto/app/bsky/feed/GetPostThreadResponseThreadUnion;)Lkotlinx/serialization/KSerializer;
+	public synthetic fun selectKnownSerializer (Lio/github/kikin81/atproto/runtime/OpenUnionMember;)Lkotlinx/serialization/KSerializer;
+	public fun unknownSerializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/GetPostThreadResponseThreadUnionUnknownSerializer : io/github/kikin81/atproto/runtime/UnknownMemberSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/feed/GetPostThreadResponseThreadUnionUnknownSerializer;
+	public fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/app/bsky/feed/GetPostThreadResponseThreadUnion$Unknown;
+	public synthetic fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/runtime/UnknownOpenUnionMember;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/GetPostsRequest {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/GetPostsRequest$Companion;
+	public fun <init> (Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lio/github/kikin81/atproto/app/bsky/feed/GetPostsRequest;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/feed/GetPostsRequest;Ljava/util/List;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/feed/GetPostsRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUris ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/feed/GetPostsRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/feed/GetPostsRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/feed/GetPostsRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/feed/GetPostsRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/GetPostsRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/GetPostsResponse {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/GetPostsResponse$Companion;
+	public fun <init> (Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lio/github/kikin81/atproto/app/bsky/feed/GetPostsResponse;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/feed/GetPostsResponse;Ljava/util/List;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/feed/GetPostsResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPosts ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/feed/GetPostsResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/feed/GetPostsResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/feed/GetPostsResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/feed/GetPostsResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/GetPostsResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/GetRepostedByRequest {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/GetRepostedByRequest$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-eL7R55w ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/Long;
+	public final fun component4-GUXd3rc ()Ljava/lang/String;
+	public final fun copy-AI9TaXU (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/feed/GetRepostedByRequest;
+	public static synthetic fun copy-AI9TaXU$default (Lio/github/kikin81/atproto/app/bsky/feed/GetRepostedByRequest;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/feed/GetRepostedByRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCid-eL7R55w ()Ljava/lang/String;
+	public final fun getCursor ()Ljava/lang/String;
+	public final fun getLimit ()Ljava/lang/Long;
+	public final fun getUri-GUXd3rc ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/feed/GetRepostedByRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/feed/GetRepostedByRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/feed/GetRepostedByRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/feed/GetRepostedByRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/GetRepostedByRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/GetRepostedByResponse {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/GetRepostedByResponse$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-eL7R55w ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4-GUXd3rc ()Ljava/lang/String;
+	public final fun copy-AI9TaXU (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/feed/GetRepostedByResponse;
+	public static synthetic fun copy-AI9TaXU$default (Lio/github/kikin81/atproto/app/bsky/feed/GetRepostedByResponse;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/feed/GetRepostedByResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCid-eL7R55w ()Ljava/lang/String;
+	public final fun getCursor ()Ljava/lang/String;
+	public final fun getRepostedBy ()Ljava/util/List;
+	public final fun getUri-GUXd3rc ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/feed/GetRepostedByResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/feed/GetRepostedByResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/feed/GetRepostedByResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/feed/GetRepostedByResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/GetRepostedByResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/GetTimelineRequest {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/GetTimelineRequest$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/Long;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;)Lio/github/kikin81/atproto/app/bsky/feed/GetTimelineRequest;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/feed/GetTimelineRequest;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/feed/GetTimelineRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAlgorithm ()Ljava/lang/String;
+	public final fun getCursor ()Ljava/lang/String;
+	public final fun getLimit ()Ljava/lang/Long;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/feed/GetTimelineRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/feed/GetTimelineRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/feed/GetTimelineRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/feed/GetTimelineRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/GetTimelineRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/GetTimelineResponse {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/GetTimelineResponse$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;)Lio/github/kikin81/atproto/app/bsky/feed/GetTimelineResponse;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/feed/GetTimelineResponse;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/feed/GetTimelineResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCursor ()Ljava/lang/String;
+	public final fun getFeed ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/feed/GetTimelineResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/feed/GetTimelineResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/feed/GetTimelineResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/feed/GetTimelineResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/GetTimelineResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/Interaction {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/Interaction$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3-XX8z880 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy-JtRxwYQ (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/feed/Interaction;
+	public static synthetic fun copy-JtRxwYQ$default (Lio/github/kikin81/atproto/app/bsky/feed/Interaction;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/feed/Interaction;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEvent ()Ljava/lang/String;
+	public final fun getFeedContext ()Ljava/lang/String;
+	public final fun getItem-XX8z880 ()Ljava/lang/String;
+	public final fun getReqId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/feed/Interaction$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/feed/Interaction$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/feed/Interaction;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/feed/Interaction;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/Interaction$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/Like {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/Like$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/com/atproto/repo/StrongRef;Lio/github/kikin81/atproto/runtime/AtField;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/com/atproto/repo/StrongRef;Lio/github/kikin81/atproto/runtime/AtField;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-DnBUIck ()Ljava/lang/String;
+	public final fun component2 ()Lio/github/kikin81/atproto/com/atproto/repo/StrongRef;
+	public final fun component3 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun copy-znBggmM (Ljava/lang/String;Lio/github/kikin81/atproto/com/atproto/repo/StrongRef;Lio/github/kikin81/atproto/runtime/AtField;)Lio/github/kikin81/atproto/app/bsky/feed/Like;
+	public static synthetic fun copy-znBggmM$default (Lio/github/kikin81/atproto/app/bsky/feed/Like;Ljava/lang/String;Lio/github/kikin81/atproto/com/atproto/repo/StrongRef;Lio/github/kikin81/atproto/runtime/AtField;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/feed/Like;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCreatedAt-DnBUIck ()Ljava/lang/String;
+	public final fun getSubject ()Lio/github/kikin81/atproto/com/atproto/repo/StrongRef;
+	public final fun getVia ()Lio/github/kikin81/atproto/runtime/AtField;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/feed/Like$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/feed/Like$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/feed/Like;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/feed/Like;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/Like$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/NotFoundPost : io/github/kikin81/atproto/app/bsky/feed/GetPostThreadResponseThreadUnion, io/github/kikin81/atproto/app/bsky/feed/ReplyRefParentUnion, io/github/kikin81/atproto/app/bsky/feed/ReplyRefRootUnion, io/github/kikin81/atproto/app/bsky/feed/ThreadViewPostParentUnion, io/github/kikin81/atproto/app/bsky/feed/ThreadViewPostRepliesUnion {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/NotFoundPost$Companion;
+	public synthetic fun <init> (ZLjava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun component2-GUXd3rc ()Ljava/lang/String;
+	public final fun copy-HnpCerU (ZLjava/lang/String;)Lio/github/kikin81/atproto/app/bsky/feed/NotFoundPost;
+	public static synthetic fun copy-HnpCerU$default (Lio/github/kikin81/atproto/app/bsky/feed/NotFoundPost;ZLjava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/feed/NotFoundPost;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getNotFound ()Z
+	public final fun getUri-GUXd3rc ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/feed/NotFoundPost$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/feed/NotFoundPost$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/feed/NotFoundPost;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/feed/NotFoundPost;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/NotFoundPost$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/Post {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/Post$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-DnBUIck ()Ljava/lang/String;
+	public final fun component2 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun component3 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun component4 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun component5 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun component6 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun component7 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun component8 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy-nfOqpjM (Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/feed/Post;
+	public static synthetic fun copy-nfOqpjM$default (Lio/github/kikin81/atproto/app/bsky/feed/Post;Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/feed/Post;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCreatedAt-DnBUIck ()Ljava/lang/String;
+	public final fun getEmbed ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun getEntities ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun getFacets ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun getLabels ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun getLangs ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun getReply ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun getTags ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun getText ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/feed/Post$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/feed/Post$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/feed/Post;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/feed/Post;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/Post$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class io/github/kikin81/atproto/app/bsky/feed/PostEmbedUnion : io/github/kikin81/atproto/runtime/OpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/PostEmbedUnion$Companion;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/PostEmbedUnion$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/PostEmbedUnion$Unknown : io/github/kikin81/atproto/app/bsky/feed/PostEmbedUnion, io/github/kikin81/atproto/runtime/UnknownOpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/PostEmbedUnion$Unknown$Companion;
+	public fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/app/bsky/feed/PostEmbedUnion$Unknown;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/feed/PostEmbedUnion$Unknown;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/feed/PostEmbedUnion$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getRaw ()Lkotlinx/serialization/json/JsonObject;
+	public fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/PostEmbedUnion$Unknown$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/PostEmbedUnionSerializer : io/github/kikin81/atproto/runtime/OpenUnionSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/feed/PostEmbedUnionSerializer;
+	public fun selectKnownDeserializer (Ljava/lang/String;)Lkotlinx/serialization/KSerializer;
+	public fun selectKnownSerializer (Lio/github/kikin81/atproto/app/bsky/feed/PostEmbedUnion;)Lkotlinx/serialization/KSerializer;
+	public synthetic fun selectKnownSerializer (Lio/github/kikin81/atproto/runtime/OpenUnionMember;)Lkotlinx/serialization/KSerializer;
+	public fun unknownSerializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/PostEmbedUnionUnknownSerializer : io/github/kikin81/atproto/runtime/UnknownMemberSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/feed/PostEmbedUnionUnknownSerializer;
+	public fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/app/bsky/feed/PostEmbedUnion$Unknown;
+	public synthetic fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/runtime/UnknownOpenUnionMember;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/PostEntity {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/PostEntity$Companion;
+	public fun <init> (Lio/github/kikin81/atproto/app/bsky/feed/PostTextSlice;Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/app/bsky/feed/PostTextSlice;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Lio/github/kikin81/atproto/app/bsky/feed/PostTextSlice;Ljava/lang/String;Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/feed/PostEntity;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/feed/PostEntity;Lio/github/kikin81/atproto/app/bsky/feed/PostTextSlice;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/feed/PostEntity;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getIndex ()Lio/github/kikin81/atproto/app/bsky/feed/PostTextSlice;
+	public final fun getType ()Ljava/lang/String;
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/feed/PostEntity$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/feed/PostEntity$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/feed/PostEntity;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/feed/PostEntity;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/PostEntity$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class io/github/kikin81/atproto/app/bsky/feed/PostLabelsUnion : io/github/kikin81/atproto/runtime/OpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/PostLabelsUnion$Companion;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/PostLabelsUnion$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/PostLabelsUnion$Unknown : io/github/kikin81/atproto/app/bsky/feed/PostLabelsUnion, io/github/kikin81/atproto/runtime/UnknownOpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/PostLabelsUnion$Unknown$Companion;
+	public fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/app/bsky/feed/PostLabelsUnion$Unknown;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/feed/PostLabelsUnion$Unknown;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/feed/PostLabelsUnion$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getRaw ()Lkotlinx/serialization/json/JsonObject;
+	public fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/PostLabelsUnion$Unknown$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/PostLabelsUnionSerializer : io/github/kikin81/atproto/runtime/OpenUnionSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/feed/PostLabelsUnionSerializer;
+	public fun selectKnownDeserializer (Ljava/lang/String;)Lkotlinx/serialization/KSerializer;
+	public fun selectKnownSerializer (Lio/github/kikin81/atproto/app/bsky/feed/PostLabelsUnion;)Lkotlinx/serialization/KSerializer;
+	public synthetic fun selectKnownSerializer (Lio/github/kikin81/atproto/runtime/OpenUnionMember;)Lkotlinx/serialization/KSerializer;
+	public fun unknownSerializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/PostLabelsUnionUnknownSerializer : io/github/kikin81/atproto/runtime/UnknownMemberSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/feed/PostLabelsUnionUnknownSerializer;
+	public fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/app/bsky/feed/PostLabelsUnion$Unknown;
+	public synthetic fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/runtime/UnknownOpenUnionMember;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/PostReplyRef {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/PostReplyRef$Companion;
+	public fun <init> (Lio/github/kikin81/atproto/com/atproto/repo/StrongRef;Lio/github/kikin81/atproto/com/atproto/repo/StrongRef;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/com/atproto/repo/StrongRef;
+	public final fun component2 ()Lio/github/kikin81/atproto/com/atproto/repo/StrongRef;
+	public final fun copy (Lio/github/kikin81/atproto/com/atproto/repo/StrongRef;Lio/github/kikin81/atproto/com/atproto/repo/StrongRef;)Lio/github/kikin81/atproto/app/bsky/feed/PostReplyRef;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/feed/PostReplyRef;Lio/github/kikin81/atproto/com/atproto/repo/StrongRef;Lio/github/kikin81/atproto/com/atproto/repo/StrongRef;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/feed/PostReplyRef;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getParent ()Lio/github/kikin81/atproto/com/atproto/repo/StrongRef;
+	public final fun getRoot ()Lio/github/kikin81/atproto/com/atproto/repo/StrongRef;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/feed/PostReplyRef$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/feed/PostReplyRef$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/feed/PostReplyRef;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/feed/PostReplyRef;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/PostReplyRef$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/PostTextSlice {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/PostTextSlice$Companion;
+	public fun <init> (JJ)V
+	public final fun component1 ()J
+	public final fun component2 ()J
+	public final fun copy (JJ)Lio/github/kikin81/atproto/app/bsky/feed/PostTextSlice;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/feed/PostTextSlice;JJILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/feed/PostTextSlice;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEnd ()J
+	public final fun getStart ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/feed/PostTextSlice$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/feed/PostTextSlice$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/feed/PostTextSlice;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/feed/PostTextSlice;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/PostTextSlice$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/PostView : io/github/kikin81/atproto/app/bsky/feed/ReplyRefParentUnion, io/github/kikin81/atproto/app/bsky/feed/ReplyRefRootUnion {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/PostView$Companion;
+	public synthetic fun <init> (Lio/github/kikin81/atproto/app/bsky/actor/ProfileViewBasic;Ljava/lang/Long;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Lio/github/kikin81/atproto/app/bsky/feed/PostViewEmbedUnion;Ljava/lang/String;Ljava/util/List;Ljava/lang/Long;Ljava/lang/Long;Lkotlinx/serialization/json/JsonObject;Ljava/lang/Long;Ljava/lang/Long;Lio/github/kikin81/atproto/app/bsky/feed/ThreadgateView;Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/feed/ViewerState;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lio/github/kikin81/atproto/app/bsky/actor/ProfileViewBasic;Ljava/lang/Long;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Lio/github/kikin81/atproto/app/bsky/feed/PostViewEmbedUnion;Ljava/lang/String;Ljava/util/List;Ljava/lang/Long;Ljava/lang/Long;Lkotlinx/serialization/json/JsonObject;Ljava/lang/Long;Ljava/lang/Long;Lio/github/kikin81/atproto/app/bsky/feed/ThreadgateView;Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/feed/ViewerState;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/app/bsky/actor/ProfileViewBasic;
+	public final fun component10 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun component11 ()Ljava/lang/Long;
+	public final fun component12 ()Ljava/lang/Long;
+	public final fun component13 ()Lio/github/kikin81/atproto/app/bsky/feed/ThreadgateView;
+	public final fun component14-GUXd3rc ()Ljava/lang/String;
+	public final fun component15 ()Lio/github/kikin81/atproto/app/bsky/feed/ViewerState;
+	public final fun component2 ()Ljava/lang/Long;
+	public final fun component3-LVDfoeI ()Ljava/lang/String;
+	public final fun component4 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun component5 ()Lio/github/kikin81/atproto/app/bsky/feed/PostViewEmbedUnion;
+	public final fun component6-DnBUIck ()Ljava/lang/String;
+	public final fun component7 ()Ljava/util/List;
+	public final fun component8 ()Ljava/lang/Long;
+	public final fun component9 ()Ljava/lang/Long;
+	public final fun copy-4nfzyfo (Lio/github/kikin81/atproto/app/bsky/actor/ProfileViewBasic;Ljava/lang/Long;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Lio/github/kikin81/atproto/app/bsky/feed/PostViewEmbedUnion;Ljava/lang/String;Ljava/util/List;Ljava/lang/Long;Ljava/lang/Long;Lkotlinx/serialization/json/JsonObject;Ljava/lang/Long;Ljava/lang/Long;Lio/github/kikin81/atproto/app/bsky/feed/ThreadgateView;Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/feed/ViewerState;)Lio/github/kikin81/atproto/app/bsky/feed/PostView;
+	public static synthetic fun copy-4nfzyfo$default (Lio/github/kikin81/atproto/app/bsky/feed/PostView;Lio/github/kikin81/atproto/app/bsky/actor/ProfileViewBasic;Ljava/lang/Long;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Lio/github/kikin81/atproto/app/bsky/feed/PostViewEmbedUnion;Ljava/lang/String;Ljava/util/List;Ljava/lang/Long;Ljava/lang/Long;Lkotlinx/serialization/json/JsonObject;Ljava/lang/Long;Ljava/lang/Long;Lio/github/kikin81/atproto/app/bsky/feed/ThreadgateView;Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/feed/ViewerState;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/feed/PostView;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAuthor ()Lio/github/kikin81/atproto/app/bsky/actor/ProfileViewBasic;
+	public final fun getBookmarkCount ()Ljava/lang/Long;
+	public final fun getCid-LVDfoeI ()Ljava/lang/String;
+	public final fun getDebug ()Lkotlinx/serialization/json/JsonObject;
+	public final fun getEmbed ()Lio/github/kikin81/atproto/app/bsky/feed/PostViewEmbedUnion;
+	public final fun getIndexedAt-DnBUIck ()Ljava/lang/String;
+	public final fun getLabels ()Ljava/util/List;
+	public final fun getLikeCount ()Ljava/lang/Long;
+	public final fun getQuoteCount ()Ljava/lang/Long;
+	public final fun getRecord ()Lkotlinx/serialization/json/JsonObject;
+	public final fun getReplyCount ()Ljava/lang/Long;
+	public final fun getRepostCount ()Ljava/lang/Long;
+	public final fun getThreadgate ()Lio/github/kikin81/atproto/app/bsky/feed/ThreadgateView;
+	public final fun getUri-GUXd3rc ()Ljava/lang/String;
+	public final fun getViewer ()Lio/github/kikin81/atproto/app/bsky/feed/ViewerState;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/feed/PostView$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/feed/PostView$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/feed/PostView;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/feed/PostView;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/PostView$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class io/github/kikin81/atproto/app/bsky/feed/PostViewEmbedUnion : io/github/kikin81/atproto/runtime/OpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/PostViewEmbedUnion$Companion;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/PostViewEmbedUnion$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/PostViewEmbedUnion$Unknown : io/github/kikin81/atproto/app/bsky/feed/PostViewEmbedUnion, io/github/kikin81/atproto/runtime/UnknownOpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/PostViewEmbedUnion$Unknown$Companion;
+	public fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/app/bsky/feed/PostViewEmbedUnion$Unknown;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/feed/PostViewEmbedUnion$Unknown;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/feed/PostViewEmbedUnion$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getRaw ()Lkotlinx/serialization/json/JsonObject;
+	public fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/PostViewEmbedUnion$Unknown$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/PostViewEmbedUnionSerializer : io/github/kikin81/atproto/runtime/OpenUnionSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/feed/PostViewEmbedUnionSerializer;
+	public fun selectKnownDeserializer (Ljava/lang/String;)Lkotlinx/serialization/KSerializer;
+	public fun selectKnownSerializer (Lio/github/kikin81/atproto/app/bsky/feed/PostViewEmbedUnion;)Lkotlinx/serialization/KSerializer;
+	public synthetic fun selectKnownSerializer (Lio/github/kikin81/atproto/runtime/OpenUnionMember;)Lkotlinx/serialization/KSerializer;
+	public fun unknownSerializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/PostViewEmbedUnionUnknownSerializer : io/github/kikin81/atproto/runtime/UnknownMemberSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/feed/PostViewEmbedUnionUnknownSerializer;
+	public fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/app/bsky/feed/PostViewEmbedUnion$Unknown;
+	public synthetic fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/runtime/UnknownOpenUnionMember;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/Postgate {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/Postgate$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-DnBUIck ()Ljava/lang/String;
+	public final fun component2 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun component3 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun component4-GUXd3rc ()Ljava/lang/String;
+	public final fun copy-W7JLGTU (Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/feed/Postgate;
+	public static synthetic fun copy-W7JLGTU$default (Lio/github/kikin81/atproto/app/bsky/feed/Postgate;Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/feed/Postgate;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCreatedAt-DnBUIck ()Ljava/lang/String;
+	public final fun getDetachedEmbeddingUris ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun getEmbeddingRules ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun getPost-GUXd3rc ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/feed/Postgate$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/feed/Postgate$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/feed/Postgate;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/feed/Postgate;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/Postgate$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/PostgateDisableRule : io/github/kikin81/atproto/app/bsky/actor/PostInteractionSettingsPrefPostgateEmbeddingRulesUnion, io/github/kikin81/atproto/app/bsky/feed/PostgateEmbeddingRulesUnion {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/PostgateDisableRule$Companion;
+	public fun <init> ()V
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/feed/PostgateDisableRule$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/feed/PostgateDisableRule$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/feed/PostgateDisableRule;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/feed/PostgateDisableRule;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/PostgateDisableRule$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class io/github/kikin81/atproto/app/bsky/feed/PostgateEmbeddingRulesUnion : io/github/kikin81/atproto/runtime/OpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/PostgateEmbeddingRulesUnion$Companion;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/PostgateEmbeddingRulesUnion$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/PostgateEmbeddingRulesUnion$Unknown : io/github/kikin81/atproto/app/bsky/feed/PostgateEmbeddingRulesUnion, io/github/kikin81/atproto/runtime/UnknownOpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/PostgateEmbeddingRulesUnion$Unknown$Companion;
+	public fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/app/bsky/feed/PostgateEmbeddingRulesUnion$Unknown;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/feed/PostgateEmbeddingRulesUnion$Unknown;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/feed/PostgateEmbeddingRulesUnion$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getRaw ()Lkotlinx/serialization/json/JsonObject;
+	public fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/PostgateEmbeddingRulesUnion$Unknown$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/PostgateEmbeddingRulesUnionSerializer : io/github/kikin81/atproto/runtime/OpenUnionSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/feed/PostgateEmbeddingRulesUnionSerializer;
+	public fun selectKnownDeserializer (Ljava/lang/String;)Lkotlinx/serialization/KSerializer;
+	public fun selectKnownSerializer (Lio/github/kikin81/atproto/app/bsky/feed/PostgateEmbeddingRulesUnion;)Lkotlinx/serialization/KSerializer;
+	public synthetic fun selectKnownSerializer (Lio/github/kikin81/atproto/runtime/OpenUnionMember;)Lkotlinx/serialization/KSerializer;
+	public fun unknownSerializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/PostgateEmbeddingRulesUnionUnknownSerializer : io/github/kikin81/atproto/runtime/UnknownMemberSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/feed/PostgateEmbeddingRulesUnionUnknownSerializer;
+	public fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/app/bsky/feed/PostgateEmbeddingRulesUnion$Unknown;
+	public synthetic fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/runtime/UnknownOpenUnionMember;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/ReasonPin : io/github/kikin81/atproto/app/bsky/feed/FeedViewPostReasonUnion {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/ReasonPin$Companion;
+	public fun <init> ()V
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/feed/ReasonPin$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/feed/ReasonPin$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/feed/ReasonPin;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/feed/ReasonPin;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/ReasonPin$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/ReasonRepost : io/github/kikin81/atproto/app/bsky/feed/FeedViewPostReasonUnion {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/ReasonRepost$Companion;
+	public synthetic fun <init> (Lio/github/kikin81/atproto/app/bsky/actor/ProfileViewBasic;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lio/github/kikin81/atproto/app/bsky/actor/ProfileViewBasic;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/app/bsky/actor/ProfileViewBasic;
+	public final fun component2-eL7R55w ()Ljava/lang/String;
+	public final fun component3-DnBUIck ()Ljava/lang/String;
+	public final fun component4-XX8z880 ()Ljava/lang/String;
+	public final fun copy-HkhFZ90 (Lio/github/kikin81/atproto/app/bsky/actor/ProfileViewBasic;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/feed/ReasonRepost;
+	public static synthetic fun copy-HkhFZ90$default (Lio/github/kikin81/atproto/app/bsky/feed/ReasonRepost;Lio/github/kikin81/atproto/app/bsky/actor/ProfileViewBasic;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/feed/ReasonRepost;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBy ()Lio/github/kikin81/atproto/app/bsky/actor/ProfileViewBasic;
+	public final fun getCid-eL7R55w ()Ljava/lang/String;
+	public final fun getIndexedAt-DnBUIck ()Ljava/lang/String;
+	public final fun getUri-XX8z880 ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/feed/ReasonRepost$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/feed/ReasonRepost$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/feed/ReasonRepost;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/feed/ReasonRepost;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/ReasonRepost$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/ReplyRef {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/ReplyRef$Companion;
+	public fun <init> (Lio/github/kikin81/atproto/app/bsky/actor/ProfileViewBasic;Lio/github/kikin81/atproto/app/bsky/feed/ReplyRefParentUnion;Lio/github/kikin81/atproto/app/bsky/feed/ReplyRefRootUnion;)V
+	public synthetic fun <init> (Lio/github/kikin81/atproto/app/bsky/actor/ProfileViewBasic;Lio/github/kikin81/atproto/app/bsky/feed/ReplyRefParentUnion;Lio/github/kikin81/atproto/app/bsky/feed/ReplyRefRootUnion;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/app/bsky/actor/ProfileViewBasic;
+	public final fun component2 ()Lio/github/kikin81/atproto/app/bsky/feed/ReplyRefParentUnion;
+	public final fun component3 ()Lio/github/kikin81/atproto/app/bsky/feed/ReplyRefRootUnion;
+	public final fun copy (Lio/github/kikin81/atproto/app/bsky/actor/ProfileViewBasic;Lio/github/kikin81/atproto/app/bsky/feed/ReplyRefParentUnion;Lio/github/kikin81/atproto/app/bsky/feed/ReplyRefRootUnion;)Lio/github/kikin81/atproto/app/bsky/feed/ReplyRef;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/feed/ReplyRef;Lio/github/kikin81/atproto/app/bsky/actor/ProfileViewBasic;Lio/github/kikin81/atproto/app/bsky/feed/ReplyRefParentUnion;Lio/github/kikin81/atproto/app/bsky/feed/ReplyRefRootUnion;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/feed/ReplyRef;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getGrandparentAuthor ()Lio/github/kikin81/atproto/app/bsky/actor/ProfileViewBasic;
+	public final fun getParent ()Lio/github/kikin81/atproto/app/bsky/feed/ReplyRefParentUnion;
+	public final fun getRoot ()Lio/github/kikin81/atproto/app/bsky/feed/ReplyRefRootUnion;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/feed/ReplyRef$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/feed/ReplyRef$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/feed/ReplyRef;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/feed/ReplyRef;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/ReplyRef$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class io/github/kikin81/atproto/app/bsky/feed/ReplyRefParentUnion : io/github/kikin81/atproto/runtime/OpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/ReplyRefParentUnion$Companion;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/ReplyRefParentUnion$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/ReplyRefParentUnion$Unknown : io/github/kikin81/atproto/app/bsky/feed/ReplyRefParentUnion, io/github/kikin81/atproto/runtime/UnknownOpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/ReplyRefParentUnion$Unknown$Companion;
+	public fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/app/bsky/feed/ReplyRefParentUnion$Unknown;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/feed/ReplyRefParentUnion$Unknown;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/feed/ReplyRefParentUnion$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getRaw ()Lkotlinx/serialization/json/JsonObject;
+	public fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/ReplyRefParentUnion$Unknown$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/ReplyRefParentUnionSerializer : io/github/kikin81/atproto/runtime/OpenUnionSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/feed/ReplyRefParentUnionSerializer;
+	public fun selectKnownDeserializer (Ljava/lang/String;)Lkotlinx/serialization/KSerializer;
+	public fun selectKnownSerializer (Lio/github/kikin81/atproto/app/bsky/feed/ReplyRefParentUnion;)Lkotlinx/serialization/KSerializer;
+	public synthetic fun selectKnownSerializer (Lio/github/kikin81/atproto/runtime/OpenUnionMember;)Lkotlinx/serialization/KSerializer;
+	public fun unknownSerializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/ReplyRefParentUnionUnknownSerializer : io/github/kikin81/atproto/runtime/UnknownMemberSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/feed/ReplyRefParentUnionUnknownSerializer;
+	public fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/app/bsky/feed/ReplyRefParentUnion$Unknown;
+	public synthetic fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/runtime/UnknownOpenUnionMember;
+}
+
+public abstract interface class io/github/kikin81/atproto/app/bsky/feed/ReplyRefRootUnion : io/github/kikin81/atproto/runtime/OpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/ReplyRefRootUnion$Companion;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/ReplyRefRootUnion$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/ReplyRefRootUnion$Unknown : io/github/kikin81/atproto/app/bsky/feed/ReplyRefRootUnion, io/github/kikin81/atproto/runtime/UnknownOpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/ReplyRefRootUnion$Unknown$Companion;
+	public fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/app/bsky/feed/ReplyRefRootUnion$Unknown;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/feed/ReplyRefRootUnion$Unknown;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/feed/ReplyRefRootUnion$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getRaw ()Lkotlinx/serialization/json/JsonObject;
+	public fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/ReplyRefRootUnion$Unknown$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/ReplyRefRootUnionSerializer : io/github/kikin81/atproto/runtime/OpenUnionSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/feed/ReplyRefRootUnionSerializer;
+	public fun selectKnownDeserializer (Ljava/lang/String;)Lkotlinx/serialization/KSerializer;
+	public fun selectKnownSerializer (Lio/github/kikin81/atproto/app/bsky/feed/ReplyRefRootUnion;)Lkotlinx/serialization/KSerializer;
+	public synthetic fun selectKnownSerializer (Lio/github/kikin81/atproto/runtime/OpenUnionMember;)Lkotlinx/serialization/KSerializer;
+	public fun unknownSerializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/ReplyRefRootUnionUnknownSerializer : io/github/kikin81/atproto/runtime/UnknownMemberSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/feed/ReplyRefRootUnionUnknownSerializer;
+	public fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/app/bsky/feed/ReplyRefRootUnion$Unknown;
+	public synthetic fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/runtime/UnknownOpenUnionMember;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/Repost {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/Repost$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/com/atproto/repo/StrongRef;Lio/github/kikin81/atproto/runtime/AtField;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/com/atproto/repo/StrongRef;Lio/github/kikin81/atproto/runtime/AtField;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-DnBUIck ()Ljava/lang/String;
+	public final fun component2 ()Lio/github/kikin81/atproto/com/atproto/repo/StrongRef;
+	public final fun component3 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun copy-znBggmM (Ljava/lang/String;Lio/github/kikin81/atproto/com/atproto/repo/StrongRef;Lio/github/kikin81/atproto/runtime/AtField;)Lio/github/kikin81/atproto/app/bsky/feed/Repost;
+	public static synthetic fun copy-znBggmM$default (Lio/github/kikin81/atproto/app/bsky/feed/Repost;Ljava/lang/String;Lio/github/kikin81/atproto/com/atproto/repo/StrongRef;Lio/github/kikin81/atproto/runtime/AtField;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/feed/Repost;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCreatedAt-DnBUIck ()Ljava/lang/String;
+	public final fun getSubject ()Lio/github/kikin81/atproto/com/atproto/repo/StrongRef;
+	public final fun getVia ()Lio/github/kikin81/atproto/runtime/AtField;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/feed/Repost$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/feed/Repost$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/feed/Repost;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/feed/Repost;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/Repost$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/SearchPostsRequest {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/SearchPostsRequest$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-aUiJi74 ()Ljava/lang/String;
+	public final fun component10 ()Ljava/util/List;
+	public final fun component11 ()Ljava/lang/String;
+	public final fun component12-Eo6btPk ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4-r6rtVIw ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/Long;
+	public final fun component6-aUiJi74 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy-Uezq004 (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/feed/SearchPostsRequest;
+	public static synthetic fun copy-Uezq004$default (Lio/github/kikin81/atproto/app/bsky/feed/SearchPostsRequest;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/feed/SearchPostsRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAuthor-aUiJi74 ()Ljava/lang/String;
+	public final fun getCursor ()Ljava/lang/String;
+	public final fun getDomain ()Ljava/lang/String;
+	public final fun getLang-r6rtVIw ()Ljava/lang/String;
+	public final fun getLimit ()Ljava/lang/Long;
+	public final fun getMentions-aUiJi74 ()Ljava/lang/String;
+	public final fun getQ ()Ljava/lang/String;
+	public final fun getSince ()Ljava/lang/String;
+	public final fun getSort ()Ljava/lang/String;
+	public final fun getTag ()Ljava/util/List;
+	public final fun getUntil ()Ljava/lang/String;
+	public final fun getUrl-Eo6btPk ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/feed/SearchPostsRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/feed/SearchPostsRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/feed/SearchPostsRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/feed/SearchPostsRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/SearchPostsRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/SearchPostsResponse {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/SearchPostsResponse$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/Long;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Long;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/Long;
+	public final fun component3 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/lang/Long;Ljava/util/List;)Lio/github/kikin81/atproto/app/bsky/feed/SearchPostsResponse;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/feed/SearchPostsResponse;Ljava/lang/String;Ljava/lang/Long;Ljava/util/List;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/feed/SearchPostsResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCursor ()Ljava/lang/String;
+	public final fun getHitsTotal ()Ljava/lang/Long;
+	public final fun getPosts ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/feed/SearchPostsResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/feed/SearchPostsResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/feed/SearchPostsResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/feed/SearchPostsResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/SearchPostsResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/SkeletonFeedPost {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/SkeletonFeedPost$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/feed/SkeletonFeedPostReasonUnion;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/feed/SkeletonFeedPostReasonUnion;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2-GUXd3rc ()Ljava/lang/String;
+	public final fun component3 ()Lio/github/kikin81/atproto/app/bsky/feed/SkeletonFeedPostReasonUnion;
+	public final fun copy-8bHy5hw (Ljava/lang/String;Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/feed/SkeletonFeedPostReasonUnion;)Lio/github/kikin81/atproto/app/bsky/feed/SkeletonFeedPost;
+	public static synthetic fun copy-8bHy5hw$default (Lio/github/kikin81/atproto/app/bsky/feed/SkeletonFeedPost;Ljava/lang/String;Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/feed/SkeletonFeedPostReasonUnion;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/feed/SkeletonFeedPost;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFeedContext ()Ljava/lang/String;
+	public final fun getPost-GUXd3rc ()Ljava/lang/String;
+	public final fun getReason ()Lio/github/kikin81/atproto/app/bsky/feed/SkeletonFeedPostReasonUnion;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/feed/SkeletonFeedPost$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/feed/SkeletonFeedPost$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/feed/SkeletonFeedPost;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/feed/SkeletonFeedPost;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/SkeletonFeedPost$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class io/github/kikin81/atproto/app/bsky/feed/SkeletonFeedPostReasonUnion : io/github/kikin81/atproto/runtime/OpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/SkeletonFeedPostReasonUnion$Companion;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/SkeletonFeedPostReasonUnion$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/SkeletonFeedPostReasonUnion$Unknown : io/github/kikin81/atproto/app/bsky/feed/SkeletonFeedPostReasonUnion, io/github/kikin81/atproto/runtime/UnknownOpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/SkeletonFeedPostReasonUnion$Unknown$Companion;
+	public fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/app/bsky/feed/SkeletonFeedPostReasonUnion$Unknown;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/feed/SkeletonFeedPostReasonUnion$Unknown;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/feed/SkeletonFeedPostReasonUnion$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getRaw ()Lkotlinx/serialization/json/JsonObject;
+	public fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/SkeletonFeedPostReasonUnion$Unknown$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/SkeletonFeedPostReasonUnionSerializer : io/github/kikin81/atproto/runtime/OpenUnionSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/feed/SkeletonFeedPostReasonUnionSerializer;
+	public fun selectKnownDeserializer (Ljava/lang/String;)Lkotlinx/serialization/KSerializer;
+	public fun selectKnownSerializer (Lio/github/kikin81/atproto/app/bsky/feed/SkeletonFeedPostReasonUnion;)Lkotlinx/serialization/KSerializer;
+	public synthetic fun selectKnownSerializer (Lio/github/kikin81/atproto/runtime/OpenUnionMember;)Lkotlinx/serialization/KSerializer;
+	public fun unknownSerializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/SkeletonFeedPostReasonUnionUnknownSerializer : io/github/kikin81/atproto/runtime/UnknownMemberSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/feed/SkeletonFeedPostReasonUnionUnknownSerializer;
+	public fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/app/bsky/feed/SkeletonFeedPostReasonUnion$Unknown;
+	public synthetic fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/runtime/UnknownOpenUnionMember;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/SkeletonReasonPin : io/github/kikin81/atproto/app/bsky/feed/SkeletonFeedPostReasonUnion {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/SkeletonReasonPin$Companion;
+	public fun <init> ()V
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/feed/SkeletonReasonPin$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/feed/SkeletonReasonPin$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/feed/SkeletonReasonPin;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/feed/SkeletonReasonPin;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/SkeletonReasonPin$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/SkeletonReasonRepost : io/github/kikin81/atproto/app/bsky/feed/SkeletonFeedPostReasonUnion {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/SkeletonReasonRepost$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-GUXd3rc ()Ljava/lang/String;
+	public final fun copy-wvBT1Tk (Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/feed/SkeletonReasonRepost;
+	public static synthetic fun copy-wvBT1Tk$default (Lio/github/kikin81/atproto/app/bsky/feed/SkeletonReasonRepost;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/feed/SkeletonReasonRepost;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getRepost-GUXd3rc ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/feed/SkeletonReasonRepost$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/feed/SkeletonReasonRepost$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/feed/SkeletonReasonRepost;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/feed/SkeletonReasonRepost;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/SkeletonReasonRepost$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/ThreadContext {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/ThreadContext$Companion;
+	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-XX8z880 ()Ljava/lang/String;
+	public final fun copy-c7AqoAI (Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/feed/ThreadContext;
+	public static synthetic fun copy-c7AqoAI$default (Lio/github/kikin81/atproto/app/bsky/feed/ThreadContext;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/feed/ThreadContext;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getRootAuthorLike-XX8z880 ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/feed/ThreadContext$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/feed/ThreadContext$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/feed/ThreadContext;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/feed/ThreadContext;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/ThreadContext$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/ThreadViewPost : io/github/kikin81/atproto/app/bsky/feed/GetPostThreadResponseThreadUnion, io/github/kikin81/atproto/app/bsky/feed/ThreadViewPostParentUnion, io/github/kikin81/atproto/app/bsky/feed/ThreadViewPostRepliesUnion {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/ThreadViewPost$Companion;
+	public fun <init> (Lio/github/kikin81/atproto/app/bsky/feed/ThreadViewPostParentUnion;Lio/github/kikin81/atproto/app/bsky/feed/PostView;Ljava/util/List;Lio/github/kikin81/atproto/app/bsky/feed/ThreadContext;)V
+	public synthetic fun <init> (Lio/github/kikin81/atproto/app/bsky/feed/ThreadViewPostParentUnion;Lio/github/kikin81/atproto/app/bsky/feed/PostView;Ljava/util/List;Lio/github/kikin81/atproto/app/bsky/feed/ThreadContext;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/app/bsky/feed/ThreadViewPostParentUnion;
+	public final fun component2 ()Lio/github/kikin81/atproto/app/bsky/feed/PostView;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Lio/github/kikin81/atproto/app/bsky/feed/ThreadContext;
+	public final fun copy (Lio/github/kikin81/atproto/app/bsky/feed/ThreadViewPostParentUnion;Lio/github/kikin81/atproto/app/bsky/feed/PostView;Ljava/util/List;Lio/github/kikin81/atproto/app/bsky/feed/ThreadContext;)Lio/github/kikin81/atproto/app/bsky/feed/ThreadViewPost;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/feed/ThreadViewPost;Lio/github/kikin81/atproto/app/bsky/feed/ThreadViewPostParentUnion;Lio/github/kikin81/atproto/app/bsky/feed/PostView;Ljava/util/List;Lio/github/kikin81/atproto/app/bsky/feed/ThreadContext;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/feed/ThreadViewPost;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getParent ()Lio/github/kikin81/atproto/app/bsky/feed/ThreadViewPostParentUnion;
+	public final fun getPost ()Lio/github/kikin81/atproto/app/bsky/feed/PostView;
+	public final fun getReplies ()Ljava/util/List;
+	public final fun getThreadContext ()Lio/github/kikin81/atproto/app/bsky/feed/ThreadContext;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/feed/ThreadViewPost$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/feed/ThreadViewPost$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/feed/ThreadViewPost;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/feed/ThreadViewPost;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/ThreadViewPost$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class io/github/kikin81/atproto/app/bsky/feed/ThreadViewPostParentUnion : io/github/kikin81/atproto/runtime/OpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/ThreadViewPostParentUnion$Companion;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/ThreadViewPostParentUnion$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/ThreadViewPostParentUnion$Unknown : io/github/kikin81/atproto/app/bsky/feed/ThreadViewPostParentUnion, io/github/kikin81/atproto/runtime/UnknownOpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/ThreadViewPostParentUnion$Unknown$Companion;
+	public fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/app/bsky/feed/ThreadViewPostParentUnion$Unknown;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/feed/ThreadViewPostParentUnion$Unknown;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/feed/ThreadViewPostParentUnion$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getRaw ()Lkotlinx/serialization/json/JsonObject;
+	public fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/ThreadViewPostParentUnion$Unknown$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/ThreadViewPostParentUnionSerializer : io/github/kikin81/atproto/runtime/OpenUnionSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/feed/ThreadViewPostParentUnionSerializer;
+	public fun selectKnownDeserializer (Ljava/lang/String;)Lkotlinx/serialization/KSerializer;
+	public fun selectKnownSerializer (Lio/github/kikin81/atproto/app/bsky/feed/ThreadViewPostParentUnion;)Lkotlinx/serialization/KSerializer;
+	public synthetic fun selectKnownSerializer (Lio/github/kikin81/atproto/runtime/OpenUnionMember;)Lkotlinx/serialization/KSerializer;
+	public fun unknownSerializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/ThreadViewPostParentUnionUnknownSerializer : io/github/kikin81/atproto/runtime/UnknownMemberSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/feed/ThreadViewPostParentUnionUnknownSerializer;
+	public fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/app/bsky/feed/ThreadViewPostParentUnion$Unknown;
+	public synthetic fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/runtime/UnknownOpenUnionMember;
+}
+
+public abstract interface class io/github/kikin81/atproto/app/bsky/feed/ThreadViewPostRepliesUnion : io/github/kikin81/atproto/runtime/OpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/ThreadViewPostRepliesUnion$Companion;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/ThreadViewPostRepliesUnion$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/ThreadViewPostRepliesUnion$Unknown : io/github/kikin81/atproto/app/bsky/feed/ThreadViewPostRepliesUnion, io/github/kikin81/atproto/runtime/UnknownOpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/ThreadViewPostRepliesUnion$Unknown$Companion;
+	public fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/app/bsky/feed/ThreadViewPostRepliesUnion$Unknown;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/feed/ThreadViewPostRepliesUnion$Unknown;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/feed/ThreadViewPostRepliesUnion$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getRaw ()Lkotlinx/serialization/json/JsonObject;
+	public fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/ThreadViewPostRepliesUnion$Unknown$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/ThreadViewPostRepliesUnionSerializer : io/github/kikin81/atproto/runtime/OpenUnionSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/feed/ThreadViewPostRepliesUnionSerializer;
+	public fun selectKnownDeserializer (Ljava/lang/String;)Lkotlinx/serialization/KSerializer;
+	public fun selectKnownSerializer (Lio/github/kikin81/atproto/app/bsky/feed/ThreadViewPostRepliesUnion;)Lkotlinx/serialization/KSerializer;
+	public synthetic fun selectKnownSerializer (Lio/github/kikin81/atproto/runtime/OpenUnionMember;)Lkotlinx/serialization/KSerializer;
+	public fun unknownSerializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/ThreadViewPostRepliesUnionUnknownSerializer : io/github/kikin81/atproto/runtime/UnknownMemberSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/feed/ThreadViewPostRepliesUnionUnknownSerializer;
+	public fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/app/bsky/feed/ThreadViewPostRepliesUnion$Unknown;
+	public synthetic fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/runtime/UnknownOpenUnionMember;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/Threadgate {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/Threadgate$Companion;
+	public synthetic fun <init> (Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun component2-DnBUIck ()Ljava/lang/String;
+	public final fun component3 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun component4-GUXd3rc ()Ljava/lang/String;
+	public final fun copy-jrNlBwU (Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/feed/Threadgate;
+	public static synthetic fun copy-jrNlBwU$default (Lio/github/kikin81/atproto/app/bsky/feed/Threadgate;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/feed/Threadgate;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAllow ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun getCreatedAt-DnBUIck ()Ljava/lang/String;
+	public final fun getHiddenReplies ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun getPost-GUXd3rc ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/feed/Threadgate$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/feed/Threadgate$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/feed/Threadgate;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/feed/Threadgate;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/Threadgate$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class io/github/kikin81/atproto/app/bsky/feed/ThreadgateAllowUnion : io/github/kikin81/atproto/runtime/OpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/ThreadgateAllowUnion$Companion;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/ThreadgateAllowUnion$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/ThreadgateAllowUnion$Unknown : io/github/kikin81/atproto/app/bsky/feed/ThreadgateAllowUnion, io/github/kikin81/atproto/runtime/UnknownOpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/ThreadgateAllowUnion$Unknown$Companion;
+	public fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/app/bsky/feed/ThreadgateAllowUnion$Unknown;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/feed/ThreadgateAllowUnion$Unknown;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/feed/ThreadgateAllowUnion$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getRaw ()Lkotlinx/serialization/json/JsonObject;
+	public fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/ThreadgateAllowUnion$Unknown$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/ThreadgateAllowUnionSerializer : io/github/kikin81/atproto/runtime/OpenUnionSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/feed/ThreadgateAllowUnionSerializer;
+	public fun selectKnownDeserializer (Ljava/lang/String;)Lkotlinx/serialization/KSerializer;
+	public fun selectKnownSerializer (Lio/github/kikin81/atproto/app/bsky/feed/ThreadgateAllowUnion;)Lkotlinx/serialization/KSerializer;
+	public synthetic fun selectKnownSerializer (Lio/github/kikin81/atproto/runtime/OpenUnionMember;)Lkotlinx/serialization/KSerializer;
+	public fun unknownSerializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/ThreadgateAllowUnionUnknownSerializer : io/github/kikin81/atproto/runtime/UnknownMemberSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/feed/ThreadgateAllowUnionUnknownSerializer;
+	public fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/app/bsky/feed/ThreadgateAllowUnion$Unknown;
+	public synthetic fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/runtime/UnknownOpenUnionMember;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/ThreadgateFollowerRule : io/github/kikin81/atproto/app/bsky/actor/PostInteractionSettingsPrefThreadgateAllowRulesUnion, io/github/kikin81/atproto/app/bsky/feed/ThreadgateAllowUnion {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/ThreadgateFollowerRule$Companion;
+	public fun <init> ()V
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/feed/ThreadgateFollowerRule$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/feed/ThreadgateFollowerRule$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/feed/ThreadgateFollowerRule;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/feed/ThreadgateFollowerRule;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/ThreadgateFollowerRule$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/ThreadgateFollowingRule : io/github/kikin81/atproto/app/bsky/actor/PostInteractionSettingsPrefThreadgateAllowRulesUnion, io/github/kikin81/atproto/app/bsky/feed/ThreadgateAllowUnion {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/ThreadgateFollowingRule$Companion;
+	public fun <init> ()V
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/feed/ThreadgateFollowingRule$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/feed/ThreadgateFollowingRule$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/feed/ThreadgateFollowingRule;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/feed/ThreadgateFollowingRule;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/ThreadgateFollowingRule$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/ThreadgateListRule : io/github/kikin81/atproto/app/bsky/actor/PostInteractionSettingsPrefThreadgateAllowRulesUnion, io/github/kikin81/atproto/app/bsky/feed/ThreadgateAllowUnion {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/ThreadgateListRule$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-GUXd3rc ()Ljava/lang/String;
+	public final fun copy-wvBT1Tk (Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/feed/ThreadgateListRule;
+	public static synthetic fun copy-wvBT1Tk$default (Lio/github/kikin81/atproto/app/bsky/feed/ThreadgateListRule;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/feed/ThreadgateListRule;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getList-GUXd3rc ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/feed/ThreadgateListRule$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/feed/ThreadgateListRule$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/feed/ThreadgateListRule;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/feed/ThreadgateListRule;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/ThreadgateListRule$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/ThreadgateMentionRule : io/github/kikin81/atproto/app/bsky/actor/PostInteractionSettingsPrefThreadgateAllowRulesUnion, io/github/kikin81/atproto/app/bsky/feed/ThreadgateAllowUnion {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/ThreadgateMentionRule$Companion;
+	public fun <init> ()V
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/feed/ThreadgateMentionRule$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/feed/ThreadgateMentionRule$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/feed/ThreadgateMentionRule;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/feed/ThreadgateMentionRule;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/ThreadgateMentionRule$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/ThreadgateView {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/ThreadgateView$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-eL7R55w ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun component4-XX8z880 ()Ljava/lang/String;
+	public final fun copy-bS0D2-o (Ljava/lang/String;Ljava/util/List;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/feed/ThreadgateView;
+	public static synthetic fun copy-bS0D2-o$default (Lio/github/kikin81/atproto/app/bsky/feed/ThreadgateView;Ljava/lang/String;Ljava/util/List;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/feed/ThreadgateView;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCid-eL7R55w ()Ljava/lang/String;
+	public final fun getLists ()Ljava/util/List;
+	public final fun getRecord ()Lkotlinx/serialization/json/JsonObject;
+	public final fun getUri-XX8z880 ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/feed/ThreadgateView$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/feed/ThreadgateView$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/feed/ThreadgateView;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/feed/ThreadgateView;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/ThreadgateView$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/ViewerState {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/ViewerState$Companion;
+	public synthetic fun <init> (Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Boolean;
+	public final fun component2 ()Ljava/lang/Boolean;
+	public final fun component3-XX8z880 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/Boolean;
+	public final fun component5 ()Ljava/lang/Boolean;
+	public final fun component6-XX8z880 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/Boolean;
+	public final fun copy-7AkCfHg (Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;)Lio/github/kikin81/atproto/app/bsky/feed/ViewerState;
+	public static synthetic fun copy-7AkCfHg$default (Lio/github/kikin81/atproto/app/bsky/feed/ViewerState;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/feed/ViewerState;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBookmarked ()Ljava/lang/Boolean;
+	public final fun getEmbeddingDisabled ()Ljava/lang/Boolean;
+	public final fun getLike-XX8z880 ()Ljava/lang/String;
+	public final fun getPinned ()Ljava/lang/Boolean;
+	public final fun getReplyDisabled ()Ljava/lang/Boolean;
+	public final fun getRepost-XX8z880 ()Ljava/lang/String;
+	public final fun getThreadMuted ()Ljava/lang/Boolean;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/feed/ViewerState$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/feed/ViewerState$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/feed/ViewerState;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/feed/ViewerState;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/ViewerState$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/Block {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/graph/Block$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-DnBUIck ()Ljava/lang/String;
+	public final fun component2-UyB9Nic ()Ljava/lang/String;
+	public final fun copy-KDnUP0Y (Ljava/lang/String;Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/graph/Block;
+	public static synthetic fun copy-KDnUP0Y$default (Lio/github/kikin81/atproto/app/bsky/graph/Block;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/graph/Block;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCreatedAt-DnBUIck ()Ljava/lang/String;
+	public final fun getSubject-UyB9Nic ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/graph/Block$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/graph/Block$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/graph/Block;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/graph/Block;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/Block$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/Follow {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/graph/Follow$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-DnBUIck ()Ljava/lang/String;
+	public final fun component2-UyB9Nic ()Ljava/lang/String;
+	public final fun component3 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun copy-etamZcM (Ljava/lang/String;Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;)Lio/github/kikin81/atproto/app/bsky/graph/Follow;
+	public static synthetic fun copy-etamZcM$default (Lio/github/kikin81/atproto/app/bsky/graph/Follow;Ljava/lang/String;Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/graph/Follow;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCreatedAt-DnBUIck ()Ljava/lang/String;
+	public final fun getSubject-UyB9Nic ()Ljava/lang/String;
+	public final fun getVia ()Lio/github/kikin81/atproto/runtime/AtField;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/graph/Follow$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/graph/Follow$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/graph/Follow;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/graph/Follow;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/Follow$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/GetBlocksRequest {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/graph/GetBlocksRequest$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Long;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Long;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/Long;
+	public final fun copy (Ljava/lang/String;Ljava/lang/Long;)Lio/github/kikin81/atproto/app/bsky/graph/GetBlocksRequest;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/graph/GetBlocksRequest;Ljava/lang/String;Ljava/lang/Long;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/graph/GetBlocksRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCursor ()Ljava/lang/String;
+	public final fun getLimit ()Ljava/lang/Long;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/graph/GetBlocksRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/graph/GetBlocksRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/graph/GetBlocksRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/graph/GetBlocksRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/GetBlocksRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/GetBlocksResponse {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/graph/GetBlocksResponse$Companion;
+	public fun <init> (Ljava/util/List;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/util/List;Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/graph/GetBlocksResponse;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/graph/GetBlocksResponse;Ljava/util/List;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/graph/GetBlocksResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBlocks ()Ljava/util/List;
+	public final fun getCursor ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/graph/GetBlocksResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/graph/GetBlocksResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/graph/GetBlocksResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/graph/GetBlocksResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/GetBlocksResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/GetFollowersRequest {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/graph/GetFollowersRequest$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-mlEIfv0 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/Long;
+	public final fun copy-zhZdu3M (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;)Lio/github/kikin81/atproto/app/bsky/graph/GetFollowersRequest;
+	public static synthetic fun copy-zhZdu3M$default (Lio/github/kikin81/atproto/app/bsky/graph/GetFollowersRequest;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/graph/GetFollowersRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActor-mlEIfv0 ()Ljava/lang/String;
+	public final fun getCursor ()Ljava/lang/String;
+	public final fun getLimit ()Ljava/lang/Long;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/graph/GetFollowersRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/graph/GetFollowersRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/graph/GetFollowersRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/graph/GetFollowersRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/GetFollowersRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/GetFollowersResponse {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/graph/GetFollowersResponse$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Lio/github/kikin81/atproto/app/bsky/actor/ProfileView;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Lio/github/kikin81/atproto/app/bsky/actor/ProfileView;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Lio/github/kikin81/atproto/app/bsky/actor/ProfileView;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;Lio/github/kikin81/atproto/app/bsky/actor/ProfileView;)Lio/github/kikin81/atproto/app/bsky/graph/GetFollowersResponse;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/graph/GetFollowersResponse;Ljava/lang/String;Ljava/util/List;Lio/github/kikin81/atproto/app/bsky/actor/ProfileView;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/graph/GetFollowersResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCursor ()Ljava/lang/String;
+	public final fun getFollowers ()Ljava/util/List;
+	public final fun getSubject ()Lio/github/kikin81/atproto/app/bsky/actor/ProfileView;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/graph/GetFollowersResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/graph/GetFollowersResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/graph/GetFollowersResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/graph/GetFollowersResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/GetFollowersResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/GetFollowsRequest {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/graph/GetFollowsRequest$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-mlEIfv0 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/Long;
+	public final fun copy-zhZdu3M (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;)Lio/github/kikin81/atproto/app/bsky/graph/GetFollowsRequest;
+	public static synthetic fun copy-zhZdu3M$default (Lio/github/kikin81/atproto/app/bsky/graph/GetFollowsRequest;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/graph/GetFollowsRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActor-mlEIfv0 ()Ljava/lang/String;
+	public final fun getCursor ()Ljava/lang/String;
+	public final fun getLimit ()Ljava/lang/Long;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/graph/GetFollowsRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/graph/GetFollowsRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/graph/GetFollowsRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/graph/GetFollowsRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/GetFollowsRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/GetFollowsResponse {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/graph/GetFollowsResponse$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Lio/github/kikin81/atproto/app/bsky/actor/ProfileView;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Lio/github/kikin81/atproto/app/bsky/actor/ProfileView;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Lio/github/kikin81/atproto/app/bsky/actor/ProfileView;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;Lio/github/kikin81/atproto/app/bsky/actor/ProfileView;)Lio/github/kikin81/atproto/app/bsky/graph/GetFollowsResponse;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/graph/GetFollowsResponse;Ljava/lang/String;Ljava/util/List;Lio/github/kikin81/atproto/app/bsky/actor/ProfileView;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/graph/GetFollowsResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCursor ()Ljava/lang/String;
+	public final fun getFollows ()Ljava/util/List;
+	public final fun getSubject ()Lio/github/kikin81/atproto/app/bsky/actor/ProfileView;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/graph/GetFollowsResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/graph/GetFollowsResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/graph/GetFollowsResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/graph/GetFollowsResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/GetFollowsResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/GetListsRequest {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/graph/GetListsRequest$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/util/List;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-mlEIfv0 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/Long;
+	public final fun component4 ()Ljava/util/List;
+	public final fun copy-icULqAM (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/util/List;)Lio/github/kikin81/atproto/app/bsky/graph/GetListsRequest;
+	public static synthetic fun copy-icULqAM$default (Lio/github/kikin81/atproto/app/bsky/graph/GetListsRequest;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/util/List;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/graph/GetListsRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActor-mlEIfv0 ()Ljava/lang/String;
+	public final fun getCursor ()Ljava/lang/String;
+	public final fun getLimit ()Ljava/lang/Long;
+	public final fun getPurposes ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/graph/GetListsRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/graph/GetListsRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/graph/GetListsRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/graph/GetListsRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/GetListsRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/GetListsResponse {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/graph/GetListsResponse$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;)Lio/github/kikin81/atproto/app/bsky/graph/GetListsResponse;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/graph/GetListsResponse;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/graph/GetListsResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCursor ()Ljava/lang/String;
+	public final fun getLists ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/graph/GetListsResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/graph/GetListsResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/graph/GetListsResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/graph/GetListsResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/GetListsResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/GetMutesRequest {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/graph/GetMutesRequest$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Long;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Long;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/Long;
+	public final fun copy (Ljava/lang/String;Ljava/lang/Long;)Lio/github/kikin81/atproto/app/bsky/graph/GetMutesRequest;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/graph/GetMutesRequest;Ljava/lang/String;Ljava/lang/Long;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/graph/GetMutesRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCursor ()Ljava/lang/String;
+	public final fun getLimit ()Ljava/lang/Long;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/graph/GetMutesRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/graph/GetMutesRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/graph/GetMutesRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/graph/GetMutesRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/GetMutesRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/GetMutesResponse {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/graph/GetMutesResponse$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;)Lio/github/kikin81/atproto/app/bsky/graph/GetMutesResponse;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/graph/GetMutesResponse;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/graph/GetMutesResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCursor ()Ljava/lang/String;
+	public final fun getMutes ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/graph/GetMutesResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/graph/GetMutesResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/graph/GetMutesResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/graph/GetMutesResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/GetMutesResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/GraphService {
+	public fun <init> (Lio/github/kikin81/atproto/runtime/XrpcClient;)V
+	public final fun getBlocks (Lio/github/kikin81/atproto/app/bsky/graph/GetBlocksRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getBlocks$default (Lio/github/kikin81/atproto/app/bsky/graph/GraphService;Lio/github/kikin81/atproto/app/bsky/graph/GetBlocksRequest;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getFollowers (Lio/github/kikin81/atproto/app/bsky/graph/GetFollowersRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getFollows (Lio/github/kikin81/atproto/app/bsky/graph/GetFollowsRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getLists (Lio/github/kikin81/atproto/app/bsky/graph/GetListsRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getMutes (Lio/github/kikin81/atproto/app/bsky/graph/GetMutesRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getMutes$default (Lio/github/kikin81/atproto/app/bsky/graph/GraphService;Lio/github/kikin81/atproto/app/bsky/graph/GetMutesRequest;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun muteActor (Lio/github/kikin81/atproto/app/bsky/graph/MuteActorRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/GraphServiceKt {
+	public static final fun blocksFlow (Lio/github/kikin81/atproto/app/bsky/graph/GraphService;Lio/github/kikin81/atproto/app/bsky/graph/GetBlocksRequest;)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun blocksFlow$default (Lio/github/kikin81/atproto/app/bsky/graph/GraphService;Lio/github/kikin81/atproto/app/bsky/graph/GetBlocksRequest;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun blocksPageFlow (Lio/github/kikin81/atproto/app/bsky/graph/GraphService;Lio/github/kikin81/atproto/app/bsky/graph/GetBlocksRequest;)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun blocksPageFlow$default (Lio/github/kikin81/atproto/app/bsky/graph/GraphService;Lio/github/kikin81/atproto/app/bsky/graph/GetBlocksRequest;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun followersFlow (Lio/github/kikin81/atproto/app/bsky/graph/GraphService;Lio/github/kikin81/atproto/app/bsky/graph/GetFollowersRequest;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun followersPageFlow (Lio/github/kikin81/atproto/app/bsky/graph/GraphService;Lio/github/kikin81/atproto/app/bsky/graph/GetFollowersRequest;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun followsFlow (Lio/github/kikin81/atproto/app/bsky/graph/GraphService;Lio/github/kikin81/atproto/app/bsky/graph/GetFollowsRequest;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun followsPageFlow (Lio/github/kikin81/atproto/app/bsky/graph/GraphService;Lio/github/kikin81/atproto/app/bsky/graph/GetFollowsRequest;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun listsFlow (Lio/github/kikin81/atproto/app/bsky/graph/GraphService;Lio/github/kikin81/atproto/app/bsky/graph/GetListsRequest;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun listsPageFlow (Lio/github/kikin81/atproto/app/bsky/graph/GraphService;Lio/github/kikin81/atproto/app/bsky/graph/GetListsRequest;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun mutesFlow (Lio/github/kikin81/atproto/app/bsky/graph/GraphService;Lio/github/kikin81/atproto/app/bsky/graph/GetMutesRequest;)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun mutesFlow$default (Lio/github/kikin81/atproto/app/bsky/graph/GraphService;Lio/github/kikin81/atproto/app/bsky/graph/GetMutesRequest;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun mutesPageFlow (Lio/github/kikin81/atproto/app/bsky/graph/GraphService;Lio/github/kikin81/atproto/app/bsky/graph/GetMutesRequest;)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun mutesPageFlow$default (Lio/github/kikin81/atproto/app/bsky/graph/GraphService;Lio/github/kikin81/atproto/app/bsky/graph/GetMutesRequest;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/List {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/graph/List$Companion;
+	public synthetic fun <init> (Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun component2-DnBUIck ()Ljava/lang/String;
+	public final fun component3 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun component4 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun component5 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun copy-7ZecPdU (Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/graph/List;
+	public static synthetic fun copy-7ZecPdU$default (Lio/github/kikin81/atproto/app/bsky/graph/List;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/graph/List;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAvatar ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun getCreatedAt-DnBUIck ()Ljava/lang/String;
+	public final fun getDescription ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun getDescriptionFacets ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun getLabels ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getPurpose ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/graph/List$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/graph/List$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/graph/List;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/graph/List;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/List$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/ListItemView {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/graph/ListItemView$Companion;
+	public synthetic fun <init> (Lio/github/kikin81/atproto/app/bsky/actor/ProfileView;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/app/bsky/actor/ProfileView;
+	public final fun component2-GUXd3rc ()Ljava/lang/String;
+	public final fun copy-HnpCerU (Lio/github/kikin81/atproto/app/bsky/actor/ProfileView;Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/graph/ListItemView;
+	public static synthetic fun copy-HnpCerU$default (Lio/github/kikin81/atproto/app/bsky/graph/ListItemView;Lio/github/kikin81/atproto/app/bsky/actor/ProfileView;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/graph/ListItemView;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getSubject ()Lio/github/kikin81/atproto/app/bsky/actor/ProfileView;
+	public final fun getUri-GUXd3rc ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/graph/ListItemView$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/graph/ListItemView$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/graph/ListItemView;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/graph/ListItemView;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/ListItemView$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class io/github/kikin81/atproto/app/bsky/graph/ListLabelsUnion : io/github/kikin81/atproto/runtime/OpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/graph/ListLabelsUnion$Companion;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/ListLabelsUnion$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/ListLabelsUnion$Unknown : io/github/kikin81/atproto/app/bsky/graph/ListLabelsUnion, io/github/kikin81/atproto/runtime/UnknownOpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/graph/ListLabelsUnion$Unknown$Companion;
+	public fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/app/bsky/graph/ListLabelsUnion$Unknown;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/graph/ListLabelsUnion$Unknown;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/graph/ListLabelsUnion$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getRaw ()Lkotlinx/serialization/json/JsonObject;
+	public fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/ListLabelsUnion$Unknown$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/ListLabelsUnionSerializer : io/github/kikin81/atproto/runtime/OpenUnionSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/graph/ListLabelsUnionSerializer;
+	public fun selectKnownDeserializer (Ljava/lang/String;)Lkotlinx/serialization/KSerializer;
+	public fun selectKnownSerializer (Lio/github/kikin81/atproto/app/bsky/graph/ListLabelsUnion;)Lkotlinx/serialization/KSerializer;
+	public synthetic fun selectKnownSerializer (Lio/github/kikin81/atproto/runtime/OpenUnionMember;)Lkotlinx/serialization/KSerializer;
+	public fun unknownSerializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/ListLabelsUnionUnknownSerializer : io/github/kikin81/atproto/runtime/UnknownMemberSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/graph/ListLabelsUnionUnknownSerializer;
+	public fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/app/bsky/graph/ListLabelsUnion$Unknown;
+	public synthetic fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/runtime/UnknownOpenUnionMember;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/ListView : io/github/kikin81/atproto/app/bsky/embed/RecordViewRecordUnion {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/graph/ListView$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/actor/ProfileView;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/graph/ListViewerState;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/actor/ProfileView;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/graph/ListViewerState;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-Eo6btPk ()Ljava/lang/String;
+	public final fun component10 ()Ljava/lang/String;
+	public final fun component11-GUXd3rc ()Ljava/lang/String;
+	public final fun component12 ()Lio/github/kikin81/atproto/app/bsky/graph/ListViewerState;
+	public final fun component2-LVDfoeI ()Ljava/lang/String;
+	public final fun component3 ()Lio/github/kikin81/atproto/app/bsky/actor/ProfileView;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/util/List;
+	public final fun component6-DnBUIck ()Ljava/lang/String;
+	public final fun component7 ()Ljava/util/List;
+	public final fun component8 ()Ljava/lang/Long;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy-u9Qbdnc (Ljava/lang/String;Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/actor/ProfileView;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/graph/ListViewerState;)Lio/github/kikin81/atproto/app/bsky/graph/ListView;
+	public static synthetic fun copy-u9Qbdnc$default (Lio/github/kikin81/atproto/app/bsky/graph/ListView;Ljava/lang/String;Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/actor/ProfileView;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/graph/ListViewerState;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/graph/ListView;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAvatar-Eo6btPk ()Ljava/lang/String;
+	public final fun getCid-LVDfoeI ()Ljava/lang/String;
+	public final fun getCreator ()Lio/github/kikin81/atproto/app/bsky/actor/ProfileView;
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getDescriptionFacets ()Ljava/util/List;
+	public final fun getIndexedAt-DnBUIck ()Ljava/lang/String;
+	public final fun getLabels ()Ljava/util/List;
+	public final fun getListItemCount ()Ljava/lang/Long;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getPurpose ()Ljava/lang/String;
+	public final fun getUri-GUXd3rc ()Ljava/lang/String;
+	public final fun getViewer ()Lio/github/kikin81/atproto/app/bsky/graph/ListViewerState;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/graph/ListView$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/graph/ListView$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/graph/ListView;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/graph/ListView;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/ListView$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/ListViewBasic {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/graph/ListViewBasic$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/graph/ListViewerState;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/graph/ListViewerState;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-Eo6btPk ()Ljava/lang/String;
+	public final fun component2-LVDfoeI ()Ljava/lang/String;
+	public final fun component3-G5DCnlA ()Ljava/lang/String;
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Ljava/lang/Long;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8-GUXd3rc ()Ljava/lang/String;
+	public final fun component9 ()Lio/github/kikin81/atproto/app/bsky/graph/ListViewerState;
+	public final fun copy-la0_wyo (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/graph/ListViewerState;)Lio/github/kikin81/atproto/app/bsky/graph/ListViewBasic;
+	public static synthetic fun copy-la0_wyo$default (Lio/github/kikin81/atproto/app/bsky/graph/ListViewBasic;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/graph/ListViewerState;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/graph/ListViewBasic;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAvatar-Eo6btPk ()Ljava/lang/String;
+	public final fun getCid-LVDfoeI ()Ljava/lang/String;
+	public final fun getIndexedAt-G5DCnlA ()Ljava/lang/String;
+	public final fun getLabels ()Ljava/util/List;
+	public final fun getListItemCount ()Ljava/lang/Long;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getPurpose ()Ljava/lang/String;
+	public final fun getUri-GUXd3rc ()Ljava/lang/String;
+	public final fun getViewer ()Lio/github/kikin81/atproto/app/bsky/graph/ListViewerState;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/graph/ListViewBasic$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/graph/ListViewBasic$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/graph/ListViewBasic;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/graph/ListViewBasic;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/ListViewBasic$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/ListViewerState {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/graph/ListViewerState$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Boolean;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-XX8z880 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/Boolean;
+	public final fun copy-IJIWQeI (Ljava/lang/String;Ljava/lang/Boolean;)Lio/github/kikin81/atproto/app/bsky/graph/ListViewerState;
+	public static synthetic fun copy-IJIWQeI$default (Lio/github/kikin81/atproto/app/bsky/graph/ListViewerState;Ljava/lang/String;Ljava/lang/Boolean;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/graph/ListViewerState;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBlocked-XX8z880 ()Ljava/lang/String;
+	public final fun getMuted ()Ljava/lang/Boolean;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/graph/ListViewerState$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/graph/ListViewerState$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/graph/ListViewerState;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/graph/ListViewerState;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/ListViewerState$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/Listblock {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/graph/Listblock$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-DnBUIck ()Ljava/lang/String;
+	public final fun component2-GUXd3rc ()Ljava/lang/String;
+	public final fun copy-11Nbroo (Ljava/lang/String;Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/graph/Listblock;
+	public static synthetic fun copy-11Nbroo$default (Lio/github/kikin81/atproto/app/bsky/graph/Listblock;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/graph/Listblock;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCreatedAt-DnBUIck ()Ljava/lang/String;
+	public final fun getSubject-GUXd3rc ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/graph/Listblock$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/graph/Listblock$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/graph/Listblock;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/graph/Listblock;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/Listblock$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/Listitem {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/graph/Listitem$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-DnBUIck ()Ljava/lang/String;
+	public final fun component2-GUXd3rc ()Ljava/lang/String;
+	public final fun component3-UyB9Nic ()Ljava/lang/String;
+	public final fun copy-7qXsTyE (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/graph/Listitem;
+	public static synthetic fun copy-7qXsTyE$default (Lio/github/kikin81/atproto/app/bsky/graph/Listitem;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/graph/Listitem;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCreatedAt-DnBUIck ()Ljava/lang/String;
+	public final fun getList-GUXd3rc ()Ljava/lang/String;
+	public final fun getSubject-UyB9Nic ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/graph/Listitem$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/graph/Listitem$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/graph/Listitem;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/graph/Listitem;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/Listitem$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/MuteActorRequest {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/graph/MuteActorRequest$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-mlEIfv0 ()Ljava/lang/String;
+	public final fun copy-6PA111I (Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/graph/MuteActorRequest;
+	public static synthetic fun copy-6PA111I$default (Lio/github/kikin81/atproto/app/bsky/graph/MuteActorRequest;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/graph/MuteActorRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActor-mlEIfv0 ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/graph/MuteActorRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/graph/MuteActorRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/graph/MuteActorRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/graph/MuteActorRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/MuteActorRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/NotFoundActor {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/graph/NotFoundActor$Companion;
+	public synthetic fun <init> (Ljava/lang/String;ZLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-mlEIfv0 ()Ljava/lang/String;
+	public final fun component2 ()Z
+	public final fun copy-hAgOyBw (Ljava/lang/String;Z)Lio/github/kikin81/atproto/app/bsky/graph/NotFoundActor;
+	public static synthetic fun copy-hAgOyBw$default (Lio/github/kikin81/atproto/app/bsky/graph/NotFoundActor;Ljava/lang/String;ZILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/graph/NotFoundActor;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActor-mlEIfv0 ()Ljava/lang/String;
+	public final fun getNotFound ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/graph/NotFoundActor$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/graph/NotFoundActor$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/graph/NotFoundActor;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/graph/NotFoundActor;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/NotFoundActor$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/Relationship {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/graph/Relationship$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-XX8z880 ()Ljava/lang/String;
+	public final fun component2-XX8z880 ()Ljava/lang/String;
+	public final fun component3-XX8z880 ()Ljava/lang/String;
+	public final fun component4-XX8z880 ()Ljava/lang/String;
+	public final fun component5-UyB9Nic ()Ljava/lang/String;
+	public final fun component6-XX8z880 ()Ljava/lang/String;
+	public final fun component7-XX8z880 ()Ljava/lang/String;
+	public final fun copy-U6I_keo (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/graph/Relationship;
+	public static synthetic fun copy-U6I_keo$default (Lio/github/kikin81/atproto/app/bsky/graph/Relationship;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/graph/Relationship;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBlockedBy-XX8z880 ()Ljava/lang/String;
+	public final fun getBlockedByList-XX8z880 ()Ljava/lang/String;
+	public final fun getBlocking-XX8z880 ()Ljava/lang/String;
+	public final fun getBlockingByList-XX8z880 ()Ljava/lang/String;
+	public final fun getDid-UyB9Nic ()Ljava/lang/String;
+	public final fun getFollowedBy-XX8z880 ()Ljava/lang/String;
+	public final fun getFollowing-XX8z880 ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/graph/Relationship$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/graph/Relationship$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/graph/Relationship;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/graph/Relationship;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/Relationship$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/StarterPackView {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/graph/StarterPackView$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/actor/ProfileViewBasic;Ljava/util/List;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/util/List;Lio/github/kikin81/atproto/app/bsky/graph/ListViewBasic;Ljava/util/List;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/actor/ProfileViewBasic;Ljava/util/List;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/util/List;Lio/github/kikin81/atproto/app/bsky/graph/ListViewBasic;Ljava/util/List;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-LVDfoeI ()Ljava/lang/String;
+	public final fun component10 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun component11-GUXd3rc ()Ljava/lang/String;
+	public final fun component2 ()Lio/github/kikin81/atproto/app/bsky/actor/ProfileViewBasic;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4-DnBUIck ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/Long;
+	public final fun component6 ()Ljava/lang/Long;
+	public final fun component7 ()Ljava/util/List;
+	public final fun component8 ()Lio/github/kikin81/atproto/app/bsky/graph/ListViewBasic;
+	public final fun component9 ()Ljava/util/List;
+	public final fun copy-OWQmWxI (Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/actor/ProfileViewBasic;Ljava/util/List;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/util/List;Lio/github/kikin81/atproto/app/bsky/graph/ListViewBasic;Ljava/util/List;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/graph/StarterPackView;
+	public static synthetic fun copy-OWQmWxI$default (Lio/github/kikin81/atproto/app/bsky/graph/StarterPackView;Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/actor/ProfileViewBasic;Ljava/util/List;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/util/List;Lio/github/kikin81/atproto/app/bsky/graph/ListViewBasic;Ljava/util/List;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/graph/StarterPackView;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCid-LVDfoeI ()Ljava/lang/String;
+	public final fun getCreator ()Lio/github/kikin81/atproto/app/bsky/actor/ProfileViewBasic;
+	public final fun getFeeds ()Ljava/util/List;
+	public final fun getIndexedAt-DnBUIck ()Ljava/lang/String;
+	public final fun getJoinedAllTimeCount ()Ljava/lang/Long;
+	public final fun getJoinedWeekCount ()Ljava/lang/Long;
+	public final fun getLabels ()Ljava/util/List;
+	public final fun getList ()Lio/github/kikin81/atproto/app/bsky/graph/ListViewBasic;
+	public final fun getListItemsSample ()Ljava/util/List;
+	public final fun getRecord ()Lkotlinx/serialization/json/JsonObject;
+	public final fun getUri-GUXd3rc ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/graph/StarterPackView$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/graph/StarterPackView$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/graph/StarterPackView;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/graph/StarterPackView;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/StarterPackView$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/StarterPackViewBasic : io/github/kikin81/atproto/app/bsky/embed/RecordViewRecordUnion {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/graph/StarterPackViewBasic$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/actor/ProfileViewBasic;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/util/List;Ljava/lang/Long;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/actor/ProfileViewBasic;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/util/List;Ljava/lang/Long;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-LVDfoeI ()Ljava/lang/String;
+	public final fun component2 ()Lio/github/kikin81/atproto/app/bsky/actor/ProfileViewBasic;
+	public final fun component3-DnBUIck ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/Long;
+	public final fun component5 ()Ljava/lang/Long;
+	public final fun component6 ()Ljava/util/List;
+	public final fun component7 ()Ljava/lang/Long;
+	public final fun component8 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun component9-GUXd3rc ()Ljava/lang/String;
+	public final fun copy-G9iAMhA (Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/actor/ProfileViewBasic;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/util/List;Ljava/lang/Long;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/graph/StarterPackViewBasic;
+	public static synthetic fun copy-G9iAMhA$default (Lio/github/kikin81/atproto/app/bsky/graph/StarterPackViewBasic;Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/actor/ProfileViewBasic;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/util/List;Ljava/lang/Long;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/graph/StarterPackViewBasic;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCid-LVDfoeI ()Ljava/lang/String;
+	public final fun getCreator ()Lio/github/kikin81/atproto/app/bsky/actor/ProfileViewBasic;
+	public final fun getIndexedAt-DnBUIck ()Ljava/lang/String;
+	public final fun getJoinedAllTimeCount ()Ljava/lang/Long;
+	public final fun getJoinedWeekCount ()Ljava/lang/Long;
+	public final fun getLabels ()Ljava/util/List;
+	public final fun getListItemCount ()Ljava/lang/Long;
+	public final fun getRecord ()Lkotlinx/serialization/json/JsonObject;
+	public final fun getUri-GUXd3rc ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/graph/StarterPackViewBasic$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/graph/StarterPackViewBasic$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/graph/StarterPackViewBasic;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/graph/StarterPackViewBasic;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/StarterPackViewBasic$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/Starterpack {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/graph/Starterpack$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-DnBUIck ()Ljava/lang/String;
+	public final fun component2 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun component3 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun component4 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun component5-GUXd3rc ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun copy-aPiROnc (Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/graph/Starterpack;
+	public static synthetic fun copy-aPiROnc$default (Lio/github/kikin81/atproto/app/bsky/graph/Starterpack;Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/graph/Starterpack;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCreatedAt-DnBUIck ()Ljava/lang/String;
+	public final fun getDescription ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun getDescriptionFacets ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun getFeeds ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun getList-GUXd3rc ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/graph/Starterpack$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/graph/Starterpack$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/graph/Starterpack;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/graph/Starterpack;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/Starterpack$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/StarterpackFeedItem {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/graph/StarterpackFeedItem$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-GUXd3rc ()Ljava/lang/String;
+	public final fun copy-wvBT1Tk (Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/graph/StarterpackFeedItem;
+	public static synthetic fun copy-wvBT1Tk$default (Lio/github/kikin81/atproto/app/bsky/graph/StarterpackFeedItem;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/graph/StarterpackFeedItem;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUri-GUXd3rc ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/graph/StarterpackFeedItem$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/graph/StarterpackFeedItem$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/graph/StarterpackFeedItem;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/graph/StarterpackFeedItem;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/StarterpackFeedItem$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/Verification {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/graph/Verification$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-DnBUIck ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3-3bGGrYM ()Ljava/lang/String;
+	public final fun component4-UyB9Nic ()Ljava/lang/String;
+	public final fun copy-ytcO-ws (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/graph/Verification;
+	public static synthetic fun copy-ytcO-ws$default (Lio/github/kikin81/atproto/app/bsky/graph/Verification;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/graph/Verification;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCreatedAt-DnBUIck ()Ljava/lang/String;
+	public final fun getDisplayName ()Ljava/lang/String;
+	public final fun getHandle-3bGGrYM ()Ljava/lang/String;
+	public final fun getSubject-UyB9Nic ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/graph/Verification$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/graph/Verification$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/graph/Verification;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/graph/Verification;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/Verification$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/labeler/GetServicesRequest {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/labeler/GetServicesRequest$Companion;
+	public fun <init> (Ljava/lang/Boolean;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/Boolean;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Boolean;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/Boolean;Ljava/util/List;)Lio/github/kikin81/atproto/app/bsky/labeler/GetServicesRequest;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/labeler/GetServicesRequest;Ljava/lang/Boolean;Ljava/util/List;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/labeler/GetServicesRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDetailed ()Ljava/lang/Boolean;
+	public final fun getDids ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/labeler/GetServicesRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/labeler/GetServicesRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/labeler/GetServicesRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/labeler/GetServicesRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/labeler/GetServicesRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/labeler/GetServicesResponse {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/labeler/GetServicesResponse$Companion;
+	public fun <init> (Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lio/github/kikin81/atproto/app/bsky/labeler/GetServicesResponse;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/labeler/GetServicesResponse;Ljava/util/List;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/labeler/GetServicesResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getViews ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/labeler/GetServicesResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/labeler/GetServicesResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/labeler/GetServicesResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/labeler/GetServicesResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/labeler/GetServicesResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class io/github/kikin81/atproto/app/bsky/labeler/GetServicesResponseViewsUnion : io/github/kikin81/atproto/runtime/OpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/labeler/GetServicesResponseViewsUnion$Companion;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/labeler/GetServicesResponseViewsUnion$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/labeler/GetServicesResponseViewsUnion$Unknown : io/github/kikin81/atproto/app/bsky/labeler/GetServicesResponseViewsUnion, io/github/kikin81/atproto/runtime/UnknownOpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/labeler/GetServicesResponseViewsUnion$Unknown$Companion;
+	public fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/app/bsky/labeler/GetServicesResponseViewsUnion$Unknown;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/labeler/GetServicesResponseViewsUnion$Unknown;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/labeler/GetServicesResponseViewsUnion$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getRaw ()Lkotlinx/serialization/json/JsonObject;
+	public fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/labeler/GetServicesResponseViewsUnion$Unknown$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/labeler/GetServicesResponseViewsUnionSerializer : io/github/kikin81/atproto/runtime/OpenUnionSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/labeler/GetServicesResponseViewsUnionSerializer;
+	public fun selectKnownDeserializer (Ljava/lang/String;)Lkotlinx/serialization/KSerializer;
+	public fun selectKnownSerializer (Lio/github/kikin81/atproto/app/bsky/labeler/GetServicesResponseViewsUnion;)Lkotlinx/serialization/KSerializer;
+	public synthetic fun selectKnownSerializer (Lio/github/kikin81/atproto/runtime/OpenUnionMember;)Lkotlinx/serialization/KSerializer;
+	public fun unknownSerializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/labeler/GetServicesResponseViewsUnionUnknownSerializer : io/github/kikin81/atproto/runtime/UnknownMemberSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/labeler/GetServicesResponseViewsUnionUnknownSerializer;
+	public fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/app/bsky/labeler/GetServicesResponseViewsUnion$Unknown;
+	public synthetic fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/runtime/UnknownOpenUnionMember;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/labeler/LabelerPolicies {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/labeler/LabelerPolicies$Companion;
+	public fun <init> (Ljava/util/List;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;Ljava/util/List;)Lio/github/kikin81/atproto/app/bsky/labeler/LabelerPolicies;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/labeler/LabelerPolicies;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/labeler/LabelerPolicies;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getLabelValueDefinitions ()Ljava/util/List;
+	public final fun getLabelValues ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/labeler/LabelerPolicies$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/labeler/LabelerPolicies$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/labeler/LabelerPolicies;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/labeler/LabelerPolicies;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/labeler/LabelerPolicies$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/labeler/LabelerPoliciesInput {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/labeler/LabelerPoliciesInput$Companion;
+	public fun <init> (Lio/github/kikin81/atproto/runtime/AtField;Ljava/util/List;)V
+	public synthetic fun <init> (Lio/github/kikin81/atproto/runtime/AtField;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Lio/github/kikin81/atproto/runtime/AtField;Ljava/util/List;)Lio/github/kikin81/atproto/app/bsky/labeler/LabelerPoliciesInput;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/labeler/LabelerPoliciesInput;Lio/github/kikin81/atproto/runtime/AtField;Ljava/util/List;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/labeler/LabelerPoliciesInput;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getLabelValueDefinitions ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun getLabelValues ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/labeler/LabelerPoliciesInput$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/labeler/LabelerPoliciesInput$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/labeler/LabelerPoliciesInput;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/labeler/LabelerPoliciesInput;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/labeler/LabelerPoliciesInput$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/labeler/LabelerService {
+	public fun <init> (Lio/github/kikin81/atproto/runtime/XrpcClient;)V
+	public final fun getServices (Lio/github/kikin81/atproto/app/bsky/labeler/GetServicesRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/labeler/LabelerView : io/github/kikin81/atproto/app/bsky/embed/RecordViewRecordUnion, io/github/kikin81/atproto/app/bsky/labeler/GetServicesResponseViewsUnion {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/labeler/LabelerView$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/actor/ProfileView;Ljava/lang/String;Ljava/util/List;Ljava/lang/Long;Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/labeler/LabelerViewerState;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/actor/ProfileView;Ljava/lang/String;Ljava/util/List;Ljava/lang/Long;Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/labeler/LabelerViewerState;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-LVDfoeI ()Ljava/lang/String;
+	public final fun component2 ()Lio/github/kikin81/atproto/app/bsky/actor/ProfileView;
+	public final fun component3-DnBUIck ()Ljava/lang/String;
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Ljava/lang/Long;
+	public final fun component6-GUXd3rc ()Ljava/lang/String;
+	public final fun component7 ()Lio/github/kikin81/atproto/app/bsky/labeler/LabelerViewerState;
+	public final fun copy-9fgXcbQ (Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/actor/ProfileView;Ljava/lang/String;Ljava/util/List;Ljava/lang/Long;Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/labeler/LabelerViewerState;)Lio/github/kikin81/atproto/app/bsky/labeler/LabelerView;
+	public static synthetic fun copy-9fgXcbQ$default (Lio/github/kikin81/atproto/app/bsky/labeler/LabelerView;Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/actor/ProfileView;Ljava/lang/String;Ljava/util/List;Ljava/lang/Long;Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/labeler/LabelerViewerState;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/labeler/LabelerView;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCid-LVDfoeI ()Ljava/lang/String;
+	public final fun getCreator ()Lio/github/kikin81/atproto/app/bsky/actor/ProfileView;
+	public final fun getIndexedAt-DnBUIck ()Ljava/lang/String;
+	public final fun getLabels ()Ljava/util/List;
+	public final fun getLikeCount ()Ljava/lang/Long;
+	public final fun getUri-GUXd3rc ()Ljava/lang/String;
+	public final fun getViewer ()Lio/github/kikin81/atproto/app/bsky/labeler/LabelerViewerState;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/labeler/LabelerView$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/labeler/LabelerView$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/labeler/LabelerView;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/labeler/LabelerView;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/labeler/LabelerView$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/labeler/LabelerViewDetailed : io/github/kikin81/atproto/app/bsky/labeler/GetServicesResponseViewsUnion {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/labeler/LabelerViewDetailed$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/actor/ProfileView;Ljava/lang/String;Ljava/util/List;Ljava/lang/Long;Lio/github/kikin81/atproto/app/bsky/labeler/LabelerPolicies;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/labeler/LabelerViewerState;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/actor/ProfileView;Ljava/lang/String;Ljava/util/List;Ljava/lang/Long;Lio/github/kikin81/atproto/app/bsky/labeler/LabelerPolicies;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/labeler/LabelerViewerState;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-LVDfoeI ()Ljava/lang/String;
+	public final fun component10-GUXd3rc ()Ljava/lang/String;
+	public final fun component11 ()Lio/github/kikin81/atproto/app/bsky/labeler/LabelerViewerState;
+	public final fun component2 ()Lio/github/kikin81/atproto/app/bsky/actor/ProfileView;
+	public final fun component3-DnBUIck ()Ljava/lang/String;
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Ljava/lang/Long;
+	public final fun component6 ()Lio/github/kikin81/atproto/app/bsky/labeler/LabelerPolicies;
+	public final fun component7 ()Ljava/util/List;
+	public final fun component8 ()Ljava/util/List;
+	public final fun component9 ()Ljava/util/List;
+	public final fun copy-dixqSa0 (Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/actor/ProfileView;Ljava/lang/String;Ljava/util/List;Ljava/lang/Long;Lio/github/kikin81/atproto/app/bsky/labeler/LabelerPolicies;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/labeler/LabelerViewerState;)Lio/github/kikin81/atproto/app/bsky/labeler/LabelerViewDetailed;
+	public static synthetic fun copy-dixqSa0$default (Lio/github/kikin81/atproto/app/bsky/labeler/LabelerViewDetailed;Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/actor/ProfileView;Ljava/lang/String;Ljava/util/List;Ljava/lang/Long;Lio/github/kikin81/atproto/app/bsky/labeler/LabelerPolicies;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/labeler/LabelerViewerState;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/labeler/LabelerViewDetailed;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCid-LVDfoeI ()Ljava/lang/String;
+	public final fun getCreator ()Lio/github/kikin81/atproto/app/bsky/actor/ProfileView;
+	public final fun getIndexedAt-DnBUIck ()Ljava/lang/String;
+	public final fun getLabels ()Ljava/util/List;
+	public final fun getLikeCount ()Ljava/lang/Long;
+	public final fun getPolicies ()Lio/github/kikin81/atproto/app/bsky/labeler/LabelerPolicies;
+	public final fun getReasonTypes ()Ljava/util/List;
+	public final fun getSubjectCollections ()Ljava/util/List;
+	public final fun getSubjectTypes ()Ljava/util/List;
+	public final fun getUri-GUXd3rc ()Ljava/lang/String;
+	public final fun getViewer ()Lio/github/kikin81/atproto/app/bsky/labeler/LabelerViewerState;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/labeler/LabelerViewDetailed$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/labeler/LabelerViewDetailed$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/labeler/LabelerViewDetailed;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/labeler/LabelerViewDetailed;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/labeler/LabelerViewDetailed$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/labeler/LabelerViewerState {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/labeler/LabelerViewerState$Companion;
+	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-XX8z880 ()Ljava/lang/String;
+	public final fun copy-c7AqoAI (Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/labeler/LabelerViewerState;
+	public static synthetic fun copy-c7AqoAI$default (Lio/github/kikin81/atproto/app/bsky/labeler/LabelerViewerState;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/labeler/LabelerViewerState;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getLike-XX8z880 ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/labeler/LabelerViewerState$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/labeler/LabelerViewerState$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/labeler/LabelerViewerState;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/labeler/LabelerViewerState;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/labeler/LabelerViewerState$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/labeler/Service {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/labeler/Service$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/app/bsky/labeler/LabelerPolicies;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/app/bsky/labeler/LabelerPolicies;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-DnBUIck ()Ljava/lang/String;
+	public final fun component2 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun component3 ()Lio/github/kikin81/atproto/app/bsky/labeler/LabelerPolicies;
+	public final fun component4 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun component5 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun component6 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun copy-MR29QaQ (Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/app/bsky/labeler/LabelerPolicies;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;)Lio/github/kikin81/atproto/app/bsky/labeler/Service;
+	public static synthetic fun copy-MR29QaQ$default (Lio/github/kikin81/atproto/app/bsky/labeler/Service;Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/app/bsky/labeler/LabelerPolicies;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/labeler/Service;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCreatedAt-DnBUIck ()Ljava/lang/String;
+	public final fun getLabels ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun getPolicies ()Lio/github/kikin81/atproto/app/bsky/labeler/LabelerPolicies;
+	public final fun getReasonTypes ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun getSubjectCollections ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun getSubjectTypes ()Lio/github/kikin81/atproto/runtime/AtField;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/labeler/Service$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/labeler/Service$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/labeler/Service;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/labeler/Service;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/labeler/Service$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class io/github/kikin81/atproto/app/bsky/labeler/ServiceLabelsUnion : io/github/kikin81/atproto/runtime/OpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/labeler/ServiceLabelsUnion$Companion;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/labeler/ServiceLabelsUnion$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/labeler/ServiceLabelsUnion$Unknown : io/github/kikin81/atproto/app/bsky/labeler/ServiceLabelsUnion, io/github/kikin81/atproto/runtime/UnknownOpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/labeler/ServiceLabelsUnion$Unknown$Companion;
+	public fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/app/bsky/labeler/ServiceLabelsUnion$Unknown;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/labeler/ServiceLabelsUnion$Unknown;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/labeler/ServiceLabelsUnion$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getRaw ()Lkotlinx/serialization/json/JsonObject;
+	public fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/labeler/ServiceLabelsUnion$Unknown$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/labeler/ServiceLabelsUnionSerializer : io/github/kikin81/atproto/runtime/OpenUnionSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/labeler/ServiceLabelsUnionSerializer;
+	public fun selectKnownDeserializer (Ljava/lang/String;)Lkotlinx/serialization/KSerializer;
+	public fun selectKnownSerializer (Lio/github/kikin81/atproto/app/bsky/labeler/ServiceLabelsUnion;)Lkotlinx/serialization/KSerializer;
+	public synthetic fun selectKnownSerializer (Lio/github/kikin81/atproto/runtime/OpenUnionMember;)Lkotlinx/serialization/KSerializer;
+	public fun unknownSerializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/labeler/ServiceLabelsUnionUnknownSerializer : io/github/kikin81/atproto/runtime/UnknownMemberSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/labeler/ServiceLabelsUnionUnknownSerializer;
+	public fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/app/bsky/labeler/ServiceLabelsUnion$Unknown;
+	public synthetic fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/runtime/UnknownOpenUnionMember;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/notification/ActivitySubscription {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/notification/ActivitySubscription$Companion;
+	public fun <init> (ZZ)V
+	public final fun component1 ()Z
+	public final fun component2 ()Z
+	public final fun copy (ZZ)Lio/github/kikin81/atproto/app/bsky/notification/ActivitySubscription;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/notification/ActivitySubscription;ZZILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/notification/ActivitySubscription;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPost ()Z
+	public final fun getReply ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/notification/ActivitySubscription$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/notification/ActivitySubscription$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/notification/ActivitySubscription;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/notification/ActivitySubscription;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/notification/ActivitySubscription$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/notification/ChatPreference {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/notification/ChatPreference$Companion;
+	public fun <init> (Ljava/lang/String;Z)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Z
+	public final fun copy (Ljava/lang/String;Z)Lio/github/kikin81/atproto/app/bsky/notification/ChatPreference;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/notification/ChatPreference;Ljava/lang/String;ZILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/notification/ChatPreference;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getInclude ()Ljava/lang/String;
+	public final fun getPush ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/notification/ChatPreference$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/notification/ChatPreference$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/notification/ChatPreference;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/notification/ChatPreference;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/notification/ChatPreference$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/notification/FilterablePreference {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/notification/FilterablePreference$Companion;
+	public fun <init> (Ljava/lang/String;ZZ)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Z
+	public final fun component3 ()Z
+	public final fun copy (Ljava/lang/String;ZZ)Lio/github/kikin81/atproto/app/bsky/notification/FilterablePreference;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/notification/FilterablePreference;Ljava/lang/String;ZZILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/notification/FilterablePreference;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getInclude ()Ljava/lang/String;
+	public final fun getList ()Z
+	public final fun getPush ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/notification/FilterablePreference$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/notification/FilterablePreference$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/notification/FilterablePreference;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/notification/FilterablePreference;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/notification/FilterablePreference$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/notification/GetUnreadCountRequest {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/notification/GetUnreadCountRequest$Companion;
+	public synthetic fun <init> (Ljava/lang/Boolean;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/Boolean;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Boolean;
+	public final fun component2-G5DCnlA ()Ljava/lang/String;
+	public final fun copy-Tl4erm8 (Ljava/lang/Boolean;Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/notification/GetUnreadCountRequest;
+	public static synthetic fun copy-Tl4erm8$default (Lio/github/kikin81/atproto/app/bsky/notification/GetUnreadCountRequest;Ljava/lang/Boolean;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/notification/GetUnreadCountRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPriority ()Ljava/lang/Boolean;
+	public final fun getSeenAt-G5DCnlA ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/notification/GetUnreadCountRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/notification/GetUnreadCountRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/notification/GetUnreadCountRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/notification/GetUnreadCountRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/notification/GetUnreadCountRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/notification/GetUnreadCountResponse {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/notification/GetUnreadCountResponse$Companion;
+	public fun <init> (J)V
+	public final fun component1 ()J
+	public final fun copy (J)Lio/github/kikin81/atproto/app/bsky/notification/GetUnreadCountResponse;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/notification/GetUnreadCountResponse;JILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/notification/GetUnreadCountResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCount ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/notification/GetUnreadCountResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/notification/GetUnreadCountResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/notification/GetUnreadCountResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/notification/GetUnreadCountResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/notification/GetUnreadCountResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/notification/ListNotificationsNotification {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/notification/ListNotificationsNotification$Companion;
+	public synthetic fun <init> (Lio/github/kikin81/atproto/app/bsky/actor/ProfileView;Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lio/github/kikin81/atproto/app/bsky/actor/ProfileView;Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/app/bsky/actor/ProfileView;
+	public final fun component2-LVDfoeI ()Ljava/lang/String;
+	public final fun component3-DnBUIck ()Ljava/lang/String;
+	public final fun component4 ()Z
+	public final fun component5 ()Ljava/util/List;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7-XX8z880 ()Ljava/lang/String;
+	public final fun component8 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun component9-GUXd3rc ()Ljava/lang/String;
+	public final fun copy-fuaNEfE (Lio/github/kikin81/atproto/app/bsky/actor/ProfileView;Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/notification/ListNotificationsNotification;
+	public static synthetic fun copy-fuaNEfE$default (Lio/github/kikin81/atproto/app/bsky/notification/ListNotificationsNotification;Lio/github/kikin81/atproto/app/bsky/actor/ProfileView;Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/notification/ListNotificationsNotification;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAuthor ()Lio/github/kikin81/atproto/app/bsky/actor/ProfileView;
+	public final fun getCid-LVDfoeI ()Ljava/lang/String;
+	public final fun getIndexedAt-DnBUIck ()Ljava/lang/String;
+	public final fun getLabels ()Ljava/util/List;
+	public final fun getReason ()Ljava/lang/String;
+	public final fun getReasonSubject-XX8z880 ()Ljava/lang/String;
+	public final fun getRecord ()Lkotlinx/serialization/json/JsonObject;
+	public final fun getUri-GUXd3rc ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun isRead ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/notification/ListNotificationsNotification$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/notification/ListNotificationsNotification$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/notification/ListNotificationsNotification;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/notification/ListNotificationsNotification;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/notification/ListNotificationsNotification$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/notification/ListNotificationsRequest {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/notification/ListNotificationsRequest$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/Long;
+	public final fun component3 ()Ljava/lang/Boolean;
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5-G5DCnlA ()Ljava/lang/String;
+	public final fun copy-wz8iMsg (Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/notification/ListNotificationsRequest;
+	public static synthetic fun copy-wz8iMsg$default (Lio/github/kikin81/atproto/app/bsky/notification/ListNotificationsRequest;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/notification/ListNotificationsRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCursor ()Ljava/lang/String;
+	public final fun getLimit ()Ljava/lang/Long;
+	public final fun getPriority ()Ljava/lang/Boolean;
+	public final fun getReasons ()Ljava/util/List;
+	public final fun getSeenAt-G5DCnlA ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/notification/ListNotificationsRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/notification/ListNotificationsRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/notification/ListNotificationsRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/notification/ListNotificationsRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/notification/ListNotificationsRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/notification/ListNotificationsResponse {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/notification/ListNotificationsResponse$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/lang/Boolean;
+	public final fun component4-G5DCnlA ()Ljava/lang/String;
+	public final fun copy-ncnrRco (Ljava/lang/String;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/notification/ListNotificationsResponse;
+	public static synthetic fun copy-ncnrRco$default (Lio/github/kikin81/atproto/app/bsky/notification/ListNotificationsResponse;Ljava/lang/String;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/notification/ListNotificationsResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCursor ()Ljava/lang/String;
+	public final fun getNotifications ()Ljava/util/List;
+	public final fun getPriority ()Ljava/lang/Boolean;
+	public final fun getSeenAt-G5DCnlA ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/notification/ListNotificationsResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/notification/ListNotificationsResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/notification/ListNotificationsResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/notification/ListNotificationsResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/notification/ListNotificationsResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/notification/NotificationService {
+	public fun <init> (Lio/github/kikin81/atproto/runtime/XrpcClient;)V
+	public final fun getUnreadCount (Lio/github/kikin81/atproto/app/bsky/notification/GetUnreadCountRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getUnreadCount$default (Lio/github/kikin81/atproto/app/bsky/notification/NotificationService;Lio/github/kikin81/atproto/app/bsky/notification/GetUnreadCountRequest;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun listNotifications (Lio/github/kikin81/atproto/app/bsky/notification/ListNotificationsRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun listNotifications$default (Lio/github/kikin81/atproto/app/bsky/notification/NotificationService;Lio/github/kikin81/atproto/app/bsky/notification/ListNotificationsRequest;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun updateSeen (Lio/github/kikin81/atproto/app/bsky/notification/UpdateSeenRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/notification/NotificationServiceKt {
+	public static final fun listNotificationsFlow (Lio/github/kikin81/atproto/app/bsky/notification/NotificationService;Lio/github/kikin81/atproto/app/bsky/notification/ListNotificationsRequest;)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun listNotificationsFlow$default (Lio/github/kikin81/atproto/app/bsky/notification/NotificationService;Lio/github/kikin81/atproto/app/bsky/notification/ListNotificationsRequest;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun listNotificationsPageFlow (Lio/github/kikin81/atproto/app/bsky/notification/NotificationService;Lio/github/kikin81/atproto/app/bsky/notification/ListNotificationsRequest;)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun listNotificationsPageFlow$default (Lio/github/kikin81/atproto/app/bsky/notification/NotificationService;Lio/github/kikin81/atproto/app/bsky/notification/ListNotificationsRequest;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/notification/Preference {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/notification/Preference$Companion;
+	public fun <init> (ZZ)V
+	public final fun component1 ()Z
+	public final fun component2 ()Z
+	public final fun copy (ZZ)Lio/github/kikin81/atproto/app/bsky/notification/Preference;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/notification/Preference;ZZILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/notification/Preference;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getList ()Z
+	public final fun getPush ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/notification/Preference$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/notification/Preference$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/notification/Preference;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/notification/Preference;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/notification/Preference$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/notification/Preferences {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/notification/Preferences$Companion;
+	public fun <init> (Lio/github/kikin81/atproto/app/bsky/notification/ChatPreference;Lio/github/kikin81/atproto/app/bsky/notification/FilterablePreference;Lio/github/kikin81/atproto/app/bsky/notification/FilterablePreference;Lio/github/kikin81/atproto/app/bsky/notification/FilterablePreference;Lio/github/kikin81/atproto/app/bsky/notification/FilterablePreference;Lio/github/kikin81/atproto/app/bsky/notification/FilterablePreference;Lio/github/kikin81/atproto/app/bsky/notification/FilterablePreference;Lio/github/kikin81/atproto/app/bsky/notification/FilterablePreference;Lio/github/kikin81/atproto/app/bsky/notification/FilterablePreference;Lio/github/kikin81/atproto/app/bsky/notification/Preference;Lio/github/kikin81/atproto/app/bsky/notification/Preference;Lio/github/kikin81/atproto/app/bsky/notification/Preference;Lio/github/kikin81/atproto/app/bsky/notification/Preference;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/app/bsky/notification/ChatPreference;
+	public final fun component10 ()Lio/github/kikin81/atproto/app/bsky/notification/Preference;
+	public final fun component11 ()Lio/github/kikin81/atproto/app/bsky/notification/Preference;
+	public final fun component12 ()Lio/github/kikin81/atproto/app/bsky/notification/Preference;
+	public final fun component13 ()Lio/github/kikin81/atproto/app/bsky/notification/Preference;
+	public final fun component2 ()Lio/github/kikin81/atproto/app/bsky/notification/FilterablePreference;
+	public final fun component3 ()Lio/github/kikin81/atproto/app/bsky/notification/FilterablePreference;
+	public final fun component4 ()Lio/github/kikin81/atproto/app/bsky/notification/FilterablePreference;
+	public final fun component5 ()Lio/github/kikin81/atproto/app/bsky/notification/FilterablePreference;
+	public final fun component6 ()Lio/github/kikin81/atproto/app/bsky/notification/FilterablePreference;
+	public final fun component7 ()Lio/github/kikin81/atproto/app/bsky/notification/FilterablePreference;
+	public final fun component8 ()Lio/github/kikin81/atproto/app/bsky/notification/FilterablePreference;
+	public final fun component9 ()Lio/github/kikin81/atproto/app/bsky/notification/FilterablePreference;
+	public final fun copy (Lio/github/kikin81/atproto/app/bsky/notification/ChatPreference;Lio/github/kikin81/atproto/app/bsky/notification/FilterablePreference;Lio/github/kikin81/atproto/app/bsky/notification/FilterablePreference;Lio/github/kikin81/atproto/app/bsky/notification/FilterablePreference;Lio/github/kikin81/atproto/app/bsky/notification/FilterablePreference;Lio/github/kikin81/atproto/app/bsky/notification/FilterablePreference;Lio/github/kikin81/atproto/app/bsky/notification/FilterablePreference;Lio/github/kikin81/atproto/app/bsky/notification/FilterablePreference;Lio/github/kikin81/atproto/app/bsky/notification/FilterablePreference;Lio/github/kikin81/atproto/app/bsky/notification/Preference;Lio/github/kikin81/atproto/app/bsky/notification/Preference;Lio/github/kikin81/atproto/app/bsky/notification/Preference;Lio/github/kikin81/atproto/app/bsky/notification/Preference;)Lio/github/kikin81/atproto/app/bsky/notification/Preferences;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/notification/Preferences;Lio/github/kikin81/atproto/app/bsky/notification/ChatPreference;Lio/github/kikin81/atproto/app/bsky/notification/FilterablePreference;Lio/github/kikin81/atproto/app/bsky/notification/FilterablePreference;Lio/github/kikin81/atproto/app/bsky/notification/FilterablePreference;Lio/github/kikin81/atproto/app/bsky/notification/FilterablePreference;Lio/github/kikin81/atproto/app/bsky/notification/FilterablePreference;Lio/github/kikin81/atproto/app/bsky/notification/FilterablePreference;Lio/github/kikin81/atproto/app/bsky/notification/FilterablePreference;Lio/github/kikin81/atproto/app/bsky/notification/FilterablePreference;Lio/github/kikin81/atproto/app/bsky/notification/Preference;Lio/github/kikin81/atproto/app/bsky/notification/Preference;Lio/github/kikin81/atproto/app/bsky/notification/Preference;Lio/github/kikin81/atproto/app/bsky/notification/Preference;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/notification/Preferences;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getChat ()Lio/github/kikin81/atproto/app/bsky/notification/ChatPreference;
+	public final fun getFollow ()Lio/github/kikin81/atproto/app/bsky/notification/FilterablePreference;
+	public final fun getLike ()Lio/github/kikin81/atproto/app/bsky/notification/FilterablePreference;
+	public final fun getLikeViaRepost ()Lio/github/kikin81/atproto/app/bsky/notification/FilterablePreference;
+	public final fun getMention ()Lio/github/kikin81/atproto/app/bsky/notification/FilterablePreference;
+	public final fun getQuote ()Lio/github/kikin81/atproto/app/bsky/notification/FilterablePreference;
+	public final fun getReply ()Lio/github/kikin81/atproto/app/bsky/notification/FilterablePreference;
+	public final fun getRepost ()Lio/github/kikin81/atproto/app/bsky/notification/FilterablePreference;
+	public final fun getRepostViaRepost ()Lio/github/kikin81/atproto/app/bsky/notification/FilterablePreference;
+	public final fun getStarterpackJoined ()Lio/github/kikin81/atproto/app/bsky/notification/Preference;
+	public final fun getSubscribedPost ()Lio/github/kikin81/atproto/app/bsky/notification/Preference;
+	public final fun getUnverified ()Lio/github/kikin81/atproto/app/bsky/notification/Preference;
+	public final fun getVerified ()Lio/github/kikin81/atproto/app/bsky/notification/Preference;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/notification/Preferences$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/notification/Preferences$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/notification/Preferences;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/notification/Preferences;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/notification/Preferences$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/notification/RecordDeleted {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/notification/RecordDeleted$Companion;
+	public fun <init> ()V
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/notification/RecordDeleted$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/notification/RecordDeleted$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/notification/RecordDeleted;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/notification/RecordDeleted;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/notification/RecordDeleted$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/notification/SubjectActivitySubscription {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/notification/SubjectActivitySubscription$Companion;
+	public synthetic fun <init> (Lio/github/kikin81/atproto/app/bsky/notification/ActivitySubscription;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/app/bsky/notification/ActivitySubscription;
+	public final fun component2-UyB9Nic ()Ljava/lang/String;
+	public final fun copy-aB4ouW8 (Lio/github/kikin81/atproto/app/bsky/notification/ActivitySubscription;Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/notification/SubjectActivitySubscription;
+	public static synthetic fun copy-aB4ouW8$default (Lio/github/kikin81/atproto/app/bsky/notification/SubjectActivitySubscription;Lio/github/kikin81/atproto/app/bsky/notification/ActivitySubscription;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/notification/SubjectActivitySubscription;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActivitySubscription ()Lio/github/kikin81/atproto/app/bsky/notification/ActivitySubscription;
+	public final fun getSubject-UyB9Nic ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/notification/SubjectActivitySubscription$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/notification/SubjectActivitySubscription$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/notification/SubjectActivitySubscription;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/notification/SubjectActivitySubscription;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/notification/SubjectActivitySubscription$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/notification/UpdateSeenRequest {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/notification/UpdateSeenRequest$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-DnBUIck ()Ljava/lang/String;
+	public final fun copy-Xa6jipg (Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/notification/UpdateSeenRequest;
+	public static synthetic fun copy-Xa6jipg$default (Lio/github/kikin81/atproto/app/bsky/notification/UpdateSeenRequest;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/notification/UpdateSeenRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getSeenAt-DnBUIck ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/notification/UpdateSeenRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/notification/UpdateSeenRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/notification/UpdateSeenRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/notification/UpdateSeenRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/notification/UpdateSeenRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/richtext/Facet {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/richtext/Facet$Companion;
+	public fun <init> (Ljava/util/List;Lio/github/kikin81/atproto/app/bsky/richtext/FacetByteSlice;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Lio/github/kikin81/atproto/app/bsky/richtext/FacetByteSlice;
+	public final fun copy (Ljava/util/List;Lio/github/kikin81/atproto/app/bsky/richtext/FacetByteSlice;)Lio/github/kikin81/atproto/app/bsky/richtext/Facet;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/richtext/Facet;Ljava/util/List;Lio/github/kikin81/atproto/app/bsky/richtext/FacetByteSlice;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/richtext/Facet;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFeatures ()Ljava/util/List;
+	public final fun getIndex ()Lio/github/kikin81/atproto/app/bsky/richtext/FacetByteSlice;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/richtext/Facet$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/richtext/Facet$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/richtext/Facet;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/richtext/Facet;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/richtext/Facet$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/richtext/FacetByteSlice {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/richtext/FacetByteSlice$Companion;
+	public fun <init> (JJ)V
+	public final fun component1 ()J
+	public final fun component2 ()J
+	public final fun copy (JJ)Lio/github/kikin81/atproto/app/bsky/richtext/FacetByteSlice;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/richtext/FacetByteSlice;JJILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/richtext/FacetByteSlice;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getByteEnd ()J
+	public final fun getByteStart ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/richtext/FacetByteSlice$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/richtext/FacetByteSlice$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/richtext/FacetByteSlice;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/richtext/FacetByteSlice;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/richtext/FacetByteSlice$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class io/github/kikin81/atproto/app/bsky/richtext/FacetFeaturesUnion : io/github/kikin81/atproto/runtime/OpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/richtext/FacetFeaturesUnion$Companion;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/richtext/FacetFeaturesUnion$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/richtext/FacetFeaturesUnion$Unknown : io/github/kikin81/atproto/app/bsky/richtext/FacetFeaturesUnion, io/github/kikin81/atproto/runtime/UnknownOpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/richtext/FacetFeaturesUnion$Unknown$Companion;
+	public fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/app/bsky/richtext/FacetFeaturesUnion$Unknown;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/richtext/FacetFeaturesUnion$Unknown;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/richtext/FacetFeaturesUnion$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getRaw ()Lkotlinx/serialization/json/JsonObject;
+	public fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/richtext/FacetFeaturesUnion$Unknown$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/richtext/FacetFeaturesUnionSerializer : io/github/kikin81/atproto/runtime/OpenUnionSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/richtext/FacetFeaturesUnionSerializer;
+	public fun selectKnownDeserializer (Ljava/lang/String;)Lkotlinx/serialization/KSerializer;
+	public fun selectKnownSerializer (Lio/github/kikin81/atproto/app/bsky/richtext/FacetFeaturesUnion;)Lkotlinx/serialization/KSerializer;
+	public synthetic fun selectKnownSerializer (Lio/github/kikin81/atproto/runtime/OpenUnionMember;)Lkotlinx/serialization/KSerializer;
+	public fun unknownSerializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/richtext/FacetFeaturesUnionUnknownSerializer : io/github/kikin81/atproto/runtime/UnknownMemberSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/richtext/FacetFeaturesUnionUnknownSerializer;
+	public fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/app/bsky/richtext/FacetFeaturesUnion$Unknown;
+	public synthetic fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/runtime/UnknownOpenUnionMember;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/richtext/FacetLink : io/github/kikin81/atproto/app/bsky/richtext/FacetFeaturesUnion {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/richtext/FacetLink$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-jMNtXP8 ()Ljava/lang/String;
+	public final fun copy-joEfuLA (Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/richtext/FacetLink;
+	public static synthetic fun copy-joEfuLA$default (Lio/github/kikin81/atproto/app/bsky/richtext/FacetLink;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/richtext/FacetLink;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUri-jMNtXP8 ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/richtext/FacetLink$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/richtext/FacetLink$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/richtext/FacetLink;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/richtext/FacetLink;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/richtext/FacetLink$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/richtext/FacetMention : io/github/kikin81/atproto/app/bsky/richtext/FacetFeaturesUnion {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/richtext/FacetMention$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-UyB9Nic ()Ljava/lang/String;
+	public final fun copy-OoJ1cAE (Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/richtext/FacetMention;
+	public static synthetic fun copy-OoJ1cAE$default (Lio/github/kikin81/atproto/app/bsky/richtext/FacetMention;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/richtext/FacetMention;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDid-UyB9Nic ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/richtext/FacetMention$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/richtext/FacetMention$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/richtext/FacetMention;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/richtext/FacetMention;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/richtext/FacetMention$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/richtext/FacetTag : io/github/kikin81/atproto/app/bsky/richtext/FacetFeaturesUnion {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/richtext/FacetTag$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/richtext/FacetTag;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/richtext/FacetTag;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/richtext/FacetTag;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getTag ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/richtext/FacetTag$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/richtext/FacetTag$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/richtext/FacetTag;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/richtext/FacetTag;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/richtext/FacetTag$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/actor/Declaration {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/actor/Declaration$Companion;
+	public fun <init> (Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;)V
+	public synthetic fun <init> (Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/actor/Declaration;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/actor/Declaration;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/actor/Declaration;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAllowGroupInvites ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun getAllowIncoming ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/actor/Declaration$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/actor/Declaration$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/actor/Declaration;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/actor/Declaration;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/actor/Declaration$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/actor/DirectConvoMember : io/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasicKindUnion {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/actor/DirectConvoMember$Companion;
+	public fun <init> ()V
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/actor/DirectConvoMember$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/actor/DirectConvoMember$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/actor/DirectConvoMember;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/actor/DirectConvoMember;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/actor/DirectConvoMember$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/actor/GroupConvoMember : io/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasicKindUnion {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/actor/GroupConvoMember$Companion;
+	public fun <init> (Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;Ljava/lang/String;)V
+	public synthetic fun <init> (Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/actor/GroupConvoMember;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/actor/GroupConvoMember;Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/actor/GroupConvoMember;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAddedBy ()Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;
+	public final fun getRole ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/actor/GroupConvoMember$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/actor/GroupConvoMember$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/actor/GroupConvoMember;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/actor/GroupConvoMember;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/actor/GroupConvoMember$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic$Companion;
+	public synthetic fun <init> (Lio/github/kikin81/atproto/app/bsky/actor/ProfileAssociated;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasicKindUnion;Ljava/util/List;Lio/github/kikin81/atproto/app/bsky/actor/VerificationState;Lio/github/kikin81/atproto/app/bsky/actor/ViewerState;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lio/github/kikin81/atproto/app/bsky/actor/ProfileAssociated;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasicKindUnion;Ljava/util/List;Lio/github/kikin81/atproto/app/bsky/actor/VerificationState;Lio/github/kikin81/atproto/app/bsky/actor/ViewerState;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/app/bsky/actor/ProfileAssociated;
+	public final fun component10 ()Lio/github/kikin81/atproto/app/bsky/actor/VerificationState;
+	public final fun component11 ()Lio/github/kikin81/atproto/app/bsky/actor/ViewerState;
+	public final fun component2-Eo6btPk ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/Boolean;
+	public final fun component4-G5DCnlA ()Ljava/lang/String;
+	public final fun component5-UyB9Nic ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7-3bGGrYM ()Ljava/lang/String;
+	public final fun component8 ()Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasicKindUnion;
+	public final fun component9 ()Ljava/util/List;
+	public final fun copy-V4FqKTw (Lio/github/kikin81/atproto/app/bsky/actor/ProfileAssociated;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasicKindUnion;Ljava/util/List;Lio/github/kikin81/atproto/app/bsky/actor/VerificationState;Lio/github/kikin81/atproto/app/bsky/actor/ViewerState;)Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;
+	public static synthetic fun copy-V4FqKTw$default (Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;Lio/github/kikin81/atproto/app/bsky/actor/ProfileAssociated;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasicKindUnion;Ljava/util/List;Lio/github/kikin81/atproto/app/bsky/actor/VerificationState;Lio/github/kikin81/atproto/app/bsky/actor/ViewerState;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAssociated ()Lio/github/kikin81/atproto/app/bsky/actor/ProfileAssociated;
+	public final fun getAvatar-Eo6btPk ()Ljava/lang/String;
+	public final fun getChatDisabled ()Ljava/lang/Boolean;
+	public final fun getCreatedAt-G5DCnlA ()Ljava/lang/String;
+	public final fun getDid-UyB9Nic ()Ljava/lang/String;
+	public final fun getDisplayName ()Ljava/lang/String;
+	public final fun getHandle-3bGGrYM ()Ljava/lang/String;
+	public final fun getKind ()Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasicKindUnion;
+	public final fun getLabels ()Ljava/util/List;
+	public final fun getVerification ()Lio/github/kikin81/atproto/app/bsky/actor/VerificationState;
+	public final fun getViewer ()Lio/github/kikin81/atproto/app/bsky/actor/ViewerState;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class io/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasicKindUnion : io/github/kikin81/atproto/runtime/OpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasicKindUnion$Companion;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasicKindUnion$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasicKindUnion$Unknown : io/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasicKindUnion, io/github/kikin81/atproto/runtime/UnknownOpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasicKindUnion$Unknown$Companion;
+	public fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasicKindUnion$Unknown;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasicKindUnion$Unknown;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasicKindUnion$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getRaw ()Lkotlinx/serialization/json/JsonObject;
+	public fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasicKindUnion$Unknown$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasicKindUnionSerializer : io/github/kikin81/atproto/runtime/OpenUnionSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasicKindUnionSerializer;
+	public fun selectKnownDeserializer (Ljava/lang/String;)Lkotlinx/serialization/KSerializer;
+	public fun selectKnownSerializer (Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasicKindUnion;)Lkotlinx/serialization/KSerializer;
+	public synthetic fun selectKnownSerializer (Lio/github/kikin81/atproto/runtime/OpenUnionMember;)Lkotlinx/serialization/KSerializer;
+	public fun unknownSerializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasicKindUnionUnknownSerializer : io/github/kikin81/atproto/runtime/UnknownMemberSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasicKindUnionUnknownSerializer;
+	public fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasicKindUnion$Unknown;
+	public synthetic fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/runtime/UnknownOpenUnionMember;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/ConvoService {
+	public fun <init> (Lio/github/kikin81/atproto/runtime/XrpcClient;)V
+	public final fun getMessages (Lio/github/kikin81/atproto/chat/bsky/convo/GetMessagesRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun listConvos (Lio/github/kikin81/atproto/chat/bsky/convo/ListConvosRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun listConvos$default (Lio/github/kikin81/atproto/chat/bsky/convo/ConvoService;Lio/github/kikin81/atproto/chat/bsky/convo/ListConvosRequest;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun sendMessage (Lio/github/kikin81/atproto/chat/bsky/convo/SendMessageRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/ConvoServiceKt {
+	public static final fun listConvosFlow (Lio/github/kikin81/atproto/chat/bsky/convo/ConvoService;Lio/github/kikin81/atproto/chat/bsky/convo/ListConvosRequest;)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun listConvosFlow$default (Lio/github/kikin81/atproto/chat/bsky/convo/ConvoService;Lio/github/kikin81/atproto/chat/bsky/convo/ListConvosRequest;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun listConvosPageFlow (Lio/github/kikin81/atproto/chat/bsky/convo/ConvoService;Lio/github/kikin81/atproto/chat/bsky/convo/ListConvosRequest;)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun listConvosPageFlow$default (Lio/github/kikin81/atproto/chat/bsky/convo/ConvoService;Lio/github/kikin81/atproto/chat/bsky/convo/ListConvosRequest;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun messagesFlow (Lio/github/kikin81/atproto/chat/bsky/convo/ConvoService;Lio/github/kikin81/atproto/chat/bsky/convo/GetMessagesRequest;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun messagesPageFlow (Lio/github/kikin81/atproto/chat/bsky/convo/ConvoService;Lio/github/kikin81/atproto/chat/bsky/convo/GetMessagesRequest;)Lkotlinx/coroutines/flow/Flow;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/ConvoView {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/ConvoView$Companion;
+	public fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/ConvoViewKindUnion;Lio/github/kikin81/atproto/chat/bsky/convo/ConvoViewLastMessageUnion;Lio/github/kikin81/atproto/chat/bsky/convo/ConvoViewLastReactionUnion;Ljava/util/List;ZLjava/lang/String;Ljava/lang/String;J)V
+	public synthetic fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/ConvoViewKindUnion;Lio/github/kikin81/atproto/chat/bsky/convo/ConvoViewLastMessageUnion;Lio/github/kikin81/atproto/chat/bsky/convo/ConvoViewLastReactionUnion;Ljava/util/List;ZLjava/lang/String;Ljava/lang/String;JILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/github/kikin81/atproto/chat/bsky/convo/ConvoViewKindUnion;
+	public final fun component3 ()Lio/github/kikin81/atproto/chat/bsky/convo/ConvoViewLastMessageUnion;
+	public final fun component4 ()Lio/github/kikin81/atproto/chat/bsky/convo/ConvoViewLastReactionUnion;
+	public final fun component5 ()Ljava/util/List;
+	public final fun component6 ()Z
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()J
+	public final fun copy (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/ConvoViewKindUnion;Lio/github/kikin81/atproto/chat/bsky/convo/ConvoViewLastMessageUnion;Lio/github/kikin81/atproto/chat/bsky/convo/ConvoViewLastReactionUnion;Ljava/util/List;ZLjava/lang/String;Ljava/lang/String;J)Lio/github/kikin81/atproto/chat/bsky/convo/ConvoView;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/ConvoView;Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/ConvoViewKindUnion;Lio/github/kikin81/atproto/chat/bsky/convo/ConvoViewLastMessageUnion;Lio/github/kikin81/atproto/chat/bsky/convo/ConvoViewLastReactionUnion;Ljava/util/List;ZLjava/lang/String;Ljava/lang/String;JILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/ConvoView;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getId ()Ljava/lang/String;
+	public final fun getKind ()Lio/github/kikin81/atproto/chat/bsky/convo/ConvoViewKindUnion;
+	public final fun getLastMessage ()Lio/github/kikin81/atproto/chat/bsky/convo/ConvoViewLastMessageUnion;
+	public final fun getLastReaction ()Lio/github/kikin81/atproto/chat/bsky/convo/ConvoViewLastReactionUnion;
+	public final fun getMembers ()Ljava/util/List;
+	public final fun getMuted ()Z
+	public final fun getRev ()Ljava/lang/String;
+	public final fun getStatus ()Ljava/lang/String;
+	public final fun getUnreadCount ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/convo/ConvoView$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/ConvoView$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/convo/ConvoView;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/convo/ConvoView;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/ConvoView$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class io/github/kikin81/atproto/chat/bsky/convo/ConvoViewKindUnion : io/github/kikin81/atproto/runtime/OpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/ConvoViewKindUnion$Companion;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/ConvoViewKindUnion$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/ConvoViewKindUnion$Unknown : io/github/kikin81/atproto/chat/bsky/convo/ConvoViewKindUnion, io/github/kikin81/atproto/runtime/UnknownOpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/ConvoViewKindUnion$Unknown$Companion;
+	public fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/chat/bsky/convo/ConvoViewKindUnion$Unknown;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/ConvoViewKindUnion$Unknown;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/ConvoViewKindUnion$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getRaw ()Lkotlinx/serialization/json/JsonObject;
+	public fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/ConvoViewKindUnion$Unknown$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/ConvoViewKindUnionSerializer : io/github/kikin81/atproto/runtime/OpenUnionSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/ConvoViewKindUnionSerializer;
+	public fun selectKnownDeserializer (Ljava/lang/String;)Lkotlinx/serialization/KSerializer;
+	public fun selectKnownSerializer (Lio/github/kikin81/atproto/chat/bsky/convo/ConvoViewKindUnion;)Lkotlinx/serialization/KSerializer;
+	public synthetic fun selectKnownSerializer (Lio/github/kikin81/atproto/runtime/OpenUnionMember;)Lkotlinx/serialization/KSerializer;
+	public fun unknownSerializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/ConvoViewKindUnionUnknownSerializer : io/github/kikin81/atproto/runtime/UnknownMemberSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/ConvoViewKindUnionUnknownSerializer;
+	public fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/chat/bsky/convo/ConvoViewKindUnion$Unknown;
+	public synthetic fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/runtime/UnknownOpenUnionMember;
+}
+
+public abstract interface class io/github/kikin81/atproto/chat/bsky/convo/ConvoViewLastMessageUnion : io/github/kikin81/atproto/runtime/OpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/ConvoViewLastMessageUnion$Companion;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/ConvoViewLastMessageUnion$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/ConvoViewLastMessageUnion$Unknown : io/github/kikin81/atproto/chat/bsky/convo/ConvoViewLastMessageUnion, io/github/kikin81/atproto/runtime/UnknownOpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/ConvoViewLastMessageUnion$Unknown$Companion;
+	public fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/chat/bsky/convo/ConvoViewLastMessageUnion$Unknown;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/ConvoViewLastMessageUnion$Unknown;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/ConvoViewLastMessageUnion$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getRaw ()Lkotlinx/serialization/json/JsonObject;
+	public fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/ConvoViewLastMessageUnion$Unknown$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/ConvoViewLastMessageUnionSerializer : io/github/kikin81/atproto/runtime/OpenUnionSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/ConvoViewLastMessageUnionSerializer;
+	public fun selectKnownDeserializer (Ljava/lang/String;)Lkotlinx/serialization/KSerializer;
+	public fun selectKnownSerializer (Lio/github/kikin81/atproto/chat/bsky/convo/ConvoViewLastMessageUnion;)Lkotlinx/serialization/KSerializer;
+	public synthetic fun selectKnownSerializer (Lio/github/kikin81/atproto/runtime/OpenUnionMember;)Lkotlinx/serialization/KSerializer;
+	public fun unknownSerializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/ConvoViewLastMessageUnionUnknownSerializer : io/github/kikin81/atproto/runtime/UnknownMemberSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/ConvoViewLastMessageUnionUnknownSerializer;
+	public fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/chat/bsky/convo/ConvoViewLastMessageUnion$Unknown;
+	public synthetic fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/runtime/UnknownOpenUnionMember;
+}
+
+public abstract interface class io/github/kikin81/atproto/chat/bsky/convo/ConvoViewLastReactionUnion : io/github/kikin81/atproto/runtime/OpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/ConvoViewLastReactionUnion$Companion;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/ConvoViewLastReactionUnion$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/ConvoViewLastReactionUnion$Unknown : io/github/kikin81/atproto/chat/bsky/convo/ConvoViewLastReactionUnion, io/github/kikin81/atproto/runtime/UnknownOpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/ConvoViewLastReactionUnion$Unknown$Companion;
+	public fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/chat/bsky/convo/ConvoViewLastReactionUnion$Unknown;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/ConvoViewLastReactionUnion$Unknown;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/ConvoViewLastReactionUnion$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getRaw ()Lkotlinx/serialization/json/JsonObject;
+	public fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/ConvoViewLastReactionUnion$Unknown$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/ConvoViewLastReactionUnionSerializer : io/github/kikin81/atproto/runtime/OpenUnionSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/ConvoViewLastReactionUnionSerializer;
+	public fun selectKnownDeserializer (Ljava/lang/String;)Lkotlinx/serialization/KSerializer;
+	public fun selectKnownSerializer (Lio/github/kikin81/atproto/chat/bsky/convo/ConvoViewLastReactionUnion;)Lkotlinx/serialization/KSerializer;
+	public synthetic fun selectKnownSerializer (Lio/github/kikin81/atproto/runtime/OpenUnionMember;)Lkotlinx/serialization/KSerializer;
+	public fun unknownSerializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/ConvoViewLastReactionUnionUnknownSerializer : io/github/kikin81/atproto/runtime/UnknownMemberSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/ConvoViewLastReactionUnionUnknownSerializer;
+	public fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/chat/bsky/convo/ConvoViewLastReactionUnion$Unknown;
+	public synthetic fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/runtime/UnknownOpenUnionMember;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/DeletedMessageView : io/github/kikin81/atproto/chat/bsky/convo/ConvoViewLastMessageUnion, io/github/kikin81/atproto/chat/bsky/convo/GetMessagesResponseMessagesUnion, io/github/kikin81/atproto/chat/bsky/convo/LogAddReactionMessageUnion, io/github/kikin81/atproto/chat/bsky/convo/LogCreateMessageMessageUnion, io/github/kikin81/atproto/chat/bsky/convo/LogDeleteMessageMessageUnion, io/github/kikin81/atproto/chat/bsky/convo/LogReadConvoMessageUnion, io/github/kikin81/atproto/chat/bsky/convo/LogReadMessageMessageUnion, io/github/kikin81/atproto/chat/bsky/convo/LogRemoveReactionMessageUnion {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/DeletedMessageView$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/MessageViewSender;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lio/github/kikin81/atproto/chat/bsky/convo/MessageViewSender;
+	public final fun component4-DnBUIck ()Ljava/lang/String;
+	public final fun copy-VYk0tSs (Ljava/lang/String;Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/MessageViewSender;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/DeletedMessageView;
+	public static synthetic fun copy-VYk0tSs$default (Lio/github/kikin81/atproto/chat/bsky/convo/DeletedMessageView;Ljava/lang/String;Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/MessageViewSender;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/DeletedMessageView;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getId ()Ljava/lang/String;
+	public final fun getRev ()Ljava/lang/String;
+	public final fun getSender ()Lio/github/kikin81/atproto/chat/bsky/convo/MessageViewSender;
+	public final fun getSentAt-DnBUIck ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/convo/DeletedMessageView$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/DeletedMessageView$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/convo/DeletedMessageView;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/convo/DeletedMessageView;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/DeletedMessageView$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/DirectConvo : io/github/kikin81/atproto/chat/bsky/convo/ConvoViewKindUnion {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/DirectConvo$Companion;
+	public fun <init> ()V
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/convo/DirectConvo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/DirectConvo$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/convo/DirectConvo;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/convo/DirectConvo;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/DirectConvo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/GetMessagesRequest {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/GetMessagesRequest$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/Long;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;)Lio/github/kikin81/atproto/chat/bsky/convo/GetMessagesRequest;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/GetMessagesRequest;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/GetMessagesRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConvoId ()Ljava/lang/String;
+	public final fun getCursor ()Ljava/lang/String;
+	public final fun getLimit ()Ljava/lang/Long;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/convo/GetMessagesRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/GetMessagesRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/convo/GetMessagesRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/convo/GetMessagesRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/GetMessagesRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/GetMessagesResponse {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/GetMessagesResponse$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;)Lio/github/kikin81/atproto/chat/bsky/convo/GetMessagesResponse;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/GetMessagesResponse;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/GetMessagesResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCursor ()Ljava/lang/String;
+	public final fun getMessages ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/convo/GetMessagesResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/GetMessagesResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/convo/GetMessagesResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/convo/GetMessagesResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/GetMessagesResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class io/github/kikin81/atproto/chat/bsky/convo/GetMessagesResponseMessagesUnion : io/github/kikin81/atproto/runtime/OpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/GetMessagesResponseMessagesUnion$Companion;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/GetMessagesResponseMessagesUnion$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/GetMessagesResponseMessagesUnion$Unknown : io/github/kikin81/atproto/chat/bsky/convo/GetMessagesResponseMessagesUnion, io/github/kikin81/atproto/runtime/UnknownOpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/GetMessagesResponseMessagesUnion$Unknown$Companion;
+	public fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/chat/bsky/convo/GetMessagesResponseMessagesUnion$Unknown;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/GetMessagesResponseMessagesUnion$Unknown;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/GetMessagesResponseMessagesUnion$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getRaw ()Lkotlinx/serialization/json/JsonObject;
+	public fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/GetMessagesResponseMessagesUnion$Unknown$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/GetMessagesResponseMessagesUnionSerializer : io/github/kikin81/atproto/runtime/OpenUnionSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/GetMessagesResponseMessagesUnionSerializer;
+	public fun selectKnownDeserializer (Ljava/lang/String;)Lkotlinx/serialization/KSerializer;
+	public fun selectKnownSerializer (Lio/github/kikin81/atproto/chat/bsky/convo/GetMessagesResponseMessagesUnion;)Lkotlinx/serialization/KSerializer;
+	public synthetic fun selectKnownSerializer (Lio/github/kikin81/atproto/runtime/OpenUnionMember;)Lkotlinx/serialization/KSerializer;
+	public fun unknownSerializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/GetMessagesResponseMessagesUnionUnknownSerializer : io/github/kikin81/atproto/runtime/UnknownMemberSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/GetMessagesResponseMessagesUnionUnknownSerializer;
+	public fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/chat/bsky/convo/GetMessagesResponseMessagesUnion$Unknown;
+	public synthetic fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/runtime/UnknownOpenUnionMember;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/GroupConvo : io/github/kikin81/atproto/chat/bsky/convo/ConvoViewKindUnion {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/GroupConvo$Companion;
+	public fun <init> (Lio/github/kikin81/atproto/chat/bsky/group/JoinLinkView;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Lio/github/kikin81/atproto/chat/bsky/group/JoinLinkView;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/chat/bsky/group/JoinLinkView;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Lio/github/kikin81/atproto/chat/bsky/group/JoinLinkView;Ljava/lang/String;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/GroupConvo;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/GroupConvo;Lio/github/kikin81/atproto/chat/bsky/group/JoinLinkView;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/GroupConvo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getJoinLink ()Lio/github/kikin81/atproto/chat/bsky/group/JoinLinkView;
+	public final fun getLockStatus ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/convo/GroupConvo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/GroupConvo$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/convo/GroupConvo;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/convo/GroupConvo;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/GroupConvo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/ListConvosRequest {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/ListConvosRequest$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/Long;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/ListConvosRequest;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/ListConvosRequest;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/ListConvosRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCursor ()Ljava/lang/String;
+	public final fun getKind ()Ljava/lang/String;
+	public final fun getLimit ()Ljava/lang/Long;
+	public final fun getReadState ()Ljava/lang/String;
+	public final fun getStatus ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/convo/ListConvosRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/ListConvosRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/convo/ListConvosRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/convo/ListConvosRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/ListConvosRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/ListConvosResponse {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/ListConvosResponse$Companion;
+	public fun <init> (Ljava/util/List;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/util/List;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/ListConvosResponse;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/ListConvosResponse;Ljava/util/List;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/ListConvosResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConvos ()Ljava/util/List;
+	public final fun getCursor ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/convo/ListConvosResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/ListConvosResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/convo/ListConvosResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/convo/ListConvosResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/ListConvosResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogAcceptConvo {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/LogAcceptConvo$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/LogAcceptConvo;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/LogAcceptConvo;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/LogAcceptConvo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConvoId ()Ljava/lang/String;
+	public final fun getRev ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/convo/LogAcceptConvo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/LogAcceptConvo$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/convo/LogAcceptConvo;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/convo/LogAcceptConvo;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogAcceptConvo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogAddMember {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/LogAddMember$Companion;
+	public fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataAddMember;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataAddMember;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataAddMember;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/LogAddMember;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/LogAddMember;Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataAddMember;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/LogAddMember;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConvoId ()Ljava/lang/String;
+	public final fun getMessage ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataAddMember;
+	public final fun getRev ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/convo/LogAddMember$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/LogAddMember$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/convo/LogAddMember;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/convo/LogAddMember;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogAddMember$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogAddReaction {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/LogAddReaction$Companion;
+	public fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/LogAddReactionMessageUnion;Lio/github/kikin81/atproto/chat/bsky/convo/ReactionView;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/github/kikin81/atproto/chat/bsky/convo/LogAddReactionMessageUnion;
+	public final fun component3 ()Lio/github/kikin81/atproto/chat/bsky/convo/ReactionView;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/LogAddReactionMessageUnion;Lio/github/kikin81/atproto/chat/bsky/convo/ReactionView;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/LogAddReaction;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/LogAddReaction;Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/LogAddReactionMessageUnion;Lio/github/kikin81/atproto/chat/bsky/convo/ReactionView;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/LogAddReaction;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConvoId ()Ljava/lang/String;
+	public final fun getMessage ()Lio/github/kikin81/atproto/chat/bsky/convo/LogAddReactionMessageUnion;
+	public final fun getReaction ()Lio/github/kikin81/atproto/chat/bsky/convo/ReactionView;
+	public final fun getRev ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/convo/LogAddReaction$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/LogAddReaction$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/convo/LogAddReaction;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/convo/LogAddReaction;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogAddReaction$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class io/github/kikin81/atproto/chat/bsky/convo/LogAddReactionMessageUnion : io/github/kikin81/atproto/runtime/OpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/LogAddReactionMessageUnion$Companion;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogAddReactionMessageUnion$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogAddReactionMessageUnion$Unknown : io/github/kikin81/atproto/chat/bsky/convo/LogAddReactionMessageUnion, io/github/kikin81/atproto/runtime/UnknownOpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/LogAddReactionMessageUnion$Unknown$Companion;
+	public fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/chat/bsky/convo/LogAddReactionMessageUnion$Unknown;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/LogAddReactionMessageUnion$Unknown;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/LogAddReactionMessageUnion$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getRaw ()Lkotlinx/serialization/json/JsonObject;
+	public fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogAddReactionMessageUnion$Unknown$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogAddReactionMessageUnionSerializer : io/github/kikin81/atproto/runtime/OpenUnionSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/LogAddReactionMessageUnionSerializer;
+	public fun selectKnownDeserializer (Ljava/lang/String;)Lkotlinx/serialization/KSerializer;
+	public fun selectKnownSerializer (Lio/github/kikin81/atproto/chat/bsky/convo/LogAddReactionMessageUnion;)Lkotlinx/serialization/KSerializer;
+	public synthetic fun selectKnownSerializer (Lio/github/kikin81/atproto/runtime/OpenUnionMember;)Lkotlinx/serialization/KSerializer;
+	public fun unknownSerializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogAddReactionMessageUnionUnknownSerializer : io/github/kikin81/atproto/runtime/UnknownMemberSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/LogAddReactionMessageUnionUnknownSerializer;
+	public fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/chat/bsky/convo/LogAddReactionMessageUnion$Unknown;
+	public synthetic fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/runtime/UnknownOpenUnionMember;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogApproveJoinRequest {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/LogApproveJoinRequest$Companion;
+	public fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/LogApproveJoinRequest;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/LogApproveJoinRequest;Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/LogApproveJoinRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConvoId ()Ljava/lang/String;
+	public final fun getMember ()Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;
+	public final fun getRev ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/convo/LogApproveJoinRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/LogApproveJoinRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/convo/LogApproveJoinRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/convo/LogApproveJoinRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogApproveJoinRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogBeginConvo {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/LogBeginConvo$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/LogBeginConvo;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/LogBeginConvo;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/LogBeginConvo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConvoId ()Ljava/lang/String;
+	public final fun getRev ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/convo/LogBeginConvo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/LogBeginConvo$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/convo/LogBeginConvo;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/convo/LogBeginConvo;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogBeginConvo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogCreateJoinLink {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/LogCreateJoinLink$Companion;
+	public fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataCreateJoinLink;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataCreateJoinLink;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataCreateJoinLink;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/LogCreateJoinLink;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/LogCreateJoinLink;Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataCreateJoinLink;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/LogCreateJoinLink;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConvoId ()Ljava/lang/String;
+	public final fun getMessage ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataCreateJoinLink;
+	public final fun getRev ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/convo/LogCreateJoinLink$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/LogCreateJoinLink$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/convo/LogCreateJoinLink;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/convo/LogCreateJoinLink;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogCreateJoinLink$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogCreateMessage {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/LogCreateMessage$Companion;
+	public fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/LogCreateMessageMessageUnion;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/github/kikin81/atproto/chat/bsky/convo/LogCreateMessageMessageUnion;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/LogCreateMessageMessageUnion;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/LogCreateMessage;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/LogCreateMessage;Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/LogCreateMessageMessageUnion;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/LogCreateMessage;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConvoId ()Ljava/lang/String;
+	public final fun getMessage ()Lio/github/kikin81/atproto/chat/bsky/convo/LogCreateMessageMessageUnion;
+	public final fun getRev ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/convo/LogCreateMessage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/LogCreateMessage$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/convo/LogCreateMessage;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/convo/LogCreateMessage;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogCreateMessage$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class io/github/kikin81/atproto/chat/bsky/convo/LogCreateMessageMessageUnion : io/github/kikin81/atproto/runtime/OpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/LogCreateMessageMessageUnion$Companion;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogCreateMessageMessageUnion$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogCreateMessageMessageUnion$Unknown : io/github/kikin81/atproto/chat/bsky/convo/LogCreateMessageMessageUnion, io/github/kikin81/atproto/runtime/UnknownOpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/LogCreateMessageMessageUnion$Unknown$Companion;
+	public fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/chat/bsky/convo/LogCreateMessageMessageUnion$Unknown;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/LogCreateMessageMessageUnion$Unknown;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/LogCreateMessageMessageUnion$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getRaw ()Lkotlinx/serialization/json/JsonObject;
+	public fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogCreateMessageMessageUnion$Unknown$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogCreateMessageMessageUnionSerializer : io/github/kikin81/atproto/runtime/OpenUnionSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/LogCreateMessageMessageUnionSerializer;
+	public fun selectKnownDeserializer (Ljava/lang/String;)Lkotlinx/serialization/KSerializer;
+	public fun selectKnownSerializer (Lio/github/kikin81/atproto/chat/bsky/convo/LogCreateMessageMessageUnion;)Lkotlinx/serialization/KSerializer;
+	public synthetic fun selectKnownSerializer (Lio/github/kikin81/atproto/runtime/OpenUnionMember;)Lkotlinx/serialization/KSerializer;
+	public fun unknownSerializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogCreateMessageMessageUnionUnknownSerializer : io/github/kikin81/atproto/runtime/UnknownMemberSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/LogCreateMessageMessageUnionUnknownSerializer;
+	public fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/chat/bsky/convo/LogCreateMessageMessageUnion$Unknown;
+	public synthetic fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/runtime/UnknownOpenUnionMember;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogDeleteMessage {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/LogDeleteMessage$Companion;
+	public fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/LogDeleteMessageMessageUnion;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/github/kikin81/atproto/chat/bsky/convo/LogDeleteMessageMessageUnion;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/LogDeleteMessageMessageUnion;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/LogDeleteMessage;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/LogDeleteMessage;Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/LogDeleteMessageMessageUnion;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/LogDeleteMessage;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConvoId ()Ljava/lang/String;
+	public final fun getMessage ()Lio/github/kikin81/atproto/chat/bsky/convo/LogDeleteMessageMessageUnion;
+	public final fun getRev ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/convo/LogDeleteMessage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/LogDeleteMessage$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/convo/LogDeleteMessage;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/convo/LogDeleteMessage;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogDeleteMessage$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class io/github/kikin81/atproto/chat/bsky/convo/LogDeleteMessageMessageUnion : io/github/kikin81/atproto/runtime/OpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/LogDeleteMessageMessageUnion$Companion;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogDeleteMessageMessageUnion$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogDeleteMessageMessageUnion$Unknown : io/github/kikin81/atproto/chat/bsky/convo/LogDeleteMessageMessageUnion, io/github/kikin81/atproto/runtime/UnknownOpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/LogDeleteMessageMessageUnion$Unknown$Companion;
+	public fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/chat/bsky/convo/LogDeleteMessageMessageUnion$Unknown;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/LogDeleteMessageMessageUnion$Unknown;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/LogDeleteMessageMessageUnion$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getRaw ()Lkotlinx/serialization/json/JsonObject;
+	public fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogDeleteMessageMessageUnion$Unknown$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogDeleteMessageMessageUnionSerializer : io/github/kikin81/atproto/runtime/OpenUnionSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/LogDeleteMessageMessageUnionSerializer;
+	public fun selectKnownDeserializer (Ljava/lang/String;)Lkotlinx/serialization/KSerializer;
+	public fun selectKnownSerializer (Lio/github/kikin81/atproto/chat/bsky/convo/LogDeleteMessageMessageUnion;)Lkotlinx/serialization/KSerializer;
+	public synthetic fun selectKnownSerializer (Lio/github/kikin81/atproto/runtime/OpenUnionMember;)Lkotlinx/serialization/KSerializer;
+	public fun unknownSerializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogDeleteMessageMessageUnionUnknownSerializer : io/github/kikin81/atproto/runtime/UnknownMemberSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/LogDeleteMessageMessageUnionUnknownSerializer;
+	public fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/chat/bsky/convo/LogDeleteMessageMessageUnion$Unknown;
+	public synthetic fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/runtime/UnknownOpenUnionMember;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogDisableJoinLink {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/LogDisableJoinLink$Companion;
+	public fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataDisableJoinLink;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataDisableJoinLink;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataDisableJoinLink;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/LogDisableJoinLink;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/LogDisableJoinLink;Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataDisableJoinLink;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/LogDisableJoinLink;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConvoId ()Ljava/lang/String;
+	public final fun getMessage ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataDisableJoinLink;
+	public final fun getRev ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/convo/LogDisableJoinLink$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/LogDisableJoinLink$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/convo/LogDisableJoinLink;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/convo/LogDisableJoinLink;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogDisableJoinLink$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogEditGroup {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/LogEditGroup$Companion;
+	public fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataEditGroup;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataEditGroup;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataEditGroup;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/LogEditGroup;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/LogEditGroup;Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataEditGroup;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/LogEditGroup;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConvoId ()Ljava/lang/String;
+	public final fun getMessage ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataEditGroup;
+	public final fun getRev ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/convo/LogEditGroup$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/LogEditGroup$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/convo/LogEditGroup;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/convo/LogEditGroup;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogEditGroup$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogEditJoinLink {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/LogEditJoinLink$Companion;
+	public fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataEditJoinLink;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataEditJoinLink;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataEditJoinLink;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/LogEditJoinLink;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/LogEditJoinLink;Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataEditJoinLink;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/LogEditJoinLink;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConvoId ()Ljava/lang/String;
+	public final fun getMessage ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataEditJoinLink;
+	public final fun getRev ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/convo/LogEditJoinLink$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/LogEditJoinLink$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/convo/LogEditJoinLink;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/convo/LogEditJoinLink;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogEditJoinLink$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogEnableJoinLink {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/LogEnableJoinLink$Companion;
+	public fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataEnableJoinLink;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataEnableJoinLink;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataEnableJoinLink;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/LogEnableJoinLink;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/LogEnableJoinLink;Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataEnableJoinLink;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/LogEnableJoinLink;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConvoId ()Ljava/lang/String;
+	public final fun getMessage ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataEnableJoinLink;
+	public final fun getRev ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/convo/LogEnableJoinLink$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/LogEnableJoinLink$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/convo/LogEnableJoinLink;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/convo/LogEnableJoinLink;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogEnableJoinLink$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogIncomingJoinRequest {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/LogIncomingJoinRequest$Companion;
+	public fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/LogIncomingJoinRequest;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/LogIncomingJoinRequest;Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/LogIncomingJoinRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConvoId ()Ljava/lang/String;
+	public final fun getMember ()Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;
+	public final fun getRev ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/convo/LogIncomingJoinRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/LogIncomingJoinRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/convo/LogIncomingJoinRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/convo/LogIncomingJoinRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogIncomingJoinRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogLeaveConvo {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/LogLeaveConvo$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/LogLeaveConvo;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/LogLeaveConvo;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/LogLeaveConvo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConvoId ()Ljava/lang/String;
+	public final fun getRev ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/convo/LogLeaveConvo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/LogLeaveConvo$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/convo/LogLeaveConvo;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/convo/LogLeaveConvo;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogLeaveConvo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogLockConvo {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/LogLockConvo$Companion;
+	public fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataLockConvo;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataLockConvo;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataLockConvo;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/LogLockConvo;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/LogLockConvo;Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataLockConvo;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/LogLockConvo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConvoId ()Ljava/lang/String;
+	public final fun getMessage ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataLockConvo;
+	public final fun getRev ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/convo/LogLockConvo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/LogLockConvo$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/convo/LogLockConvo;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/convo/LogLockConvo;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogLockConvo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogLockConvoPermanently {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/LogLockConvoPermanently$Companion;
+	public fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataLockConvoPermanently;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataLockConvoPermanently;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataLockConvoPermanently;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/LogLockConvoPermanently;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/LogLockConvoPermanently;Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataLockConvoPermanently;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/LogLockConvoPermanently;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConvoId ()Ljava/lang/String;
+	public final fun getMessage ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataLockConvoPermanently;
+	public final fun getRev ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/convo/LogLockConvoPermanently$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/LogLockConvoPermanently$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/convo/LogLockConvoPermanently;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/convo/LogLockConvoPermanently;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogLockConvoPermanently$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogMemberJoin {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/LogMemberJoin$Companion;
+	public fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataMemberJoin;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataMemberJoin;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataMemberJoin;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/LogMemberJoin;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/LogMemberJoin;Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataMemberJoin;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/LogMemberJoin;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConvoId ()Ljava/lang/String;
+	public final fun getMessage ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataMemberJoin;
+	public final fun getRev ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/convo/LogMemberJoin$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/LogMemberJoin$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/convo/LogMemberJoin;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/convo/LogMemberJoin;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogMemberJoin$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogMemberLeave {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/LogMemberLeave$Companion;
+	public fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataMemberLeave;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataMemberLeave;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataMemberLeave;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/LogMemberLeave;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/LogMemberLeave;Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataMemberLeave;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/LogMemberLeave;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConvoId ()Ljava/lang/String;
+	public final fun getMessage ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataMemberLeave;
+	public final fun getRev ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/convo/LogMemberLeave$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/LogMemberLeave$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/convo/LogMemberLeave;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/convo/LogMemberLeave;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogMemberLeave$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogMuteConvo {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/LogMuteConvo$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/LogMuteConvo;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/LogMuteConvo;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/LogMuteConvo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConvoId ()Ljava/lang/String;
+	public final fun getRev ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/convo/LogMuteConvo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/LogMuteConvo$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/convo/LogMuteConvo;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/convo/LogMuteConvo;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogMuteConvo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogOutgoingJoinRequest {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/LogOutgoingJoinRequest$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/LogOutgoingJoinRequest;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/LogOutgoingJoinRequest;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/LogOutgoingJoinRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConvoId ()Ljava/lang/String;
+	public final fun getRev ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/convo/LogOutgoingJoinRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/LogOutgoingJoinRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/convo/LogOutgoingJoinRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/convo/LogOutgoingJoinRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogOutgoingJoinRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogReadConvo {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/LogReadConvo$Companion;
+	public fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/LogReadConvoMessageUnion;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/github/kikin81/atproto/chat/bsky/convo/LogReadConvoMessageUnion;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/LogReadConvoMessageUnion;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/LogReadConvo;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/LogReadConvo;Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/LogReadConvoMessageUnion;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/LogReadConvo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConvoId ()Ljava/lang/String;
+	public final fun getMessage ()Lio/github/kikin81/atproto/chat/bsky/convo/LogReadConvoMessageUnion;
+	public final fun getRev ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/convo/LogReadConvo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/LogReadConvo$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/convo/LogReadConvo;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/convo/LogReadConvo;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogReadConvo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class io/github/kikin81/atproto/chat/bsky/convo/LogReadConvoMessageUnion : io/github/kikin81/atproto/runtime/OpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/LogReadConvoMessageUnion$Companion;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogReadConvoMessageUnion$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogReadConvoMessageUnion$Unknown : io/github/kikin81/atproto/chat/bsky/convo/LogReadConvoMessageUnion, io/github/kikin81/atproto/runtime/UnknownOpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/LogReadConvoMessageUnion$Unknown$Companion;
+	public fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/chat/bsky/convo/LogReadConvoMessageUnion$Unknown;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/LogReadConvoMessageUnion$Unknown;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/LogReadConvoMessageUnion$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getRaw ()Lkotlinx/serialization/json/JsonObject;
+	public fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogReadConvoMessageUnion$Unknown$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogReadConvoMessageUnionSerializer : io/github/kikin81/atproto/runtime/OpenUnionSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/LogReadConvoMessageUnionSerializer;
+	public fun selectKnownDeserializer (Ljava/lang/String;)Lkotlinx/serialization/KSerializer;
+	public fun selectKnownSerializer (Lio/github/kikin81/atproto/chat/bsky/convo/LogReadConvoMessageUnion;)Lkotlinx/serialization/KSerializer;
+	public synthetic fun selectKnownSerializer (Lio/github/kikin81/atproto/runtime/OpenUnionMember;)Lkotlinx/serialization/KSerializer;
+	public fun unknownSerializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogReadConvoMessageUnionUnknownSerializer : io/github/kikin81/atproto/runtime/UnknownMemberSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/LogReadConvoMessageUnionUnknownSerializer;
+	public fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/chat/bsky/convo/LogReadConvoMessageUnion$Unknown;
+	public synthetic fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/runtime/UnknownOpenUnionMember;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogReadMessage {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/LogReadMessage$Companion;
+	public fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/LogReadMessageMessageUnion;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/github/kikin81/atproto/chat/bsky/convo/LogReadMessageMessageUnion;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/LogReadMessageMessageUnion;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/LogReadMessage;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/LogReadMessage;Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/LogReadMessageMessageUnion;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/LogReadMessage;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConvoId ()Ljava/lang/String;
+	public final fun getMessage ()Lio/github/kikin81/atproto/chat/bsky/convo/LogReadMessageMessageUnion;
+	public final fun getRev ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/convo/LogReadMessage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/LogReadMessage$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/convo/LogReadMessage;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/convo/LogReadMessage;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogReadMessage$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class io/github/kikin81/atproto/chat/bsky/convo/LogReadMessageMessageUnion : io/github/kikin81/atproto/runtime/OpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/LogReadMessageMessageUnion$Companion;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogReadMessageMessageUnion$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogReadMessageMessageUnion$Unknown : io/github/kikin81/atproto/chat/bsky/convo/LogReadMessageMessageUnion, io/github/kikin81/atproto/runtime/UnknownOpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/LogReadMessageMessageUnion$Unknown$Companion;
+	public fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/chat/bsky/convo/LogReadMessageMessageUnion$Unknown;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/LogReadMessageMessageUnion$Unknown;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/LogReadMessageMessageUnion$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getRaw ()Lkotlinx/serialization/json/JsonObject;
+	public fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogReadMessageMessageUnion$Unknown$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogReadMessageMessageUnionSerializer : io/github/kikin81/atproto/runtime/OpenUnionSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/LogReadMessageMessageUnionSerializer;
+	public fun selectKnownDeserializer (Ljava/lang/String;)Lkotlinx/serialization/KSerializer;
+	public fun selectKnownSerializer (Lio/github/kikin81/atproto/chat/bsky/convo/LogReadMessageMessageUnion;)Lkotlinx/serialization/KSerializer;
+	public synthetic fun selectKnownSerializer (Lio/github/kikin81/atproto/runtime/OpenUnionMember;)Lkotlinx/serialization/KSerializer;
+	public fun unknownSerializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogReadMessageMessageUnionUnknownSerializer : io/github/kikin81/atproto/runtime/UnknownMemberSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/LogReadMessageMessageUnionUnknownSerializer;
+	public fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/chat/bsky/convo/LogReadMessageMessageUnion$Unknown;
+	public synthetic fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/runtime/UnknownOpenUnionMember;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogRejectJoinRequest {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/LogRejectJoinRequest$Companion;
+	public fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/LogRejectJoinRequest;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/LogRejectJoinRequest;Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/LogRejectJoinRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConvoId ()Ljava/lang/String;
+	public final fun getMember ()Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;
+	public final fun getRev ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/convo/LogRejectJoinRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/LogRejectJoinRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/convo/LogRejectJoinRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/convo/LogRejectJoinRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogRejectJoinRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogRemoveMember {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/LogRemoveMember$Companion;
+	public fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataRemoveMember;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataRemoveMember;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataRemoveMember;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/LogRemoveMember;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/LogRemoveMember;Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataRemoveMember;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/LogRemoveMember;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConvoId ()Ljava/lang/String;
+	public final fun getMessage ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataRemoveMember;
+	public final fun getRev ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/convo/LogRemoveMember$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/LogRemoveMember$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/convo/LogRemoveMember;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/convo/LogRemoveMember;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogRemoveMember$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogRemoveReaction {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/LogRemoveReaction$Companion;
+	public fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/LogRemoveReactionMessageUnion;Lio/github/kikin81/atproto/chat/bsky/convo/ReactionView;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/github/kikin81/atproto/chat/bsky/convo/LogRemoveReactionMessageUnion;
+	public final fun component3 ()Lio/github/kikin81/atproto/chat/bsky/convo/ReactionView;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/LogRemoveReactionMessageUnion;Lio/github/kikin81/atproto/chat/bsky/convo/ReactionView;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/LogRemoveReaction;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/LogRemoveReaction;Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/LogRemoveReactionMessageUnion;Lio/github/kikin81/atproto/chat/bsky/convo/ReactionView;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/LogRemoveReaction;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConvoId ()Ljava/lang/String;
+	public final fun getMessage ()Lio/github/kikin81/atproto/chat/bsky/convo/LogRemoveReactionMessageUnion;
+	public final fun getReaction ()Lio/github/kikin81/atproto/chat/bsky/convo/ReactionView;
+	public final fun getRev ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/convo/LogRemoveReaction$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/LogRemoveReaction$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/convo/LogRemoveReaction;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/convo/LogRemoveReaction;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogRemoveReaction$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class io/github/kikin81/atproto/chat/bsky/convo/LogRemoveReactionMessageUnion : io/github/kikin81/atproto/runtime/OpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/LogRemoveReactionMessageUnion$Companion;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogRemoveReactionMessageUnion$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogRemoveReactionMessageUnion$Unknown : io/github/kikin81/atproto/chat/bsky/convo/LogRemoveReactionMessageUnion, io/github/kikin81/atproto/runtime/UnknownOpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/LogRemoveReactionMessageUnion$Unknown$Companion;
+	public fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/chat/bsky/convo/LogRemoveReactionMessageUnion$Unknown;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/LogRemoveReactionMessageUnion$Unknown;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/LogRemoveReactionMessageUnion$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getRaw ()Lkotlinx/serialization/json/JsonObject;
+	public fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogRemoveReactionMessageUnion$Unknown$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogRemoveReactionMessageUnionSerializer : io/github/kikin81/atproto/runtime/OpenUnionSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/LogRemoveReactionMessageUnionSerializer;
+	public fun selectKnownDeserializer (Ljava/lang/String;)Lkotlinx/serialization/KSerializer;
+	public fun selectKnownSerializer (Lio/github/kikin81/atproto/chat/bsky/convo/LogRemoveReactionMessageUnion;)Lkotlinx/serialization/KSerializer;
+	public synthetic fun selectKnownSerializer (Lio/github/kikin81/atproto/runtime/OpenUnionMember;)Lkotlinx/serialization/KSerializer;
+	public fun unknownSerializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogRemoveReactionMessageUnionUnknownSerializer : io/github/kikin81/atproto/runtime/UnknownMemberSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/LogRemoveReactionMessageUnionUnknownSerializer;
+	public fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/chat/bsky/convo/LogRemoveReactionMessageUnion$Unknown;
+	public synthetic fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/runtime/UnknownOpenUnionMember;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogUnlockConvo {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/LogUnlockConvo$Companion;
+	public fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataUnlockConvo;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataUnlockConvo;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataUnlockConvo;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/LogUnlockConvo;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/LogUnlockConvo;Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataUnlockConvo;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/LogUnlockConvo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConvoId ()Ljava/lang/String;
+	public final fun getMessage ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataUnlockConvo;
+	public final fun getRev ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/convo/LogUnlockConvo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/LogUnlockConvo$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/convo/LogUnlockConvo;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/convo/LogUnlockConvo;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogUnlockConvo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogUnmuteConvo {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/LogUnmuteConvo$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/LogUnmuteConvo;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/LogUnmuteConvo;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/LogUnmuteConvo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConvoId ()Ljava/lang/String;
+	public final fun getRev ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/convo/LogUnmuteConvo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/LogUnmuteConvo$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/convo/LogUnmuteConvo;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/convo/LogUnmuteConvo;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogUnmuteConvo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/MessageAndReactionView : io/github/kikin81/atproto/chat/bsky/convo/ConvoViewLastReactionUnion {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/MessageAndReactionView$Companion;
+	public fun <init> (Lio/github/kikin81/atproto/chat/bsky/convo/MessageView;Lio/github/kikin81/atproto/chat/bsky/convo/ReactionView;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/chat/bsky/convo/MessageView;
+	public final fun component2 ()Lio/github/kikin81/atproto/chat/bsky/convo/ReactionView;
+	public final fun copy (Lio/github/kikin81/atproto/chat/bsky/convo/MessageView;Lio/github/kikin81/atproto/chat/bsky/convo/ReactionView;)Lio/github/kikin81/atproto/chat/bsky/convo/MessageAndReactionView;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/MessageAndReactionView;Lio/github/kikin81/atproto/chat/bsky/convo/MessageView;Lio/github/kikin81/atproto/chat/bsky/convo/ReactionView;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/MessageAndReactionView;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMessage ()Lio/github/kikin81/atproto/chat/bsky/convo/MessageView;
+	public final fun getReaction ()Lio/github/kikin81/atproto/chat/bsky/convo/ReactionView;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/convo/MessageAndReactionView$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/MessageAndReactionView$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/convo/MessageAndReactionView;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/convo/MessageAndReactionView;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/MessageAndReactionView$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/MessageInput {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/MessageInput$Companion;
+	public fun <init> (Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;)V
+	public synthetic fun <init> (Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun component2 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/MessageInput;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/MessageInput;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/MessageInput;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEmbed ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun getFacets ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun getText ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/convo/MessageInput$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/MessageInput$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/convo/MessageInput;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/convo/MessageInput;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/MessageInput$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class io/github/kikin81/atproto/chat/bsky/convo/MessageInputEmbedUnion : io/github/kikin81/atproto/runtime/OpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/MessageInputEmbedUnion$Companion;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/MessageInputEmbedUnion$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/MessageInputEmbedUnion$Unknown : io/github/kikin81/atproto/chat/bsky/convo/MessageInputEmbedUnion, io/github/kikin81/atproto/runtime/UnknownOpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/MessageInputEmbedUnion$Unknown$Companion;
+	public fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/chat/bsky/convo/MessageInputEmbedUnion$Unknown;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/MessageInputEmbedUnion$Unknown;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/MessageInputEmbedUnion$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getRaw ()Lkotlinx/serialization/json/JsonObject;
+	public fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/MessageInputEmbedUnion$Unknown$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/MessageInputEmbedUnionSerializer : io/github/kikin81/atproto/runtime/OpenUnionSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/MessageInputEmbedUnionSerializer;
+	public fun selectKnownDeserializer (Ljava/lang/String;)Lkotlinx/serialization/KSerializer;
+	public fun selectKnownSerializer (Lio/github/kikin81/atproto/chat/bsky/convo/MessageInputEmbedUnion;)Lkotlinx/serialization/KSerializer;
+	public synthetic fun selectKnownSerializer (Lio/github/kikin81/atproto/runtime/OpenUnionMember;)Lkotlinx/serialization/KSerializer;
+	public fun unknownSerializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/MessageInputEmbedUnionUnknownSerializer : io/github/kikin81/atproto/runtime/UnknownMemberSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/MessageInputEmbedUnionUnknownSerializer;
+	public fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/chat/bsky/convo/MessageInputEmbedUnion$Unknown;
+	public synthetic fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/runtime/UnknownOpenUnionMember;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/MessageRef {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/MessageRef$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2-UyB9Nic ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy-0EMVyVI (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/MessageRef;
+	public static synthetic fun copy-0EMVyVI$default (Lio/github/kikin81/atproto/chat/bsky/convo/MessageRef;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/MessageRef;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConvoId ()Ljava/lang/String;
+	public final fun getDid-UyB9Nic ()Ljava/lang/String;
+	public final fun getMessageId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/convo/MessageRef$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/MessageRef$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/convo/MessageRef;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/convo/MessageRef;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/MessageRef$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/MessageView : io/github/kikin81/atproto/chat/bsky/convo/ConvoViewLastMessageUnion, io/github/kikin81/atproto/chat/bsky/convo/GetMessagesResponseMessagesUnion, io/github/kikin81/atproto/chat/bsky/convo/LogAddReactionMessageUnion, io/github/kikin81/atproto/chat/bsky/convo/LogCreateMessageMessageUnion, io/github/kikin81/atproto/chat/bsky/convo/LogDeleteMessageMessageUnion, io/github/kikin81/atproto/chat/bsky/convo/LogReadConvoMessageUnion, io/github/kikin81/atproto/chat/bsky/convo/LogReadMessageMessageUnion, io/github/kikin81/atproto/chat/bsky/convo/LogRemoveReactionMessageUnion {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/MessageView$Companion;
+	public synthetic fun <init> (Lio/github/kikin81/atproto/chat/bsky/convo/MessageViewEmbedUnion;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/MessageViewSender;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lio/github/kikin81/atproto/chat/bsky/convo/MessageViewEmbedUnion;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/MessageViewSender;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/chat/bsky/convo/MessageViewEmbedUnion;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Lio/github/kikin81/atproto/chat/bsky/convo/MessageViewSender;
+	public final fun component7-DnBUIck ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun copy-itQWBns (Lio/github/kikin81/atproto/chat/bsky/convo/MessageViewEmbedUnion;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/MessageViewSender;Ljava/lang/String;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/MessageView;
+	public static synthetic fun copy-itQWBns$default (Lio/github/kikin81/atproto/chat/bsky/convo/MessageView;Lio/github/kikin81/atproto/chat/bsky/convo/MessageViewEmbedUnion;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/MessageViewSender;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/MessageView;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEmbed ()Lio/github/kikin81/atproto/chat/bsky/convo/MessageViewEmbedUnion;
+	public final fun getFacets ()Ljava/util/List;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getReactions ()Ljava/util/List;
+	public final fun getRev ()Ljava/lang/String;
+	public final fun getSender ()Lio/github/kikin81/atproto/chat/bsky/convo/MessageViewSender;
+	public final fun getSentAt-DnBUIck ()Ljava/lang/String;
+	public final fun getText ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/convo/MessageView$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/MessageView$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/convo/MessageView;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/convo/MessageView;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/MessageView$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class io/github/kikin81/atproto/chat/bsky/convo/MessageViewEmbedUnion : io/github/kikin81/atproto/runtime/OpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/MessageViewEmbedUnion$Companion;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/MessageViewEmbedUnion$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/MessageViewEmbedUnion$Unknown : io/github/kikin81/atproto/chat/bsky/convo/MessageViewEmbedUnion, io/github/kikin81/atproto/runtime/UnknownOpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/MessageViewEmbedUnion$Unknown$Companion;
+	public fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/chat/bsky/convo/MessageViewEmbedUnion$Unknown;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/MessageViewEmbedUnion$Unknown;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/MessageViewEmbedUnion$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getRaw ()Lkotlinx/serialization/json/JsonObject;
+	public fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/MessageViewEmbedUnion$Unknown$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/MessageViewEmbedUnionSerializer : io/github/kikin81/atproto/runtime/OpenUnionSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/MessageViewEmbedUnionSerializer;
+	public fun selectKnownDeserializer (Ljava/lang/String;)Lkotlinx/serialization/KSerializer;
+	public fun selectKnownSerializer (Lio/github/kikin81/atproto/chat/bsky/convo/MessageViewEmbedUnion;)Lkotlinx/serialization/KSerializer;
+	public synthetic fun selectKnownSerializer (Lio/github/kikin81/atproto/runtime/OpenUnionMember;)Lkotlinx/serialization/KSerializer;
+	public fun unknownSerializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/MessageViewEmbedUnionUnknownSerializer : io/github/kikin81/atproto/runtime/UnknownMemberSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/MessageViewEmbedUnionUnknownSerializer;
+	public fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/chat/bsky/convo/MessageViewEmbedUnion$Unknown;
+	public synthetic fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/runtime/UnknownOpenUnionMember;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/MessageViewSender {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/MessageViewSender$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-UyB9Nic ()Ljava/lang/String;
+	public final fun copy-OoJ1cAE (Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/MessageViewSender;
+	public static synthetic fun copy-OoJ1cAE$default (Lio/github/kikin81/atproto/chat/bsky/convo/MessageViewSender;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/MessageViewSender;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDid-UyB9Nic ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/convo/MessageViewSender$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/MessageViewSender$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/convo/MessageViewSender;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/convo/MessageViewSender;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/MessageViewSender$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/ReactionView {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/ReactionView$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/ReactionViewSender;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-DnBUIck ()Ljava/lang/String;
+	public final fun component2 ()Lio/github/kikin81/atproto/chat/bsky/convo/ReactionViewSender;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy-znBggmM (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/ReactionViewSender;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/ReactionView;
+	public static synthetic fun copy-znBggmM$default (Lio/github/kikin81/atproto/chat/bsky/convo/ReactionView;Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/ReactionViewSender;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/ReactionView;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCreatedAt-DnBUIck ()Ljava/lang/String;
+	public final fun getSender ()Lio/github/kikin81/atproto/chat/bsky/convo/ReactionViewSender;
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/convo/ReactionView$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/ReactionView$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/convo/ReactionView;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/convo/ReactionView;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/ReactionView$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/ReactionViewSender {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/ReactionViewSender$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-UyB9Nic ()Ljava/lang/String;
+	public final fun copy-OoJ1cAE (Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/ReactionViewSender;
+	public static synthetic fun copy-OoJ1cAE$default (Lio/github/kikin81/atproto/chat/bsky/convo/ReactionViewSender;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/ReactionViewSender;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDid-UyB9Nic ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/convo/ReactionViewSender$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/ReactionViewSender$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/convo/ReactionViewSender;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/convo/ReactionViewSender;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/ReactionViewSender$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/SendMessageRequest {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/SendMessageRequest$Companion;
+	public fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/MessageInput;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/github/kikin81/atproto/chat/bsky/convo/MessageInput;
+	public final fun copy (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/MessageInput;)Lio/github/kikin81/atproto/chat/bsky/convo/SendMessageRequest;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/SendMessageRequest;Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/MessageInput;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/SendMessageRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConvoId ()Ljava/lang/String;
+	public final fun getMessage ()Lio/github/kikin81/atproto/chat/bsky/convo/MessageInput;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/convo/SendMessageRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/SendMessageRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/convo/SendMessageRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/convo/SendMessageRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/SendMessageRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataAddMember : io/github/kikin81/atproto/chat/bsky/convo/SystemMessageViewDataUnion {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataAddMember$Companion;
+	public fun <init> (Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;Ljava/lang/String;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;
+	public final fun component2 ()Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataAddMember;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataAddMember;Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataAddMember;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAddedBy ()Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;
+	public final fun getMember ()Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;
+	public final fun getRole ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataAddMember$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataAddMember$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataAddMember;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataAddMember;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataAddMember$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataCreateJoinLink : io/github/kikin81/atproto/chat/bsky/convo/SystemMessageViewDataUnion {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataCreateJoinLink$Companion;
+	public fun <init> ()V
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataCreateJoinLink$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataCreateJoinLink$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataCreateJoinLink;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataCreateJoinLink;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataCreateJoinLink$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataDisableJoinLink : io/github/kikin81/atproto/chat/bsky/convo/SystemMessageViewDataUnion {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataDisableJoinLink$Companion;
+	public fun <init> ()V
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataDisableJoinLink$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataDisableJoinLink$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataDisableJoinLink;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataDisableJoinLink;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataDisableJoinLink$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataEditGroup : io/github/kikin81/atproto/chat/bsky/convo/SystemMessageViewDataUnion {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataEditGroup$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataEditGroup;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataEditGroup;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataEditGroup;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getNewName ()Ljava/lang/String;
+	public final fun getOldName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataEditGroup$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataEditGroup$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataEditGroup;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataEditGroup;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataEditGroup$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataEditJoinLink : io/github/kikin81/atproto/chat/bsky/convo/SystemMessageViewDataUnion {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataEditJoinLink$Companion;
+	public fun <init> ()V
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataEditJoinLink$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataEditJoinLink$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataEditJoinLink;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataEditJoinLink;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataEditJoinLink$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataEnableJoinLink : io/github/kikin81/atproto/chat/bsky/convo/SystemMessageViewDataUnion {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataEnableJoinLink$Companion;
+	public fun <init> ()V
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataEnableJoinLink$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataEnableJoinLink$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataEnableJoinLink;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataEnableJoinLink;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataEnableJoinLink$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataLockConvo : io/github/kikin81/atproto/chat/bsky/convo/SystemMessageViewDataUnion {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataLockConvo$Companion;
+	public fun <init> (Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;
+	public final fun copy (Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;)Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataLockConvo;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataLockConvo;Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataLockConvo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getLockedBy ()Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataLockConvo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataLockConvo$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataLockConvo;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataLockConvo;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataLockConvo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataLockConvoPermanently : io/github/kikin81/atproto/chat/bsky/convo/SystemMessageViewDataUnion {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataLockConvoPermanently$Companion;
+	public fun <init> (Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;
+	public final fun copy (Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;)Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataLockConvoPermanently;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataLockConvoPermanently;Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataLockConvoPermanently;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getLockedBy ()Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataLockConvoPermanently$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataLockConvoPermanently$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataLockConvoPermanently;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataLockConvoPermanently;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataLockConvoPermanently$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataMemberJoin : io/github/kikin81/atproto/chat/bsky/convo/SystemMessageViewDataUnion {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataMemberJoin$Companion;
+	public fun <init> (Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;Ljava/lang/String;)V
+	public synthetic fun <init> (Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;
+	public final fun component2 ()Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataMemberJoin;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataMemberJoin;Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataMemberJoin;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getApprovedBy ()Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;
+	public final fun getMember ()Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;
+	public final fun getRole ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataMemberJoin$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataMemberJoin$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataMemberJoin;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataMemberJoin;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataMemberJoin$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataMemberLeave : io/github/kikin81/atproto/chat/bsky/convo/SystemMessageViewDataUnion {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataMemberLeave$Companion;
+	public fun <init> (Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;
+	public final fun copy (Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;)Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataMemberLeave;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataMemberLeave;Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataMemberLeave;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMember ()Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataMemberLeave$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataMemberLeave$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataMemberLeave;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataMemberLeave;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataMemberLeave$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataRemoveMember : io/github/kikin81/atproto/chat/bsky/convo/SystemMessageViewDataUnion {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataRemoveMember$Companion;
+	public fun <init> (Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;
+	public final fun component2 ()Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;
+	public final fun copy (Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;)Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataRemoveMember;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataRemoveMember;Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataRemoveMember;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMember ()Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;
+	public final fun getRemovedBy ()Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataRemoveMember$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataRemoveMember$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataRemoveMember;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataRemoveMember;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataRemoveMember$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataUnlockConvo : io/github/kikin81/atproto/chat/bsky/convo/SystemMessageViewDataUnion {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataUnlockConvo$Companion;
+	public fun <init> (Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;
+	public final fun copy (Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;)Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataUnlockConvo;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataUnlockConvo;Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataUnlockConvo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUnlockedBy ()Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataUnlockConvo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataUnlockConvo$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataUnlockConvo;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataUnlockConvo;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataUnlockConvo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/SystemMessageView : io/github/kikin81/atproto/chat/bsky/convo/ConvoViewLastMessageUnion, io/github/kikin81/atproto/chat/bsky/convo/GetMessagesResponseMessagesUnion, io/github/kikin81/atproto/chat/bsky/convo/LogReadConvoMessageUnion, io/github/kikin81/atproto/chat/bsky/convo/LogReadMessageMessageUnion {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageView$Companion;
+	public synthetic fun <init> (Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageViewDataUnion;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageViewDataUnion;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4-DnBUIck ()Ljava/lang/String;
+	public final fun copy-VYk0tSs (Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageViewDataUnion;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageView;
+	public static synthetic fun copy-VYk0tSs$default (Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageView;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageViewDataUnion;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageView;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getData ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageViewDataUnion;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getRev ()Ljava/lang/String;
+	public final fun getSentAt-DnBUIck ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/convo/SystemMessageView$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageView$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageView;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageView;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/SystemMessageView$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class io/github/kikin81/atproto/chat/bsky/convo/SystemMessageViewDataUnion : io/github/kikin81/atproto/runtime/OpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageViewDataUnion$Companion;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/SystemMessageViewDataUnion$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/SystemMessageViewDataUnion$Unknown : io/github/kikin81/atproto/chat/bsky/convo/SystemMessageViewDataUnion, io/github/kikin81/atproto/runtime/UnknownOpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageViewDataUnion$Unknown$Companion;
+	public fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageViewDataUnion$Unknown;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageViewDataUnion$Unknown;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageViewDataUnion$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getRaw ()Lkotlinx/serialization/json/JsonObject;
+	public fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/SystemMessageViewDataUnion$Unknown$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/SystemMessageViewDataUnionSerializer : io/github/kikin81/atproto/runtime/OpenUnionSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageViewDataUnionSerializer;
+	public fun selectKnownDeserializer (Ljava/lang/String;)Lkotlinx/serialization/KSerializer;
+	public fun selectKnownSerializer (Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageViewDataUnion;)Lkotlinx/serialization/KSerializer;
+	public synthetic fun selectKnownSerializer (Lio/github/kikin81/atproto/runtime/OpenUnionMember;)Lkotlinx/serialization/KSerializer;
+	public fun unknownSerializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/SystemMessageViewDataUnionUnknownSerializer : io/github/kikin81/atproto/runtime/UnknownMemberSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageViewDataUnionUnknownSerializer;
+	public fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageViewDataUnion$Unknown;
+	public synthetic fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/runtime/UnknownOpenUnionMember;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/GroupPublicView {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/group/GroupPublicView$Companion;
+	public fun <init> (JLjava/lang/String;Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;Z)V
+	public final fun component1 ()J
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;
+	public final fun component4 ()Z
+	public final fun copy (JLjava/lang/String;Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;Z)Lio/github/kikin81/atproto/chat/bsky/group/GroupPublicView;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/group/GroupPublicView;JLjava/lang/String;Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;ZILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/group/GroupPublicView;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMemberCount ()J
+	public final fun getName ()Ljava/lang/String;
+	public final fun getOwner ()Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;
+	public final fun getRequireApproval ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/group/GroupPublicView$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/group/GroupPublicView$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/group/GroupPublicView;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/group/GroupPublicView;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/GroupPublicView$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/JoinLinkView {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/group/JoinLinkView$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2-DnBUIck ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Z
+	public final fun copy-u3bxCpY (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Z)Lio/github/kikin81/atproto/chat/bsky/group/JoinLinkView;
+	public static synthetic fun copy-u3bxCpY$default (Lio/github/kikin81/atproto/chat/bsky/group/JoinLinkView;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/group/JoinLinkView;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCode ()Ljava/lang/String;
+	public final fun getCreatedAt-DnBUIck ()Ljava/lang/String;
+	public final fun getEnabledStatus ()Ljava/lang/String;
+	public final fun getJoinRule ()Ljava/lang/String;
+	public final fun getRequireApproval ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/group/JoinLinkView$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/group/JoinLinkView$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/group/JoinLinkView;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/group/JoinLinkView;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/JoinLinkView$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/JoinRequestView {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/group/JoinRequestView$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2-DnBUIck ()Ljava/lang/String;
+	public final fun component3 ()Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;
+	public final fun copy-h51FFlk (Ljava/lang/String;Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;)Lio/github/kikin81/atproto/chat/bsky/group/JoinRequestView;
+	public static synthetic fun copy-h51FFlk$default (Lio/github/kikin81/atproto/chat/bsky/group/JoinRequestView;Ljava/lang/String;Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/group/JoinRequestView;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConvoId ()Ljava/lang/String;
+	public final fun getRequestedAt-DnBUIck ()Ljava/lang/String;
+	public final fun getRequestedBy ()Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/group/JoinRequestView$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/group/JoinRequestView$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/group/JoinRequestView;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/group/JoinRequestView;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/JoinRequestView$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/admin/AccountView {
+	public static final field Companion Lio/github/kikin81/atproto/com/atproto/admin/AccountView$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/github/kikin81/atproto/com/atproto/server/InviteCode;Ljava/util/List;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/github/kikin81/atproto/com/atproto/server/InviteCode;Ljava/util/List;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-G5DCnlA ()Ljava/lang/String;
+	public final fun component10 ()Ljava/lang/Boolean;
+	public final fun component11 ()Ljava/util/List;
+	public final fun component12 ()Ljava/util/List;
+	public final fun component2-UyB9Nic ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4-G5DCnlA ()Ljava/lang/String;
+	public final fun component5-3bGGrYM ()Ljava/lang/String;
+	public final fun component6-DnBUIck ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Lio/github/kikin81/atproto/com/atproto/server/InviteCode;
+	public final fun component9 ()Ljava/util/List;
+	public final fun copy-yzwptZI (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/github/kikin81/atproto/com/atproto/server/InviteCode;Ljava/util/List;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;)Lio/github/kikin81/atproto/com/atproto/admin/AccountView;
+	public static synthetic fun copy-yzwptZI$default (Lio/github/kikin81/atproto/com/atproto/admin/AccountView;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/github/kikin81/atproto/com/atproto/server/InviteCode;Ljava/util/List;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lio/github/kikin81/atproto/com/atproto/admin/AccountView;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDeactivatedAt-G5DCnlA ()Ljava/lang/String;
+	public final fun getDid-UyB9Nic ()Ljava/lang/String;
+	public final fun getEmail ()Ljava/lang/String;
+	public final fun getEmailConfirmedAt-G5DCnlA ()Ljava/lang/String;
+	public final fun getHandle-3bGGrYM ()Ljava/lang/String;
+	public final fun getIndexedAt-DnBUIck ()Ljava/lang/String;
+	public final fun getInviteNote ()Ljava/lang/String;
+	public final fun getInvitedBy ()Lio/github/kikin81/atproto/com/atproto/server/InviteCode;
+	public final fun getInvites ()Ljava/util/List;
+	public final fun getInvitesDisabled ()Ljava/lang/Boolean;
+	public final fun getRelatedRecords ()Ljava/util/List;
+	public final fun getThreatSignatures ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/com/atproto/admin/AccountView$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/com/atproto/admin/AccountView$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/com/atproto/admin/AccountView;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/com/atproto/admin/AccountView;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/admin/AccountView$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/admin/RepoBlobRef {
+	public static final field Companion Lio/github/kikin81/atproto/com/atproto/admin/RepoBlobRef$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-LVDfoeI ()Ljava/lang/String;
+	public final fun component2-UyB9Nic ()Ljava/lang/String;
+	public final fun component3-XX8z880 ()Ljava/lang/String;
+	public final fun copy-GfE_2Q8 (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/github/kikin81/atproto/com/atproto/admin/RepoBlobRef;
+	public static synthetic fun copy-GfE_2Q8$default (Lio/github/kikin81/atproto/com/atproto/admin/RepoBlobRef;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/com/atproto/admin/RepoBlobRef;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCid-LVDfoeI ()Ljava/lang/String;
+	public final fun getDid-UyB9Nic ()Ljava/lang/String;
+	public final fun getRecordUri-XX8z880 ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/com/atproto/admin/RepoBlobRef$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/com/atproto/admin/RepoBlobRef$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/com/atproto/admin/RepoBlobRef;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/com/atproto/admin/RepoBlobRef;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/admin/RepoBlobRef$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/admin/RepoRef : io/github/kikin81/atproto/com/atproto/moderation/CreateReportRequestSubjectUnion, io/github/kikin81/atproto/com/atproto/moderation/CreateReportResponseSubjectUnion {
+	public static final field Companion Lio/github/kikin81/atproto/com/atproto/admin/RepoRef$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-UyB9Nic ()Ljava/lang/String;
+	public final fun copy-OoJ1cAE (Ljava/lang/String;)Lio/github/kikin81/atproto/com/atproto/admin/RepoRef;
+	public static synthetic fun copy-OoJ1cAE$default (Lio/github/kikin81/atproto/com/atproto/admin/RepoRef;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/com/atproto/admin/RepoRef;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDid-UyB9Nic ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/com/atproto/admin/RepoRef$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/com/atproto/admin/RepoRef$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/com/atproto/admin/RepoRef;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/com/atproto/admin/RepoRef;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/admin/RepoRef$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/admin/StatusAttr {
+	public static final field Companion Lio/github/kikin81/atproto/com/atproto/admin/StatusAttr$Companion;
+	public fun <init> (ZLjava/lang/String;)V
+	public synthetic fun <init> (ZLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (ZLjava/lang/String;)Lio/github/kikin81/atproto/com/atproto/admin/StatusAttr;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/com/atproto/admin/StatusAttr;ZLjava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/com/atproto/admin/StatusAttr;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getApplied ()Z
+	public final fun getRef ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/com/atproto/admin/StatusAttr$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/com/atproto/admin/StatusAttr$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/com/atproto/admin/StatusAttr;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/com/atproto/admin/StatusAttr;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/admin/StatusAttr$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/admin/ThreatSignature {
+	public static final field Companion Lio/github/kikin81/atproto/com/atproto/admin/ThreatSignature$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lio/github/kikin81/atproto/com/atproto/admin/ThreatSignature;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/com/atproto/admin/ThreatSignature;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/com/atproto/admin/ThreatSignature;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getProperty ()Ljava/lang/String;
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/com/atproto/admin/ThreatSignature$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/com/atproto/admin/ThreatSignature$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/com/atproto/admin/ThreatSignature;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/com/atproto/admin/ThreatSignature;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/admin/ThreatSignature$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/identity/IdentityService {
+	public fun <init> (Lio/github/kikin81/atproto/runtime/XrpcClient;)V
+	public final fun resolveHandle (Lio/github/kikin81/atproto/com/atproto/identity/ResolveHandleRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun updateHandle (Lio/github/kikin81/atproto/com/atproto/identity/UpdateHandleRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/identity/ResolveHandleRequest {
+	public static final field Companion Lio/github/kikin81/atproto/com/atproto/identity/ResolveHandleRequest$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-3bGGrYM ()Ljava/lang/String;
+	public final fun copy-ls9pVrg (Ljava/lang/String;)Lio/github/kikin81/atproto/com/atproto/identity/ResolveHandleRequest;
+	public static synthetic fun copy-ls9pVrg$default (Lio/github/kikin81/atproto/com/atproto/identity/ResolveHandleRequest;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/com/atproto/identity/ResolveHandleRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getHandle-3bGGrYM ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/com/atproto/identity/ResolveHandleRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/com/atproto/identity/ResolveHandleRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/com/atproto/identity/ResolveHandleRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/com/atproto/identity/ResolveHandleRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/identity/ResolveHandleRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/identity/ResolveHandleResponse {
+	public static final field Companion Lio/github/kikin81/atproto/com/atproto/identity/ResolveHandleResponse$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-UyB9Nic ()Ljava/lang/String;
+	public final fun copy-OoJ1cAE (Ljava/lang/String;)Lio/github/kikin81/atproto/com/atproto/identity/ResolveHandleResponse;
+	public static synthetic fun copy-OoJ1cAE$default (Lio/github/kikin81/atproto/com/atproto/identity/ResolveHandleResponse;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/com/atproto/identity/ResolveHandleResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDid-UyB9Nic ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/com/atproto/identity/ResolveHandleResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/com/atproto/identity/ResolveHandleResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/com/atproto/identity/ResolveHandleResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/com/atproto/identity/ResolveHandleResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/identity/ResolveHandleResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/identity/UpdateHandleRequest {
+	public static final field Companion Lio/github/kikin81/atproto/com/atproto/identity/UpdateHandleRequest$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-3bGGrYM ()Ljava/lang/String;
+	public final fun copy-ls9pVrg (Ljava/lang/String;)Lio/github/kikin81/atproto/com/atproto/identity/UpdateHandleRequest;
+	public static synthetic fun copy-ls9pVrg$default (Lio/github/kikin81/atproto/com/atproto/identity/UpdateHandleRequest;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/com/atproto/identity/UpdateHandleRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getHandle-3bGGrYM ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/com/atproto/identity/UpdateHandleRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/com/atproto/identity/UpdateHandleRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/com/atproto/identity/UpdateHandleRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/com/atproto/identity/UpdateHandleRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/identity/UpdateHandleRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/label/Label {
+	public static final field Companion Lio/github/kikin81/atproto/com/atproto/label/Label$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;[BLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;[BLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-eL7R55w ()Ljava/lang/String;
+	public final fun component2-DnBUIck ()Ljava/lang/String;
+	public final fun component3-G5DCnlA ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/Boolean;
+	public final fun component5 ()[B
+	public final fun component6-UyB9Nic ()Ljava/lang/String;
+	public final fun component7-jMNtXP8 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Ljava/lang/Long;
+	public final fun copy-9h6yVT8 (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;[BLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;)Lio/github/kikin81/atproto/com/atproto/label/Label;
+	public static synthetic fun copy-9h6yVT8$default (Lio/github/kikin81/atproto/com/atproto/label/Label;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;[BLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;ILjava/lang/Object;)Lio/github/kikin81/atproto/com/atproto/label/Label;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCid-eL7R55w ()Ljava/lang/String;
+	public final fun getCts-DnBUIck ()Ljava/lang/String;
+	public final fun getExp-G5DCnlA ()Ljava/lang/String;
+	public final fun getNeg ()Ljava/lang/Boolean;
+	public final fun getSig ()[B
+	public final fun getSrc-UyB9Nic ()Ljava/lang/String;
+	public final fun getUri-jMNtXP8 ()Ljava/lang/String;
+	public final fun getVal ()Ljava/lang/String;
+	public final fun getVer ()Ljava/lang/Long;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/com/atproto/label/Label$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/com/atproto/label/Label$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/com/atproto/label/Label;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/com/atproto/label/Label;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/label/Label$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/label/LabelService {
+	public fun <init> (Lio/github/kikin81/atproto/runtime/XrpcClient;)V
+	public final fun queryLabels (Lio/github/kikin81/atproto/com/atproto/label/QueryLabelsRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/label/LabelServiceKt {
+	public static final fun queryLabelsFlow (Lio/github/kikin81/atproto/com/atproto/label/LabelService;Lio/github/kikin81/atproto/com/atproto/label/QueryLabelsRequest;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun queryLabelsPageFlow (Lio/github/kikin81/atproto/com/atproto/label/LabelService;Lio/github/kikin81/atproto/com/atproto/label/QueryLabelsRequest;)Lkotlinx/coroutines/flow/Flow;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/label/LabelValueDefinition {
+	public static final field Companion Lio/github/kikin81/atproto/com/atproto/label/LabelValueDefinition$Companion;
+	public fun <init> (Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Boolean;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/util/List;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;)Lio/github/kikin81/atproto/com/atproto/label/LabelValueDefinition;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/com/atproto/label/LabelValueDefinition;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/com/atproto/label/LabelValueDefinition;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAdultOnly ()Ljava/lang/Boolean;
+	public final fun getBlurs ()Ljava/lang/String;
+	public final fun getDefaultSetting ()Ljava/lang/String;
+	public final fun getIdentifier ()Ljava/lang/String;
+	public final fun getLocales ()Ljava/util/List;
+	public final fun getSeverity ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/com/atproto/label/LabelValueDefinition$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/com/atproto/label/LabelValueDefinition$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/com/atproto/label/LabelValueDefinition;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/com/atproto/label/LabelValueDefinition;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/label/LabelValueDefinition$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/label/LabelValueDefinitionInput {
+	public static final field Companion Lio/github/kikin81/atproto/com/atproto/label/LabelValueDefinitionInput$Companion;
+	public fun <init> (Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;)V
+	public synthetic fun <init> (Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/util/List;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun copy (Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;)Lio/github/kikin81/atproto/com/atproto/label/LabelValueDefinitionInput;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/com/atproto/label/LabelValueDefinitionInput;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/com/atproto/label/LabelValueDefinitionInput;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAdultOnly ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun getBlurs ()Ljava/lang/String;
+	public final fun getDefaultSetting ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun getIdentifier ()Ljava/lang/String;
+	public final fun getLocales ()Ljava/util/List;
+	public final fun getSeverity ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/com/atproto/label/LabelValueDefinitionInput$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/com/atproto/label/LabelValueDefinitionInput$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/com/atproto/label/LabelValueDefinitionInput;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/com/atproto/label/LabelValueDefinitionInput;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/label/LabelValueDefinitionInput$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/label/LabelValueDefinitionStrings {
+	public static final field Companion Lio/github/kikin81/atproto/com/atproto/label/LabelValueDefinitionStrings$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2-JI_oZ4A ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy-1uiiZy0 (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/github/kikin81/atproto/com/atproto/label/LabelValueDefinitionStrings;
+	public static synthetic fun copy-1uiiZy0$default (Lio/github/kikin81/atproto/com/atproto/label/LabelValueDefinitionStrings;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/com/atproto/label/LabelValueDefinitionStrings;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getLang-JI_oZ4A ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/com/atproto/label/LabelValueDefinitionStrings$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/com/atproto/label/LabelValueDefinitionStrings$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/com/atproto/label/LabelValueDefinitionStrings;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/com/atproto/label/LabelValueDefinitionStrings;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/label/LabelValueDefinitionStrings$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/label/QueryLabelsRequest {
+	public static final field Companion Lio/github/kikin81/atproto/com/atproto/label/QueryLabelsRequest$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/Long;Ljava/util/List;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Long;Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/Long;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/lang/Long;Ljava/util/List;Ljava/util/List;)Lio/github/kikin81/atproto/com/atproto/label/QueryLabelsRequest;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/com/atproto/label/QueryLabelsRequest;Ljava/lang/String;Ljava/lang/Long;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lio/github/kikin81/atproto/com/atproto/label/QueryLabelsRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCursor ()Ljava/lang/String;
+	public final fun getLimit ()Ljava/lang/Long;
+	public final fun getSources ()Ljava/util/List;
+	public final fun getUriPatterns ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/com/atproto/label/QueryLabelsRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/com/atproto/label/QueryLabelsRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/com/atproto/label/QueryLabelsRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/com/atproto/label/QueryLabelsRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/label/QueryLabelsRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/label/QueryLabelsResponse {
+	public static final field Companion Lio/github/kikin81/atproto/com/atproto/label/QueryLabelsResponse$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;)Lio/github/kikin81/atproto/com/atproto/label/QueryLabelsResponse;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/com/atproto/label/QueryLabelsResponse;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lio/github/kikin81/atproto/com/atproto/label/QueryLabelsResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCursor ()Ljava/lang/String;
+	public final fun getLabels ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/com/atproto/label/QueryLabelsResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/com/atproto/label/QueryLabelsResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/com/atproto/label/QueryLabelsResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/com/atproto/label/QueryLabelsResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/label/QueryLabelsResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/label/SelfLabel {
+	public static final field Companion Lio/github/kikin81/atproto/com/atproto/label/SelfLabel$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/github/kikin81/atproto/com/atproto/label/SelfLabel;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/com/atproto/label/SelfLabel;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/com/atproto/label/SelfLabel;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getVal ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/com/atproto/label/SelfLabel$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/com/atproto/label/SelfLabel$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/com/atproto/label/SelfLabel;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/com/atproto/label/SelfLabel;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/label/SelfLabel$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/label/SelfLabels : io/github/kikin81/atproto/app/bsky/actor/ProfileLabelsUnion, io/github/kikin81/atproto/app/bsky/feed/GeneratorLabelsUnion, io/github/kikin81/atproto/app/bsky/feed/PostLabelsUnion, io/github/kikin81/atproto/app/bsky/graph/ListLabelsUnion, io/github/kikin81/atproto/app/bsky/labeler/ServiceLabelsUnion {
+	public static final field Companion Lio/github/kikin81/atproto/com/atproto/label/SelfLabels$Companion;
+	public fun <init> (Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lio/github/kikin81/atproto/com/atproto/label/SelfLabels;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/com/atproto/label/SelfLabels;Ljava/util/List;ILjava/lang/Object;)Lio/github/kikin81/atproto/com/atproto/label/SelfLabels;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValues ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/com/atproto/label/SelfLabels$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/com/atproto/label/SelfLabels$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/com/atproto/label/SelfLabels;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/com/atproto/label/SelfLabels;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/label/SelfLabels$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/moderation/CreateReportModTool {
+	public static final field Companion Lio/github/kikin81/atproto/com/atproto/moderation/CreateReportModTool$Companion;
+	public fun <init> (Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;)V
+	public synthetic fun <init> (Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;)Lio/github/kikin81/atproto/com/atproto/moderation/CreateReportModTool;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/com/atproto/moderation/CreateReportModTool;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/com/atproto/moderation/CreateReportModTool;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMeta ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/com/atproto/moderation/CreateReportModTool$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/com/atproto/moderation/CreateReportModTool$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/com/atproto/moderation/CreateReportModTool;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/com/atproto/moderation/CreateReportModTool;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/moderation/CreateReportModTool$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/moderation/CreateReportRequest {
+	public static final field Companion Lio/github/kikin81/atproto/com/atproto/moderation/CreateReportRequest$Companion;
+	public fun <init> (Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;Lio/github/kikin81/atproto/com/atproto/moderation/CreateReportRequestSubjectUnion;)V
+	public synthetic fun <init> (Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;Lio/github/kikin81/atproto/com/atproto/moderation/CreateReportRequestSubjectUnion;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun component2 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Lio/github/kikin81/atproto/com/atproto/moderation/CreateReportRequestSubjectUnion;
+	public final fun copy (Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;Lio/github/kikin81/atproto/com/atproto/moderation/CreateReportRequestSubjectUnion;)Lio/github/kikin81/atproto/com/atproto/moderation/CreateReportRequest;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/com/atproto/moderation/CreateReportRequest;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;Lio/github/kikin81/atproto/com/atproto/moderation/CreateReportRequestSubjectUnion;ILjava/lang/Object;)Lio/github/kikin81/atproto/com/atproto/moderation/CreateReportRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getModTool ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun getReason ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun getReasonType ()Ljava/lang/String;
+	public final fun getSubject ()Lio/github/kikin81/atproto/com/atproto/moderation/CreateReportRequestSubjectUnion;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/com/atproto/moderation/CreateReportRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/com/atproto/moderation/CreateReportRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/com/atproto/moderation/CreateReportRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/com/atproto/moderation/CreateReportRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/moderation/CreateReportRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class io/github/kikin81/atproto/com/atproto/moderation/CreateReportRequestSubjectUnion : io/github/kikin81/atproto/runtime/OpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/com/atproto/moderation/CreateReportRequestSubjectUnion$Companion;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/moderation/CreateReportRequestSubjectUnion$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/moderation/CreateReportRequestSubjectUnion$Unknown : io/github/kikin81/atproto/com/atproto/moderation/CreateReportRequestSubjectUnion, io/github/kikin81/atproto/runtime/UnknownOpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/com/atproto/moderation/CreateReportRequestSubjectUnion$Unknown$Companion;
+	public fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/com/atproto/moderation/CreateReportRequestSubjectUnion$Unknown;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/com/atproto/moderation/CreateReportRequestSubjectUnion$Unknown;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/github/kikin81/atproto/com/atproto/moderation/CreateReportRequestSubjectUnion$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getRaw ()Lkotlinx/serialization/json/JsonObject;
+	public fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/moderation/CreateReportRequestSubjectUnion$Unknown$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/moderation/CreateReportRequestSubjectUnionSerializer : io/github/kikin81/atproto/runtime/OpenUnionSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/com/atproto/moderation/CreateReportRequestSubjectUnionSerializer;
+	public fun selectKnownDeserializer (Ljava/lang/String;)Lkotlinx/serialization/KSerializer;
+	public fun selectKnownSerializer (Lio/github/kikin81/atproto/com/atproto/moderation/CreateReportRequestSubjectUnion;)Lkotlinx/serialization/KSerializer;
+	public synthetic fun selectKnownSerializer (Lio/github/kikin81/atproto/runtime/OpenUnionMember;)Lkotlinx/serialization/KSerializer;
+	public fun unknownSerializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/moderation/CreateReportRequestSubjectUnionUnknownSerializer : io/github/kikin81/atproto/runtime/UnknownMemberSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/com/atproto/moderation/CreateReportRequestSubjectUnionUnknownSerializer;
+	public fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/com/atproto/moderation/CreateReportRequestSubjectUnion$Unknown;
+	public synthetic fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/runtime/UnknownOpenUnionMember;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/moderation/CreateReportResponse {
+	public static final field Companion Lio/github/kikin81/atproto/com/atproto/moderation/CreateReportResponse$Companion;
+	public synthetic fun <init> (Ljava/lang/String;JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/github/kikin81/atproto/com/atproto/moderation/CreateReportResponseSubjectUnion;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/github/kikin81/atproto/com/atproto/moderation/CreateReportResponseSubjectUnion;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-DnBUIck ()Ljava/lang/String;
+	public final fun component2 ()J
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5-UyB9Nic ()Ljava/lang/String;
+	public final fun component6 ()Lio/github/kikin81/atproto/com/atproto/moderation/CreateReportResponseSubjectUnion;
+	public final fun copy-cBdrWQ4 (Ljava/lang/String;JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/github/kikin81/atproto/com/atproto/moderation/CreateReportResponseSubjectUnion;)Lio/github/kikin81/atproto/com/atproto/moderation/CreateReportResponse;
+	public static synthetic fun copy-cBdrWQ4$default (Lio/github/kikin81/atproto/com/atproto/moderation/CreateReportResponse;Ljava/lang/String;JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/github/kikin81/atproto/com/atproto/moderation/CreateReportResponseSubjectUnion;ILjava/lang/Object;)Lio/github/kikin81/atproto/com/atproto/moderation/CreateReportResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCreatedAt-DnBUIck ()Ljava/lang/String;
+	public final fun getId ()J
+	public final fun getReason ()Ljava/lang/String;
+	public final fun getReasonType ()Ljava/lang/String;
+	public final fun getReportedBy-UyB9Nic ()Ljava/lang/String;
+	public final fun getSubject ()Lio/github/kikin81/atproto/com/atproto/moderation/CreateReportResponseSubjectUnion;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/com/atproto/moderation/CreateReportResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/com/atproto/moderation/CreateReportResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/com/atproto/moderation/CreateReportResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/com/atproto/moderation/CreateReportResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/moderation/CreateReportResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class io/github/kikin81/atproto/com/atproto/moderation/CreateReportResponseSubjectUnion : io/github/kikin81/atproto/runtime/OpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/com/atproto/moderation/CreateReportResponseSubjectUnion$Companion;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/moderation/CreateReportResponseSubjectUnion$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/moderation/CreateReportResponseSubjectUnion$Unknown : io/github/kikin81/atproto/com/atproto/moderation/CreateReportResponseSubjectUnion, io/github/kikin81/atproto/runtime/UnknownOpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/com/atproto/moderation/CreateReportResponseSubjectUnion$Unknown$Companion;
+	public fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/com/atproto/moderation/CreateReportResponseSubjectUnion$Unknown;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/com/atproto/moderation/CreateReportResponseSubjectUnion$Unknown;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/github/kikin81/atproto/com/atproto/moderation/CreateReportResponseSubjectUnion$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getRaw ()Lkotlinx/serialization/json/JsonObject;
+	public fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/moderation/CreateReportResponseSubjectUnion$Unknown$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/moderation/CreateReportResponseSubjectUnionSerializer : io/github/kikin81/atproto/runtime/OpenUnionSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/com/atproto/moderation/CreateReportResponseSubjectUnionSerializer;
+	public fun selectKnownDeserializer (Ljava/lang/String;)Lkotlinx/serialization/KSerializer;
+	public fun selectKnownSerializer (Lio/github/kikin81/atproto/com/atproto/moderation/CreateReportResponseSubjectUnion;)Lkotlinx/serialization/KSerializer;
+	public synthetic fun selectKnownSerializer (Lio/github/kikin81/atproto/runtime/OpenUnionMember;)Lkotlinx/serialization/KSerializer;
+	public fun unknownSerializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/moderation/CreateReportResponseSubjectUnionUnknownSerializer : io/github/kikin81/atproto/runtime/UnknownMemberSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/com/atproto/moderation/CreateReportResponseSubjectUnionUnknownSerializer;
+	public fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/com/atproto/moderation/CreateReportResponseSubjectUnion$Unknown;
+	public synthetic fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/runtime/UnknownOpenUnionMember;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/moderation/ModerationService {
+	public fun <init> (Lio/github/kikin81/atproto/runtime/XrpcClient;)V
+	public final fun createReport (Lio/github/kikin81/atproto/com/atproto/moderation/CreateReportRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/repo/ApplyWritesCreate : io/github/kikin81/atproto/com/atproto/repo/ApplyWritesRequestWritesUnion {
+	public static final field Companion Lio/github/kikin81/atproto/com/atproto/repo/ApplyWritesCreate$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;Lkotlinx/serialization/json/JsonObject;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;Lkotlinx/serialization/json/JsonObject;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-HeyBs1c ()Ljava/lang/String;
+	public final fun component2 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun component3 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy-3Gatnso (Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/com/atproto/repo/ApplyWritesCreate;
+	public static synthetic fun copy-3Gatnso$default (Lio/github/kikin81/atproto/com/atproto/repo/ApplyWritesCreate;Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/github/kikin81/atproto/com/atproto/repo/ApplyWritesCreate;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCollection-HeyBs1c ()Ljava/lang/String;
+	public final fun getRkey ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun getValue ()Lkotlinx/serialization/json/JsonObject;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/com/atproto/repo/ApplyWritesCreate$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/com/atproto/repo/ApplyWritesCreate$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/com/atproto/repo/ApplyWritesCreate;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/com/atproto/repo/ApplyWritesCreate;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/repo/ApplyWritesCreate$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/repo/ApplyWritesCreateResult : io/github/kikin81/atproto/com/atproto/repo/ApplyWritesResponseResultsUnion {
+	public static final field Companion Lio/github/kikin81/atproto/com/atproto/repo/ApplyWritesCreateResult$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-LVDfoeI ()Ljava/lang/String;
+	public final fun component2-GUXd3rc ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy-n2jABSU (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/github/kikin81/atproto/com/atproto/repo/ApplyWritesCreateResult;
+	public static synthetic fun copy-n2jABSU$default (Lio/github/kikin81/atproto/com/atproto/repo/ApplyWritesCreateResult;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/com/atproto/repo/ApplyWritesCreateResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCid-LVDfoeI ()Ljava/lang/String;
+	public final fun getUri-GUXd3rc ()Ljava/lang/String;
+	public final fun getValidationStatus ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/com/atproto/repo/ApplyWritesCreateResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/com/atproto/repo/ApplyWritesCreateResult$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/com/atproto/repo/ApplyWritesCreateResult;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/com/atproto/repo/ApplyWritesCreateResult;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/repo/ApplyWritesCreateResult$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/repo/ApplyWritesDelete : io/github/kikin81/atproto/com/atproto/repo/ApplyWritesRequestWritesUnion {
+	public static final field Companion Lio/github/kikin81/atproto/com/atproto/repo/ApplyWritesDelete$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-HeyBs1c ()Ljava/lang/String;
+	public final fun component2-58JRfp4 ()Ljava/lang/String;
+	public final fun copy-otoKI6o (Ljava/lang/String;Ljava/lang/String;)Lio/github/kikin81/atproto/com/atproto/repo/ApplyWritesDelete;
+	public static synthetic fun copy-otoKI6o$default (Lio/github/kikin81/atproto/com/atproto/repo/ApplyWritesDelete;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/com/atproto/repo/ApplyWritesDelete;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCollection-HeyBs1c ()Ljava/lang/String;
+	public final fun getRkey-58JRfp4 ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/com/atproto/repo/ApplyWritesDelete$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/com/atproto/repo/ApplyWritesDelete$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/com/atproto/repo/ApplyWritesDelete;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/com/atproto/repo/ApplyWritesDelete;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/repo/ApplyWritesDelete$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/repo/ApplyWritesDeleteResult : io/github/kikin81/atproto/com/atproto/repo/ApplyWritesResponseResultsUnion {
+	public static final field Companion Lio/github/kikin81/atproto/com/atproto/repo/ApplyWritesDeleteResult$Companion;
+	public fun <init> ()V
+}
+
+public final synthetic class io/github/kikin81/atproto/com/atproto/repo/ApplyWritesDeleteResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/com/atproto/repo/ApplyWritesDeleteResult$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/com/atproto/repo/ApplyWritesDeleteResult;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/com/atproto/repo/ApplyWritesDeleteResult;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/repo/ApplyWritesDeleteResult$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/repo/ApplyWritesRequest {
+	public static final field Companion Lio/github/kikin81/atproto/com/atproto/repo/ApplyWritesRequest$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Ljava/util/List;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-mlEIfv0 ()Ljava/lang/String;
+	public final fun component2 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun component3 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun component4 ()Ljava/util/List;
+	public final fun copy-icULqAM (Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Ljava/util/List;)Lio/github/kikin81/atproto/com/atproto/repo/ApplyWritesRequest;
+	public static synthetic fun copy-icULqAM$default (Lio/github/kikin81/atproto/com/atproto/repo/ApplyWritesRequest;Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Ljava/util/List;ILjava/lang/Object;)Lio/github/kikin81/atproto/com/atproto/repo/ApplyWritesRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getRepo-mlEIfv0 ()Ljava/lang/String;
+	public final fun getSwapCommit ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun getValidate ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun getWrites ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/com/atproto/repo/ApplyWritesRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/com/atproto/repo/ApplyWritesRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/com/atproto/repo/ApplyWritesRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/com/atproto/repo/ApplyWritesRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/repo/ApplyWritesRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class io/github/kikin81/atproto/com/atproto/repo/ApplyWritesRequestWritesUnion : io/github/kikin81/atproto/runtime/OpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/com/atproto/repo/ApplyWritesRequestWritesUnion$Companion;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/repo/ApplyWritesRequestWritesUnion$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/repo/ApplyWritesRequestWritesUnion$Unknown : io/github/kikin81/atproto/com/atproto/repo/ApplyWritesRequestWritesUnion, io/github/kikin81/atproto/runtime/UnknownOpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/com/atproto/repo/ApplyWritesRequestWritesUnion$Unknown$Companion;
+	public fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/com/atproto/repo/ApplyWritesRequestWritesUnion$Unknown;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/com/atproto/repo/ApplyWritesRequestWritesUnion$Unknown;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/github/kikin81/atproto/com/atproto/repo/ApplyWritesRequestWritesUnion$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getRaw ()Lkotlinx/serialization/json/JsonObject;
+	public fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/repo/ApplyWritesRequestWritesUnion$Unknown$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/repo/ApplyWritesRequestWritesUnionSerializer : io/github/kikin81/atproto/runtime/OpenUnionSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/com/atproto/repo/ApplyWritesRequestWritesUnionSerializer;
+	public fun selectKnownDeserializer (Ljava/lang/String;)Lkotlinx/serialization/KSerializer;
+	public fun selectKnownSerializer (Lio/github/kikin81/atproto/com/atproto/repo/ApplyWritesRequestWritesUnion;)Lkotlinx/serialization/KSerializer;
+	public synthetic fun selectKnownSerializer (Lio/github/kikin81/atproto/runtime/OpenUnionMember;)Lkotlinx/serialization/KSerializer;
+	public fun unknownSerializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/repo/ApplyWritesRequestWritesUnionUnknownSerializer : io/github/kikin81/atproto/runtime/UnknownMemberSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/com/atproto/repo/ApplyWritesRequestWritesUnionUnknownSerializer;
+	public fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/com/atproto/repo/ApplyWritesRequestWritesUnion$Unknown;
+	public synthetic fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/runtime/UnknownOpenUnionMember;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/repo/ApplyWritesResponse {
+	public static final field Companion Lio/github/kikin81/atproto/com/atproto/repo/ApplyWritesResponse$Companion;
+	public fun <init> ()V
+	public fun <init> (Lio/github/kikin81/atproto/com/atproto/repo/CommitMeta;Ljava/util/List;)V
+	public synthetic fun <init> (Lio/github/kikin81/atproto/com/atproto/repo/CommitMeta;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/com/atproto/repo/CommitMeta;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Lio/github/kikin81/atproto/com/atproto/repo/CommitMeta;Ljava/util/List;)Lio/github/kikin81/atproto/com/atproto/repo/ApplyWritesResponse;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/com/atproto/repo/ApplyWritesResponse;Lio/github/kikin81/atproto/com/atproto/repo/CommitMeta;Ljava/util/List;ILjava/lang/Object;)Lio/github/kikin81/atproto/com/atproto/repo/ApplyWritesResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCommit ()Lio/github/kikin81/atproto/com/atproto/repo/CommitMeta;
+	public final fun getResults ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/com/atproto/repo/ApplyWritesResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/com/atproto/repo/ApplyWritesResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/com/atproto/repo/ApplyWritesResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/com/atproto/repo/ApplyWritesResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/repo/ApplyWritesResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class io/github/kikin81/atproto/com/atproto/repo/ApplyWritesResponseResultsUnion : io/github/kikin81/atproto/runtime/OpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/com/atproto/repo/ApplyWritesResponseResultsUnion$Companion;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/repo/ApplyWritesResponseResultsUnion$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/repo/ApplyWritesResponseResultsUnion$Unknown : io/github/kikin81/atproto/com/atproto/repo/ApplyWritesResponseResultsUnion, io/github/kikin81/atproto/runtime/UnknownOpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/com/atproto/repo/ApplyWritesResponseResultsUnion$Unknown$Companion;
+	public fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/com/atproto/repo/ApplyWritesResponseResultsUnion$Unknown;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/com/atproto/repo/ApplyWritesResponseResultsUnion$Unknown;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/github/kikin81/atproto/com/atproto/repo/ApplyWritesResponseResultsUnion$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getRaw ()Lkotlinx/serialization/json/JsonObject;
+	public fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/repo/ApplyWritesResponseResultsUnion$Unknown$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/repo/ApplyWritesResponseResultsUnionSerializer : io/github/kikin81/atproto/runtime/OpenUnionSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/com/atproto/repo/ApplyWritesResponseResultsUnionSerializer;
+	public fun selectKnownDeserializer (Ljava/lang/String;)Lkotlinx/serialization/KSerializer;
+	public fun selectKnownSerializer (Lio/github/kikin81/atproto/com/atproto/repo/ApplyWritesResponseResultsUnion;)Lkotlinx/serialization/KSerializer;
+	public synthetic fun selectKnownSerializer (Lio/github/kikin81/atproto/runtime/OpenUnionMember;)Lkotlinx/serialization/KSerializer;
+	public fun unknownSerializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/repo/ApplyWritesResponseResultsUnionUnknownSerializer : io/github/kikin81/atproto/runtime/UnknownMemberSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/com/atproto/repo/ApplyWritesResponseResultsUnionUnknownSerializer;
+	public fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/com/atproto/repo/ApplyWritesResponseResultsUnion$Unknown;
+	public synthetic fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/runtime/UnknownOpenUnionMember;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/repo/ApplyWritesUpdate : io/github/kikin81/atproto/com/atproto/repo/ApplyWritesRequestWritesUnion {
+	public static final field Companion Lio/github/kikin81/atproto/com/atproto/repo/ApplyWritesUpdate$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-HeyBs1c ()Ljava/lang/String;
+	public final fun component2-58JRfp4 ()Ljava/lang/String;
+	public final fun component3 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy-_7u8SVo (Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/com/atproto/repo/ApplyWritesUpdate;
+	public static synthetic fun copy-_7u8SVo$default (Lio/github/kikin81/atproto/com/atproto/repo/ApplyWritesUpdate;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/github/kikin81/atproto/com/atproto/repo/ApplyWritesUpdate;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCollection-HeyBs1c ()Ljava/lang/String;
+	public final fun getRkey-58JRfp4 ()Ljava/lang/String;
+	public final fun getValue ()Lkotlinx/serialization/json/JsonObject;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/com/atproto/repo/ApplyWritesUpdate$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/com/atproto/repo/ApplyWritesUpdate$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/com/atproto/repo/ApplyWritesUpdate;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/com/atproto/repo/ApplyWritesUpdate;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/repo/ApplyWritesUpdate$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/repo/ApplyWritesUpdateResult : io/github/kikin81/atproto/com/atproto/repo/ApplyWritesResponseResultsUnion {
+	public static final field Companion Lio/github/kikin81/atproto/com/atproto/repo/ApplyWritesUpdateResult$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-LVDfoeI ()Ljava/lang/String;
+	public final fun component2-GUXd3rc ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy-n2jABSU (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/github/kikin81/atproto/com/atproto/repo/ApplyWritesUpdateResult;
+	public static synthetic fun copy-n2jABSU$default (Lio/github/kikin81/atproto/com/atproto/repo/ApplyWritesUpdateResult;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/com/atproto/repo/ApplyWritesUpdateResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCid-LVDfoeI ()Ljava/lang/String;
+	public final fun getUri-GUXd3rc ()Ljava/lang/String;
+	public final fun getValidationStatus ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/com/atproto/repo/ApplyWritesUpdateResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/com/atproto/repo/ApplyWritesUpdateResult$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/com/atproto/repo/ApplyWritesUpdateResult;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/com/atproto/repo/ApplyWritesUpdateResult;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/repo/ApplyWritesUpdateResult$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/repo/CommitMeta {
+	public static final field Companion Lio/github/kikin81/atproto/com/atproto/repo/CommitMeta$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-LVDfoeI ()Ljava/lang/String;
+	public final fun component2-nr-ICYc ()Ljava/lang/String;
+	public final fun copy-GGxkEfs (Ljava/lang/String;Ljava/lang/String;)Lio/github/kikin81/atproto/com/atproto/repo/CommitMeta;
+	public static synthetic fun copy-GGxkEfs$default (Lio/github/kikin81/atproto/com/atproto/repo/CommitMeta;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/com/atproto/repo/CommitMeta;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCid-LVDfoeI ()Ljava/lang/String;
+	public final fun getRev-nr-ICYc ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/com/atproto/repo/CommitMeta$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/com/atproto/repo/CommitMeta$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/com/atproto/repo/CommitMeta;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/com/atproto/repo/CommitMeta;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/repo/CommitMeta$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/repo/CreateRecordRequest {
+	public static final field Companion Lio/github/kikin81/atproto/com/atproto/repo/CreateRecordRequest$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-HeyBs1c ()Ljava/lang/String;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun component3-mlEIfv0 ()Ljava/lang/String;
+	public final fun component4 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun component5 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun component6 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun copy-wxTDUec (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;)Lio/github/kikin81/atproto/com/atproto/repo/CreateRecordRequest;
+	public static synthetic fun copy-wxTDUec$default (Lio/github/kikin81/atproto/com/atproto/repo/CreateRecordRequest;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;ILjava/lang/Object;)Lio/github/kikin81/atproto/com/atproto/repo/CreateRecordRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCollection-HeyBs1c ()Ljava/lang/String;
+	public final fun getRecord ()Lkotlinx/serialization/json/JsonObject;
+	public final fun getRepo-mlEIfv0 ()Ljava/lang/String;
+	public final fun getRkey ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun getSwapCommit ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun getValidate ()Lio/github/kikin81/atproto/runtime/AtField;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/com/atproto/repo/CreateRecordRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/com/atproto/repo/CreateRecordRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/com/atproto/repo/CreateRecordRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/com/atproto/repo/CreateRecordRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/repo/CreateRecordRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/repo/CreateRecordResponse {
+	public static final field Companion Lio/github/kikin81/atproto/com/atproto/repo/CreateRecordResponse$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/com/atproto/repo/CommitMeta;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/com/atproto/repo/CommitMeta;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-LVDfoeI ()Ljava/lang/String;
+	public final fun component2 ()Lio/github/kikin81/atproto/com/atproto/repo/CommitMeta;
+	public final fun component3-GUXd3rc ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy-JynTkVA (Ljava/lang/String;Lio/github/kikin81/atproto/com/atproto/repo/CommitMeta;Ljava/lang/String;Ljava/lang/String;)Lio/github/kikin81/atproto/com/atproto/repo/CreateRecordResponse;
+	public static synthetic fun copy-JynTkVA$default (Lio/github/kikin81/atproto/com/atproto/repo/CreateRecordResponse;Ljava/lang/String;Lio/github/kikin81/atproto/com/atproto/repo/CommitMeta;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/com/atproto/repo/CreateRecordResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCid-LVDfoeI ()Ljava/lang/String;
+	public final fun getCommit ()Lio/github/kikin81/atproto/com/atproto/repo/CommitMeta;
+	public final fun getUri-GUXd3rc ()Ljava/lang/String;
+	public final fun getValidationStatus ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/com/atproto/repo/CreateRecordResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/com/atproto/repo/CreateRecordResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/com/atproto/repo/CreateRecordResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/com/atproto/repo/CreateRecordResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/repo/CreateRecordResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/repo/DeleteRecordRequest {
+	public static final field Companion Lio/github/kikin81/atproto/com/atproto/repo/DeleteRecordRequest$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-HeyBs1c ()Ljava/lang/String;
+	public final fun component2-mlEIfv0 ()Ljava/lang/String;
+	public final fun component3-58JRfp4 ()Ljava/lang/String;
+	public final fun component4 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun component5 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun copy-ffW8QmY (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;)Lio/github/kikin81/atproto/com/atproto/repo/DeleteRecordRequest;
+	public static synthetic fun copy-ffW8QmY$default (Lio/github/kikin81/atproto/com/atproto/repo/DeleteRecordRequest;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;ILjava/lang/Object;)Lio/github/kikin81/atproto/com/atproto/repo/DeleteRecordRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCollection-HeyBs1c ()Ljava/lang/String;
+	public final fun getRepo-mlEIfv0 ()Ljava/lang/String;
+	public final fun getRkey-58JRfp4 ()Ljava/lang/String;
+	public final fun getSwapCommit ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun getSwapRecord ()Lio/github/kikin81/atproto/runtime/AtField;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/com/atproto/repo/DeleteRecordRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/com/atproto/repo/DeleteRecordRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/com/atproto/repo/DeleteRecordRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/com/atproto/repo/DeleteRecordRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/repo/DeleteRecordRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/repo/DeleteRecordResponse {
+	public static final field Companion Lio/github/kikin81/atproto/com/atproto/repo/DeleteRecordResponse$Companion;
+	public fun <init> ()V
+	public fun <init> (Lio/github/kikin81/atproto/com/atproto/repo/CommitMeta;)V
+	public synthetic fun <init> (Lio/github/kikin81/atproto/com/atproto/repo/CommitMeta;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/com/atproto/repo/CommitMeta;
+	public final fun copy (Lio/github/kikin81/atproto/com/atproto/repo/CommitMeta;)Lio/github/kikin81/atproto/com/atproto/repo/DeleteRecordResponse;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/com/atproto/repo/DeleteRecordResponse;Lio/github/kikin81/atproto/com/atproto/repo/CommitMeta;ILjava/lang/Object;)Lio/github/kikin81/atproto/com/atproto/repo/DeleteRecordResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCommit ()Lio/github/kikin81/atproto/com/atproto/repo/CommitMeta;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/com/atproto/repo/DeleteRecordResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/com/atproto/repo/DeleteRecordResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/com/atproto/repo/DeleteRecordResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/com/atproto/repo/DeleteRecordResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/repo/DeleteRecordResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/repo/DescribeRepoRequest {
+	public static final field Companion Lio/github/kikin81/atproto/com/atproto/repo/DescribeRepoRequest$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-mlEIfv0 ()Ljava/lang/String;
+	public final fun copy-6PA111I (Ljava/lang/String;)Lio/github/kikin81/atproto/com/atproto/repo/DescribeRepoRequest;
+	public static synthetic fun copy-6PA111I$default (Lio/github/kikin81/atproto/com/atproto/repo/DescribeRepoRequest;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/com/atproto/repo/DescribeRepoRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getRepo-mlEIfv0 ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/com/atproto/repo/DescribeRepoRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/com/atproto/repo/DescribeRepoRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/com/atproto/repo/DescribeRepoRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/com/atproto/repo/DescribeRepoRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/repo/DescribeRepoRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/repo/DescribeRepoResponse {
+	public static final field Companion Lio/github/kikin81/atproto/com/atproto/repo/DescribeRepoResponse$Companion;
+	public synthetic fun <init> (Ljava/util/List;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;ZLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2-UyB9Nic ()Ljava/lang/String;
+	public final fun component3 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun component4-3bGGrYM ()Ljava/lang/String;
+	public final fun component5 ()Z
+	public final fun copy-64B5QO8 (Ljava/util/List;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Z)Lio/github/kikin81/atproto/com/atproto/repo/DescribeRepoResponse;
+	public static synthetic fun copy-64B5QO8$default (Lio/github/kikin81/atproto/com/atproto/repo/DescribeRepoResponse;Ljava/util/List;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;ZILjava/lang/Object;)Lio/github/kikin81/atproto/com/atproto/repo/DescribeRepoResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCollections ()Ljava/util/List;
+	public final fun getDid-UyB9Nic ()Ljava/lang/String;
+	public final fun getDidDoc ()Lkotlinx/serialization/json/JsonObject;
+	public final fun getHandle-3bGGrYM ()Ljava/lang/String;
+	public final fun getHandleIsCorrect ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/com/atproto/repo/DescribeRepoResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/com/atproto/repo/DescribeRepoResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/com/atproto/repo/DescribeRepoResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/com/atproto/repo/DescribeRepoResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/repo/DescribeRepoResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/repo/GetRecordRequest {
+	public static final field Companion Lio/github/kikin81/atproto/com/atproto/repo/GetRecordRequest$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-eL7R55w ()Ljava/lang/String;
+	public final fun component2-HeyBs1c ()Ljava/lang/String;
+	public final fun component3-mlEIfv0 ()Ljava/lang/String;
+	public final fun component4-58JRfp4 ()Ljava/lang/String;
+	public final fun copy-PfJ_fYU (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/github/kikin81/atproto/com/atproto/repo/GetRecordRequest;
+	public static synthetic fun copy-PfJ_fYU$default (Lio/github/kikin81/atproto/com/atproto/repo/GetRecordRequest;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/com/atproto/repo/GetRecordRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCid-eL7R55w ()Ljava/lang/String;
+	public final fun getCollection-HeyBs1c ()Ljava/lang/String;
+	public final fun getRepo-mlEIfv0 ()Ljava/lang/String;
+	public final fun getRkey-58JRfp4 ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/com/atproto/repo/GetRecordRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/com/atproto/repo/GetRecordRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/com/atproto/repo/GetRecordRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/com/atproto/repo/GetRecordRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/repo/GetRecordRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/repo/GetRecordResponse {
+	public static final field Companion Lio/github/kikin81/atproto/com/atproto/repo/GetRecordResponse$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-eL7R55w ()Ljava/lang/String;
+	public final fun component2-GUXd3rc ()Ljava/lang/String;
+	public final fun component3 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy-dKprLkw (Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/com/atproto/repo/GetRecordResponse;
+	public static synthetic fun copy-dKprLkw$default (Lio/github/kikin81/atproto/com/atproto/repo/GetRecordResponse;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/github/kikin81/atproto/com/atproto/repo/GetRecordResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCid-eL7R55w ()Ljava/lang/String;
+	public final fun getUri-GUXd3rc ()Ljava/lang/String;
+	public final fun getValue ()Lkotlinx/serialization/json/JsonObject;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/com/atproto/repo/GetRecordResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/com/atproto/repo/GetRecordResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/com/atproto/repo/GetRecordResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/com/atproto/repo/GetRecordResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/repo/GetRecordResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/repo/ListRecordsRecord {
+	public static final field Companion Lio/github/kikin81/atproto/com/atproto/repo/ListRecordsRecord$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-LVDfoeI ()Ljava/lang/String;
+	public final fun component2-GUXd3rc ()Ljava/lang/String;
+	public final fun component3 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy-n2jABSU (Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/com/atproto/repo/ListRecordsRecord;
+	public static synthetic fun copy-n2jABSU$default (Lio/github/kikin81/atproto/com/atproto/repo/ListRecordsRecord;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/github/kikin81/atproto/com/atproto/repo/ListRecordsRecord;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCid-LVDfoeI ()Ljava/lang/String;
+	public final fun getUri-GUXd3rc ()Ljava/lang/String;
+	public final fun getValue ()Lkotlinx/serialization/json/JsonObject;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/com/atproto/repo/ListRecordsRecord$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/com/atproto/repo/ListRecordsRecord$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/com/atproto/repo/ListRecordsRecord;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/com/atproto/repo/ListRecordsRecord;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/repo/ListRecordsRecord$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/repo/ListRecordsRequest {
+	public static final field Companion Lio/github/kikin81/atproto/com/atproto/repo/ListRecordsRequest$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/Boolean;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-HeyBs1c ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/Long;
+	public final fun component4-mlEIfv0 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/Boolean;
+	public final fun copy-uAziS-Q (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/Boolean;)Lio/github/kikin81/atproto/com/atproto/repo/ListRecordsRequest;
+	public static synthetic fun copy-uAziS-Q$default (Lio/github/kikin81/atproto/com/atproto/repo/ListRecordsRequest;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/Boolean;ILjava/lang/Object;)Lio/github/kikin81/atproto/com/atproto/repo/ListRecordsRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCollection-HeyBs1c ()Ljava/lang/String;
+	public final fun getCursor ()Ljava/lang/String;
+	public final fun getLimit ()Ljava/lang/Long;
+	public final fun getRepo-mlEIfv0 ()Ljava/lang/String;
+	public final fun getReverse ()Ljava/lang/Boolean;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/com/atproto/repo/ListRecordsRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/com/atproto/repo/ListRecordsRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/com/atproto/repo/ListRecordsRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/com/atproto/repo/ListRecordsRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/repo/ListRecordsRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/repo/ListRecordsResponse {
+	public static final field Companion Lio/github/kikin81/atproto/com/atproto/repo/ListRecordsResponse$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;)Lio/github/kikin81/atproto/com/atproto/repo/ListRecordsResponse;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/com/atproto/repo/ListRecordsResponse;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lio/github/kikin81/atproto/com/atproto/repo/ListRecordsResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCursor ()Ljava/lang/String;
+	public final fun getRecords ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/com/atproto/repo/ListRecordsResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/com/atproto/repo/ListRecordsResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/com/atproto/repo/ListRecordsResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/com/atproto/repo/ListRecordsResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/repo/ListRecordsResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/repo/PutRecordRequest {
+	public static final field Companion Lio/github/kikin81/atproto/com/atproto/repo/PutRecordRequest$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-HeyBs1c ()Ljava/lang/String;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun component3-mlEIfv0 ()Ljava/lang/String;
+	public final fun component4-58JRfp4 ()Ljava/lang/String;
+	public final fun component5 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun component6 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun component7 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun copy-3D_xXzE (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;)Lio/github/kikin81/atproto/com/atproto/repo/PutRecordRequest;
+	public static synthetic fun copy-3D_xXzE$default (Lio/github/kikin81/atproto/com/atproto/repo/PutRecordRequest;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;ILjava/lang/Object;)Lio/github/kikin81/atproto/com/atproto/repo/PutRecordRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCollection-HeyBs1c ()Ljava/lang/String;
+	public final fun getRecord ()Lkotlinx/serialization/json/JsonObject;
+	public final fun getRepo-mlEIfv0 ()Ljava/lang/String;
+	public final fun getRkey-58JRfp4 ()Ljava/lang/String;
+	public final fun getSwapCommit ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun getSwapRecord ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun getValidate ()Lio/github/kikin81/atproto/runtime/AtField;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/com/atproto/repo/PutRecordRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/com/atproto/repo/PutRecordRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/com/atproto/repo/PutRecordRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/com/atproto/repo/PutRecordRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/repo/PutRecordRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/repo/PutRecordResponse {
+	public static final field Companion Lio/github/kikin81/atproto/com/atproto/repo/PutRecordResponse$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/com/atproto/repo/CommitMeta;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/com/atproto/repo/CommitMeta;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-LVDfoeI ()Ljava/lang/String;
+	public final fun component2 ()Lio/github/kikin81/atproto/com/atproto/repo/CommitMeta;
+	public final fun component3-GUXd3rc ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy-JynTkVA (Ljava/lang/String;Lio/github/kikin81/atproto/com/atproto/repo/CommitMeta;Ljava/lang/String;Ljava/lang/String;)Lio/github/kikin81/atproto/com/atproto/repo/PutRecordResponse;
+	public static synthetic fun copy-JynTkVA$default (Lio/github/kikin81/atproto/com/atproto/repo/PutRecordResponse;Ljava/lang/String;Lio/github/kikin81/atproto/com/atproto/repo/CommitMeta;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/com/atproto/repo/PutRecordResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCid-LVDfoeI ()Ljava/lang/String;
+	public final fun getCommit ()Lio/github/kikin81/atproto/com/atproto/repo/CommitMeta;
+	public final fun getUri-GUXd3rc ()Ljava/lang/String;
+	public final fun getValidationStatus ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/com/atproto/repo/PutRecordResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/com/atproto/repo/PutRecordResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/com/atproto/repo/PutRecordResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/com/atproto/repo/PutRecordResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/repo/PutRecordResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/repo/RepoService {
+	public fun <init> (Lio/github/kikin81/atproto/runtime/XrpcClient;)V
+	public final fun applyWrites (Lio/github/kikin81/atproto/com/atproto/repo/ApplyWritesRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun createRecord (Lio/github/kikin81/atproto/com/atproto/repo/CreateRecordRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun deleteRecord (Lio/github/kikin81/atproto/com/atproto/repo/DeleteRecordRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun describeRepo (Lio/github/kikin81/atproto/com/atproto/repo/DescribeRepoRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getRecord (Lio/github/kikin81/atproto/com/atproto/repo/GetRecordRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun listRecords (Lio/github/kikin81/atproto/com/atproto/repo/ListRecordsRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun putRecord (Lio/github/kikin81/atproto/com/atproto/repo/PutRecordRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun uploadBlob ([BLio/ktor/http/ContentType;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/repo/RepoServiceKt {
+	public static final fun listRecordsFlow (Lio/github/kikin81/atproto/com/atproto/repo/RepoService;Lio/github/kikin81/atproto/com/atproto/repo/ListRecordsRequest;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun listRecordsPageFlow (Lio/github/kikin81/atproto/com/atproto/repo/RepoService;Lio/github/kikin81/atproto/com/atproto/repo/ListRecordsRequest;)Lkotlinx/coroutines/flow/Flow;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/repo/StrongRef : io/github/kikin81/atproto/com/atproto/moderation/CreateReportRequestSubjectUnion, io/github/kikin81/atproto/com/atproto/moderation/CreateReportResponseSubjectUnion {
+	public static final field Companion Lio/github/kikin81/atproto/com/atproto/repo/StrongRef$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-LVDfoeI ()Ljava/lang/String;
+	public final fun component2-GUXd3rc ()Ljava/lang/String;
+	public final fun copy-rJe4bLw (Ljava/lang/String;Ljava/lang/String;)Lio/github/kikin81/atproto/com/atproto/repo/StrongRef;
+	public static synthetic fun copy-rJe4bLw$default (Lio/github/kikin81/atproto/com/atproto/repo/StrongRef;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/com/atproto/repo/StrongRef;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCid-LVDfoeI ()Ljava/lang/String;
+	public final fun getUri-GUXd3rc ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/com/atproto/repo/StrongRef$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/com/atproto/repo/StrongRef$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/com/atproto/repo/StrongRef;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/com/atproto/repo/StrongRef;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/repo/StrongRef$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/repo/UploadBlobResponse {
+	public static final field Companion Lio/github/kikin81/atproto/com/atproto/repo/UploadBlobResponse$Companion;
+	public fun <init> (Lio/github/kikin81/atproto/runtime/Blob;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/runtime/Blob;
+	public final fun copy (Lio/github/kikin81/atproto/runtime/Blob;)Lio/github/kikin81/atproto/com/atproto/repo/UploadBlobResponse;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/com/atproto/repo/UploadBlobResponse;Lio/github/kikin81/atproto/runtime/Blob;ILjava/lang/Object;)Lio/github/kikin81/atproto/com/atproto/repo/UploadBlobResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBlob ()Lio/github/kikin81/atproto/runtime/Blob;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/com/atproto/repo/UploadBlobResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/com/atproto/repo/UploadBlobResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/com/atproto/repo/UploadBlobResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/com/atproto/repo/UploadBlobResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/repo/UploadBlobResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/server/CreateAccountRequest {
+	public static final field Companion Lio/github/kikin81/atproto/com/atproto/server/CreateAccountRequest$Companion;
+	public synthetic fun <init> (Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun component2 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun component3-3bGGrYM ()Ljava/lang/String;
+	public final fun component4 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun component5 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun component6 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun component7 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun component8 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun component9 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun copy-6Z8Lp90 (Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;)Lio/github/kikin81/atproto/com/atproto/server/CreateAccountRequest;
+	public static synthetic fun copy-6Z8Lp90$default (Lio/github/kikin81/atproto/com/atproto/server/CreateAccountRequest;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;ILjava/lang/Object;)Lio/github/kikin81/atproto/com/atproto/server/CreateAccountRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDid ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun getEmail ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun getHandle-3bGGrYM ()Ljava/lang/String;
+	public final fun getInviteCode ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun getPassword ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun getPlcOp ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun getRecoveryKey ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun getVerificationCode ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun getVerificationPhone ()Lio/github/kikin81/atproto/runtime/AtField;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/com/atproto/server/CreateAccountRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/com/atproto/server/CreateAccountRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/com/atproto/server/CreateAccountRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/com/atproto/server/CreateAccountRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/server/CreateAccountRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/server/CreateAccountResponse {
+	public static final field Companion Lio/github/kikin81/atproto/com/atproto/server/CreateAccountResponse$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2-UyB9Nic ()Ljava/lang/String;
+	public final fun component3 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun component4-3bGGrYM ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy-64B5QO8 (Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Ljava/lang/String;)Lio/github/kikin81/atproto/com/atproto/server/CreateAccountResponse;
+	public static synthetic fun copy-64B5QO8$default (Lio/github/kikin81/atproto/com/atproto/server/CreateAccountResponse;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/com/atproto/server/CreateAccountResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAccessJwt ()Ljava/lang/String;
+	public final fun getDid-UyB9Nic ()Ljava/lang/String;
+	public final fun getDidDoc ()Lkotlinx/serialization/json/JsonObject;
+	public final fun getHandle-3bGGrYM ()Ljava/lang/String;
+	public final fun getRefreshJwt ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/com/atproto/server/CreateAccountResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/com/atproto/server/CreateAccountResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/com/atproto/server/CreateAccountResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/com/atproto/server/CreateAccountResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/server/CreateAccountResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/server/CreateSessionRequest {
+	public static final field Companion Lio/github/kikin81/atproto/com/atproto/server/CreateSessionRequest$Companion;
+	public fun <init> (Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun component2 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;Ljava/lang/String;)Lio/github/kikin81/atproto/com/atproto/server/CreateSessionRequest;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/com/atproto/server/CreateSessionRequest;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/com/atproto/server/CreateSessionRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAllowTakendown ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun getAuthFactorToken ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun getIdentifier ()Ljava/lang/String;
+	public final fun getPassword ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/com/atproto/server/CreateSessionRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/com/atproto/server/CreateSessionRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/com/atproto/server/CreateSessionRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/com/atproto/server/CreateSessionRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/server/CreateSessionRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/server/CreateSessionResponse {
+	public static final field Companion Lio/github/kikin81/atproto/com/atproto/server/CreateSessionResponse$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/Boolean;
+	public final fun component3-UyB9Nic ()Ljava/lang/String;
+	public final fun component4 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/Boolean;
+	public final fun component7 ()Ljava/lang/Boolean;
+	public final fun component8-3bGGrYM ()Ljava/lang/String;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy-EnZeUyQ (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/github/kikin81/atproto/com/atproto/server/CreateSessionResponse;
+	public static synthetic fun copy-EnZeUyQ$default (Lio/github/kikin81/atproto/com/atproto/server/CreateSessionResponse;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/com/atproto/server/CreateSessionResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAccessJwt ()Ljava/lang/String;
+	public final fun getActive ()Ljava/lang/Boolean;
+	public final fun getDid-UyB9Nic ()Ljava/lang/String;
+	public final fun getDidDoc ()Lkotlinx/serialization/json/JsonObject;
+	public final fun getEmail ()Ljava/lang/String;
+	public final fun getEmailAuthFactor ()Ljava/lang/Boolean;
+	public final fun getEmailConfirmed ()Ljava/lang/Boolean;
+	public final fun getHandle-3bGGrYM ()Ljava/lang/String;
+	public final fun getRefreshJwt ()Ljava/lang/String;
+	public final fun getStatus ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/com/atproto/server/CreateSessionResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/com/atproto/server/CreateSessionResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/com/atproto/server/CreateSessionResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/com/atproto/server/CreateSessionResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/server/CreateSessionResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/server/DescribeServerContact {
+	public static final field Companion Lio/github/kikin81/atproto/com/atproto/server/DescribeServerContact$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/github/kikin81/atproto/com/atproto/server/DescribeServerContact;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/com/atproto/server/DescribeServerContact;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/com/atproto/server/DescribeServerContact;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEmail ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/com/atproto/server/DescribeServerContact$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/com/atproto/server/DescribeServerContact$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/com/atproto/server/DescribeServerContact;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/com/atproto/server/DescribeServerContact;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/server/DescribeServerContact$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/server/DescribeServerLinks {
+	public static final field Companion Lio/github/kikin81/atproto/com/atproto/server/DescribeServerLinks$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-Eo6btPk ()Ljava/lang/String;
+	public final fun component2-Eo6btPk ()Ljava/lang/String;
+	public final fun copy-yeSZZ0I (Ljava/lang/String;Ljava/lang/String;)Lio/github/kikin81/atproto/com/atproto/server/DescribeServerLinks;
+	public static synthetic fun copy-yeSZZ0I$default (Lio/github/kikin81/atproto/com/atproto/server/DescribeServerLinks;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/com/atproto/server/DescribeServerLinks;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPrivacyPolicy-Eo6btPk ()Ljava/lang/String;
+	public final fun getTermsOfService-Eo6btPk ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/com/atproto/server/DescribeServerLinks$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/com/atproto/server/DescribeServerLinks$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/com/atproto/server/DescribeServerLinks;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/com/atproto/server/DescribeServerLinks;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/server/DescribeServerLinks$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/server/DescribeServerResponse {
+	public static final field Companion Lio/github/kikin81/atproto/com/atproto/server/DescribeServerResponse$Companion;
+	public synthetic fun <init> (Ljava/util/List;Lio/github/kikin81/atproto/com/atproto/server/DescribeServerContact;Ljava/lang/String;Ljava/lang/Boolean;Lio/github/kikin81/atproto/com/atproto/server/DescribeServerLinks;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/util/List;Lio/github/kikin81/atproto/com/atproto/server/DescribeServerContact;Ljava/lang/String;Ljava/lang/Boolean;Lio/github/kikin81/atproto/com/atproto/server/DescribeServerLinks;Ljava/lang/Boolean;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Lio/github/kikin81/atproto/com/atproto/server/DescribeServerContact;
+	public final fun component3-UyB9Nic ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/Boolean;
+	public final fun component5 ()Lio/github/kikin81/atproto/com/atproto/server/DescribeServerLinks;
+	public final fun component6 ()Ljava/lang/Boolean;
+	public final fun copy-HDOHtRc (Ljava/util/List;Lio/github/kikin81/atproto/com/atproto/server/DescribeServerContact;Ljava/lang/String;Ljava/lang/Boolean;Lio/github/kikin81/atproto/com/atproto/server/DescribeServerLinks;Ljava/lang/Boolean;)Lio/github/kikin81/atproto/com/atproto/server/DescribeServerResponse;
+	public static synthetic fun copy-HDOHtRc$default (Lio/github/kikin81/atproto/com/atproto/server/DescribeServerResponse;Ljava/util/List;Lio/github/kikin81/atproto/com/atproto/server/DescribeServerContact;Ljava/lang/String;Ljava/lang/Boolean;Lio/github/kikin81/atproto/com/atproto/server/DescribeServerLinks;Ljava/lang/Boolean;ILjava/lang/Object;)Lio/github/kikin81/atproto/com/atproto/server/DescribeServerResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAvailableUserDomains ()Ljava/util/List;
+	public final fun getContact ()Lio/github/kikin81/atproto/com/atproto/server/DescribeServerContact;
+	public final fun getDid-UyB9Nic ()Ljava/lang/String;
+	public final fun getInviteCodeRequired ()Ljava/lang/Boolean;
+	public final fun getLinks ()Lio/github/kikin81/atproto/com/atproto/server/DescribeServerLinks;
+	public final fun getPhoneVerificationRequired ()Ljava/lang/Boolean;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/com/atproto/server/DescribeServerResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/com/atproto/server/DescribeServerResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/com/atproto/server/DescribeServerResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/com/atproto/server/DescribeServerResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/server/DescribeServerResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/server/GetSessionResponse {
+	public static final field Companion Lio/github/kikin81/atproto/com/atproto/server/GetSessionResponse$Companion;
+	public synthetic fun <init> (Ljava/lang/Boolean;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/Boolean;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Boolean;
+	public final fun component2-UyB9Nic ()Ljava/lang/String;
+	public final fun component3 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/Boolean;
+	public final fun component6 ()Ljava/lang/Boolean;
+	public final fun component7-3bGGrYM ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun copy-66jGEPs (Ljava/lang/Boolean;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;)Lio/github/kikin81/atproto/com/atproto/server/GetSessionResponse;
+	public static synthetic fun copy-66jGEPs$default (Lio/github/kikin81/atproto/com/atproto/server/GetSessionResponse;Ljava/lang/Boolean;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/com/atproto/server/GetSessionResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActive ()Ljava/lang/Boolean;
+	public final fun getDid-UyB9Nic ()Ljava/lang/String;
+	public final fun getDidDoc ()Lkotlinx/serialization/json/JsonObject;
+	public final fun getEmail ()Ljava/lang/String;
+	public final fun getEmailAuthFactor ()Ljava/lang/Boolean;
+	public final fun getEmailConfirmed ()Ljava/lang/Boolean;
+	public final fun getHandle-3bGGrYM ()Ljava/lang/String;
+	public final fun getStatus ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/com/atproto/server/GetSessionResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/com/atproto/server/GetSessionResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/com/atproto/server/GetSessionResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/com/atproto/server/GetSessionResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/server/GetSessionResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/server/InviteCode {
+	public static final field Companion Lio/github/kikin81/atproto/com/atproto/server/InviteCode$Companion;
+	public synthetic fun <init> (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/util/List;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()J
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3-DnBUIck ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Z
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/util/List;
+	public final fun copy-cgMr17I (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/util/List;)Lio/github/kikin81/atproto/com/atproto/server/InviteCode;
+	public static synthetic fun copy-cgMr17I$default (Lio/github/kikin81/atproto/com/atproto/server/InviteCode;JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lio/github/kikin81/atproto/com/atproto/server/InviteCode;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAvailable ()J
+	public final fun getCode ()Ljava/lang/String;
+	public final fun getCreatedAt-DnBUIck ()Ljava/lang/String;
+	public final fun getCreatedBy ()Ljava/lang/String;
+	public final fun getDisabled ()Z
+	public final fun getForAccount ()Ljava/lang/String;
+	public final fun getUses ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/com/atproto/server/InviteCode$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/com/atproto/server/InviteCode$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/com/atproto/server/InviteCode;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/com/atproto/server/InviteCode;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/server/InviteCode$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/server/InviteCodeUse {
+	public static final field Companion Lio/github/kikin81/atproto/com/atproto/server/InviteCodeUse$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-DnBUIck ()Ljava/lang/String;
+	public final fun component2-UyB9Nic ()Ljava/lang/String;
+	public final fun copy-KDnUP0Y (Ljava/lang/String;Ljava/lang/String;)Lio/github/kikin81/atproto/com/atproto/server/InviteCodeUse;
+	public static synthetic fun copy-KDnUP0Y$default (Lio/github/kikin81/atproto/com/atproto/server/InviteCodeUse;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/com/atproto/server/InviteCodeUse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUsedAt-DnBUIck ()Ljava/lang/String;
+	public final fun getUsedBy-UyB9Nic ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/com/atproto/server/InviteCodeUse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/com/atproto/server/InviteCodeUse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/com/atproto/server/InviteCodeUse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/com/atproto/server/InviteCodeUse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/server/InviteCodeUse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/server/RefreshSessionResponse {
+	public static final field Companion Lio/github/kikin81/atproto/com/atproto/server/RefreshSessionResponse$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/Boolean;
+	public final fun component3-UyB9Nic ()Ljava/lang/String;
+	public final fun component4 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/Boolean;
+	public final fun component7 ()Ljava/lang/Boolean;
+	public final fun component8-3bGGrYM ()Ljava/lang/String;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy-EnZeUyQ (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/github/kikin81/atproto/com/atproto/server/RefreshSessionResponse;
+	public static synthetic fun copy-EnZeUyQ$default (Lio/github/kikin81/atproto/com/atproto/server/RefreshSessionResponse;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/com/atproto/server/RefreshSessionResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAccessJwt ()Ljava/lang/String;
+	public final fun getActive ()Ljava/lang/Boolean;
+	public final fun getDid-UyB9Nic ()Ljava/lang/String;
+	public final fun getDidDoc ()Lkotlinx/serialization/json/JsonObject;
+	public final fun getEmail ()Ljava/lang/String;
+	public final fun getEmailAuthFactor ()Ljava/lang/Boolean;
+	public final fun getEmailConfirmed ()Ljava/lang/Boolean;
+	public final fun getHandle-3bGGrYM ()Ljava/lang/String;
+	public final fun getRefreshJwt ()Ljava/lang/String;
+	public final fun getStatus ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/com/atproto/server/RefreshSessionResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/com/atproto/server/RefreshSessionResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/com/atproto/server/RefreshSessionResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/com/atproto/server/RefreshSessionResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/server/RefreshSessionResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/server/ServerService {
+	public fun <init> (Lio/github/kikin81/atproto/runtime/XrpcClient;)V
+	public final fun createAccount (Lio/github/kikin81/atproto/com/atproto/server/CreateAccountRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun createSession (Lio/github/kikin81/atproto/com/atproto/server/CreateSessionRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun describeServer (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getSession (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun refreshSession (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/sync/GetLatestCommitRequest {
+	public static final field Companion Lio/github/kikin81/atproto/com/atproto/sync/GetLatestCommitRequest$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-UyB9Nic ()Ljava/lang/String;
+	public final fun copy-OoJ1cAE (Ljava/lang/String;)Lio/github/kikin81/atproto/com/atproto/sync/GetLatestCommitRequest;
+	public static synthetic fun copy-OoJ1cAE$default (Lio/github/kikin81/atproto/com/atproto/sync/GetLatestCommitRequest;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/com/atproto/sync/GetLatestCommitRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDid-UyB9Nic ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/com/atproto/sync/GetLatestCommitRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/com/atproto/sync/GetLatestCommitRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/com/atproto/sync/GetLatestCommitRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/com/atproto/sync/GetLatestCommitRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/sync/GetLatestCommitRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/sync/GetLatestCommitResponse {
+	public static final field Companion Lio/github/kikin81/atproto/com/atproto/sync/GetLatestCommitResponse$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-LVDfoeI ()Ljava/lang/String;
+	public final fun component2-nr-ICYc ()Ljava/lang/String;
+	public final fun copy-GGxkEfs (Ljava/lang/String;Ljava/lang/String;)Lio/github/kikin81/atproto/com/atproto/sync/GetLatestCommitResponse;
+	public static synthetic fun copy-GGxkEfs$default (Lio/github/kikin81/atproto/com/atproto/sync/GetLatestCommitResponse;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/com/atproto/sync/GetLatestCommitResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCid-LVDfoeI ()Ljava/lang/String;
+	public final fun getRev-nr-ICYc ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/com/atproto/sync/GetLatestCommitResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/com/atproto/sync/GetLatestCommitResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/com/atproto/sync/GetLatestCommitResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/com/atproto/sync/GetLatestCommitResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/sync/GetLatestCommitResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/sync/GetRepoRequest {
+	public static final field Companion Lio/github/kikin81/atproto/com/atproto/sync/GetRepoRequest$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-UyB9Nic ()Ljava/lang/String;
+	public final fun component2-4QWWnLo ()Ljava/lang/String;
+	public final fun copy-Fa7eQ_8 (Ljava/lang/String;Ljava/lang/String;)Lio/github/kikin81/atproto/com/atproto/sync/GetRepoRequest;
+	public static synthetic fun copy-Fa7eQ_8$default (Lio/github/kikin81/atproto/com/atproto/sync/GetRepoRequest;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/com/atproto/sync/GetRepoRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDid-UyB9Nic ()Ljava/lang/String;
+	public final fun getSince-4QWWnLo ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/com/atproto/sync/GetRepoRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/com/atproto/sync/GetRepoRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/com/atproto/sync/GetRepoRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/com/atproto/sync/GetRepoRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/sync/GetRepoRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/sync/SyncService {
+	public fun <init> (Lio/github/kikin81/atproto/runtime/XrpcClient;)V
+	public final fun getLatestCommit (Lio/github/kikin81/atproto/com/atproto/sync/GetLatestCommitRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getRepo (Lio/github/kikin81/atproto/com/atproto/sync/GetRepoRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+

--- a/oauth/api/oauth.api
+++ b/oauth/api/oauth.api
@@ -1,0 +1,156 @@
+public final class io/github/kikin81/atproto/oauth/AtOAuth {
+	public fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/oauth/OAuthSessionStore;Lio/ktor/client/HttpClient;Lkotlinx/serialization/json/Json;)V
+	public synthetic fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/oauth/OAuthSessionStore;Lio/ktor/client/HttpClient;Lkotlinx/serialization/json/Json;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun beginLogin (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun completeLogin (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun createClient (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun logout (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class io/github/kikin81/atproto/oauth/AuthServerMetadata {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/github/kikin81/atproto/oauth/AuthServerMetadata;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/oauth/AuthServerMetadata;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/oauth/AuthServerMetadata;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAuthorizationEndpoint ()Ljava/lang/String;
+	public final fun getDid ()Ljava/lang/String;
+	public final fun getHandle ()Ljava/lang/String;
+	public final fun getIssuer ()Ljava/lang/String;
+	public final fun getParEndpoint ()Ljava/lang/String;
+	public final fun getPdsUrl ()Ljava/lang/String;
+	public final fun getRevocationEndpoint ()Ljava/lang/String;
+	public final fun getTokenEndpoint ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/kikin81/atproto/oauth/DiscoveryChain {
+	public fun <init> (Lio/ktor/client/HttpClient;Lkotlinx/serialization/json/Json;)V
+	public synthetic fun <init> (Lio/ktor/client/HttpClient;Lkotlinx/serialization/json/Json;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun resolve (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class io/github/kikin81/atproto/oauth/DpopAuthProvider : io/github/kikin81/atproto/runtime/AuthProvider {
+	public fun <init> (Lio/github/kikin81/atproto/oauth/OAuthSession;Lio/github/kikin81/atproto/oauth/DpopSigner;Lio/github/kikin81/atproto/oauth/OAuthSessionStore;Lio/ktor/client/HttpClient;Lkotlinx/serialization/json/Json;)V
+	public synthetic fun <init> (Lio/github/kikin81/atproto/oauth/OAuthSession;Lio/github/kikin81/atproto/oauth/DpopSigner;Lio/github/kikin81/atproto/oauth/OAuthSessionStore;Lio/ktor/client/HttpClient;Lkotlinx/serialization/json/Json;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun authHeaders (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun onUnauthorized (Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class io/github/kikin81/atproto/oauth/DpopSigner {
+	public static final field Companion Lio/github/kikin81/atproto/oauth/DpopSigner$Companion;
+	public synthetic fun <init> (Ljava/security/KeyPair;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun calibrateClockFromHeader (Ljava/lang/String;)V
+	public final fun exportKeyPair ()Lio/github/kikin81/atproto/oauth/DpopSigner$ExportedKeyPair;
+	public final fun getClockOffsetSeconds ()J
+	public final fun getPublicKey ()Ljava/security/interfaces/ECPublicKey;
+	public final fun setClockOffsetSeconds (J)V
+	public final fun sign (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+	public static synthetic fun sign$default (Lio/github/kikin81/atproto/oauth/DpopSigner;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Ljava/lang/String;
+}
+
+public final class io/github/kikin81/atproto/oauth/DpopSigner$Companion {
+	public final fun accessTokenHash (Ljava/lang/String;)Ljava/lang/String;
+	public final fun fromExported (Lio/github/kikin81/atproto/oauth/DpopSigner$ExportedKeyPair;)Lio/github/kikin81/atproto/oauth/DpopSigner;
+	public final fun generate ()Lio/github/kikin81/atproto/oauth/DpopSigner;
+	public final fun jwkThumbprint (Ljava/security/interfaces/ECPublicKey;)Ljava/lang/String;
+}
+
+public final class io/github/kikin81/atproto/oauth/DpopSigner$ExportedKeyPair {
+	public fun <init> ([B[B)V
+	public final fun component1 ()[B
+	public final fun component2 ()[B
+	public final fun copy ([B[B)Lio/github/kikin81/atproto/oauth/DpopSigner$ExportedKeyPair;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/oauth/DpopSigner$ExportedKeyPair;[B[BILjava/lang/Object;)Lio/github/kikin81/atproto/oauth/DpopSigner$ExportedKeyPair;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPrivateKeyEncoded ()[B
+	public final fun getPublicKeyEncoded ()[B
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/kikin81/atproto/oauth/OAuthAccountMismatchException : java/lang/RuntimeException {
+	public fun <init> (Ljava/lang/String;)V
+}
+
+public final class io/github/kikin81/atproto/oauth/OAuthDiscoveryException : java/lang/RuntimeException {
+	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class io/github/kikin81/atproto/oauth/OAuthException : java/lang/RuntimeException {
+	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class io/github/kikin81/atproto/oauth/OAuthSession {
+	public static final field Companion Lio/github/kikin81/atproto/oauth/OAuthSession$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;[B[BLjava/lang/String;JLjava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;[B[BLjava/lang/String;JLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()[B
+	public final fun component11 ()Ljava/lang/String;
+	public final fun component12 ()J
+	public final fun component13 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()[B
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;[B[BLjava/lang/String;JLjava/lang/String;)Lio/github/kikin81/atproto/oauth/OAuthSession;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/oauth/OAuthSession;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;[B[BLjava/lang/String;JLjava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/oauth/OAuthSession;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAccessToken ()Ljava/lang/String;
+	public final fun getAuthServerNonce ()Ljava/lang/String;
+	public final fun getClientId ()Ljava/lang/String;
+	public final fun getClockOffsetSeconds ()J
+	public final fun getDid ()Ljava/lang/String;
+	public final fun getDpopPrivateKey ()[B
+	public final fun getDpopPublicKey ()[B
+	public final fun getHandle ()Ljava/lang/String;
+	public final fun getPdsNonce ()Ljava/lang/String;
+	public final fun getPdsUrl ()Ljava/lang/String;
+	public final fun getRefreshToken ()Ljava/lang/String;
+	public final fun getRevocationEndpoint ()Ljava/lang/String;
+	public final fun getTokenEndpoint ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/oauth/OAuthSession$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/oauth/OAuthSession$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/oauth/OAuthSession;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/oauth/OAuthSession;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/oauth/OAuthSession$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/oauth/OAuthSessionExpiredException : java/lang/RuntimeException {
+	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public abstract interface class io/github/kikin81/atproto/oauth/OAuthSessionStore {
+	public abstract fun clear (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun load (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun save (Lio/github/kikin81/atproto/oauth/OAuthSession;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+

--- a/runtime/api/runtime.api
+++ b/runtime/api/runtime.api
@@ -1,0 +1,577 @@
+public abstract interface class io/github/kikin81/atproto/runtime/AtField {
+}
+
+public final class io/github/kikin81/atproto/runtime/AtField$Defined : io/github/kikin81/atproto/runtime/AtField {
+	public fun <init> (Ljava/lang/Object;)V
+	public final fun component1 ()Ljava/lang/Object;
+	public final fun copy (Ljava/lang/Object;)Lio/github/kikin81/atproto/runtime/AtField$Defined;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/runtime/AtField$Defined;Ljava/lang/Object;ILjava/lang/Object;)Lio/github/kikin81/atproto/runtime/AtField$Defined;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()Ljava/lang/Object;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/kikin81/atproto/runtime/AtField$Missing : io/github/kikin81/atproto/runtime/AtField {
+	public static final field INSTANCE Lio/github/kikin81/atproto/runtime/AtField$Missing;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/kikin81/atproto/runtime/AtField$Null : io/github/kikin81/atproto/runtime/AtField {
+	public static final field INSTANCE Lio/github/kikin81/atproto/runtime/AtField$Null;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/kikin81/atproto/runtime/AtFieldKt {
+	public static final fun present (Ljava/lang/Object;)Lio/github/kikin81/atproto/runtime/AtField$Defined;
+	public static final fun presentOrNull (Ljava/lang/Object;)Lio/github/kikin81/atproto/runtime/AtField;
+}
+
+public final class io/github/kikin81/atproto/runtime/AtFieldSerializer : kotlinx/serialization/KSerializer {
+	public fun <init> (Lkotlinx/serialization/KSerializer;)V
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/runtime/AtField;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/runtime/AtField;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+}
+
+public final class io/github/kikin81/atproto/runtime/AtIdentifier {
+	public static final field Companion Lio/github/kikin81/atproto/runtime/AtIdentifier$Companion;
+	public static final synthetic fun box-impl (Ljava/lang/String;)Lio/github/kikin81/atproto/runtime/AtIdentifier;
+	public static fun constructor-impl (Ljava/lang/String;)Ljava/lang/String;
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (Ljava/lang/String;Ljava/lang/Object;)Z
+	public static final fun equals-impl0 (Ljava/lang/String;Ljava/lang/String;)Z
+	public final fun getRaw ()Ljava/lang/String;
+	public fun hashCode ()I
+	public static fun hashCode-impl (Ljava/lang/String;)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (Ljava/lang/String;)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/runtime/AtIdentifier$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/runtime/AtIdentifier$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize-akx1mwY (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/String;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize-P2IvXTY (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/String;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/runtime/AtIdentifier$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/runtime/AtUri {
+	public static final field Companion Lio/github/kikin81/atproto/runtime/AtUri$Companion;
+	public static final synthetic fun box-impl (Ljava/lang/String;)Lio/github/kikin81/atproto/runtime/AtUri;
+	public static fun constructor-impl (Ljava/lang/String;)Ljava/lang/String;
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (Ljava/lang/String;Ljava/lang/Object;)Z
+	public static final fun equals-impl0 (Ljava/lang/String;Ljava/lang/String;)Z
+	public final fun getRaw ()Ljava/lang/String;
+	public fun hashCode ()I
+	public static fun hashCode-impl (Ljava/lang/String;)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (Ljava/lang/String;)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/runtime/AtUri$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/runtime/AtUri$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize-TYmbt6o (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/String;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize-HnpCerU (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/String;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/runtime/AtUri$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/runtime/AtUriParserKt {
+	public static final fun parse-wvBT1Tk (Ljava/lang/String;)Lio/github/kikin81/atproto/runtime/AtUriParts;
+	public static final fun parseOrNull-wvBT1Tk (Ljava/lang/String;)Lio/github/kikin81/atproto/runtime/AtUriParts;
+}
+
+public final class io/github/kikin81/atproto/runtime/AtUriParts {
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-mlEIfv0 ()Ljava/lang/String;
+	public final fun component2-PFGiv5M ()Ljava/lang/String;
+	public final fun component3-uZW8774 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy-M_gNkD4 (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/github/kikin81/atproto/runtime/AtUriParts;
+	public static synthetic fun copy-M_gNkD4$default (Lio/github/kikin81/atproto/runtime/AtUriParts;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/runtime/AtUriParts;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCollection-PFGiv5M ()Ljava/lang/String;
+	public final fun getFragment ()Ljava/lang/String;
+	public final fun getRepo-mlEIfv0 ()Ljava/lang/String;
+	public final fun getRkey-uZW8774 ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class io/github/kikin81/atproto/runtime/AuthProvider {
+	public abstract fun authHeaders (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun onUnauthorized (Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class io/github/kikin81/atproto/runtime/AuthProvider$DefaultImpls {
+	public static fun onUnauthorized (Lio/github/kikin81/atproto/runtime/AuthProvider;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class io/github/kikin81/atproto/runtime/BearerTokenAuth : io/github/kikin81/atproto/runtime/AuthProvider {
+	public fun <init> (Ljava/lang/String;)V
+	public fun authHeaders (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun onUnauthorized (Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class io/github/kikin81/atproto/runtime/Blob {
+	public static final field Companion Lio/github/kikin81/atproto/runtime/Blob$Companion;
+	public fun <init> (Lio/github/kikin81/atproto/runtime/CidLink;Ljava/lang/String;JLjava/lang/String;)V
+	public synthetic fun <init> (Lio/github/kikin81/atproto/runtime/CidLink;Ljava/lang/String;JLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/runtime/CidLink;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()J
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Lio/github/kikin81/atproto/runtime/CidLink;Ljava/lang/String;JLjava/lang/String;)Lio/github/kikin81/atproto/runtime/Blob;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/runtime/Blob;Lio/github/kikin81/atproto/runtime/CidLink;Ljava/lang/String;JLjava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/runtime/Blob;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMimeType ()Ljava/lang/String;
+	public final fun getRef ()Lio/github/kikin81/atproto/runtime/CidLink;
+	public final fun getSize ()J
+	public final fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/runtime/Blob$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/runtime/Blob$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/runtime/Blob;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/runtime/Blob;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/runtime/Blob$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/runtime/Cid {
+	public static final field Companion Lio/github/kikin81/atproto/runtime/Cid$Companion;
+	public static final synthetic fun box-impl (Ljava/lang/String;)Lio/github/kikin81/atproto/runtime/Cid;
+	public static fun constructor-impl (Ljava/lang/String;)Ljava/lang/String;
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (Ljava/lang/String;Ljava/lang/Object;)Z
+	public static final fun equals-impl0 (Ljava/lang/String;Ljava/lang/String;)Z
+	public final fun getRaw ()Ljava/lang/String;
+	public fun hashCode ()I
+	public static fun hashCode-impl (Ljava/lang/String;)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (Ljava/lang/String;)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/runtime/Cid$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/runtime/Cid$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize-zli7rA8 (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/String;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize-euwbAWw (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/String;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/runtime/Cid$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/runtime/CidLink {
+	public static final field Companion Lio/github/kikin81/atproto/runtime/CidLink$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/github/kikin81/atproto/runtime/CidLink;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/runtime/CidLink;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/runtime/CidLink;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getLink ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/runtime/CidLink$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/runtime/CidLink$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/runtime/CidLink;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/runtime/CidLink;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/runtime/CidLink$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/runtime/Datetime {
+	public static final field Companion Lio/github/kikin81/atproto/runtime/Datetime$Companion;
+	public static final synthetic fun box-impl (Ljava/lang/String;)Lio/github/kikin81/atproto/runtime/Datetime;
+	public static fun constructor-impl (Ljava/lang/String;)Ljava/lang/String;
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (Ljava/lang/String;Ljava/lang/Object;)Z
+	public static final fun equals-impl0 (Ljava/lang/String;Ljava/lang/String;)Z
+	public final fun getRaw ()Ljava/lang/String;
+	public fun hashCode ()I
+	public static fun hashCode-impl (Ljava/lang/String;)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (Ljava/lang/String;)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/runtime/Datetime$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/runtime/Datetime$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize-l-1esXM (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/String;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize-La2l2MI (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/String;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/runtime/Datetime$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/runtime/Did {
+	public static final field Companion Lio/github/kikin81/atproto/runtime/Did$Companion;
+	public static final synthetic fun box-impl (Ljava/lang/String;)Lio/github/kikin81/atproto/runtime/Did;
+	public static fun constructor-impl (Ljava/lang/String;)Ljava/lang/String;
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (Ljava/lang/String;Ljava/lang/Object;)Z
+	public static final fun equals-impl0 (Ljava/lang/String;Ljava/lang/String;)Z
+	public final fun getRaw ()Ljava/lang/String;
+	public fun hashCode ()I
+	public static fun hashCode-impl (Ljava/lang/String;)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (Ljava/lang/String;)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/runtime/Did$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/runtime/Did$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize-dunOXcM (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/String;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize-aB4ouW8 (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/String;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/runtime/Did$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/runtime/Handle {
+	public static final field Companion Lio/github/kikin81/atproto/runtime/Handle$Companion;
+	public static final synthetic fun box-impl (Ljava/lang/String;)Lio/github/kikin81/atproto/runtime/Handle;
+	public static fun constructor-impl (Ljava/lang/String;)Ljava/lang/String;
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (Ljava/lang/String;Ljava/lang/Object;)Z
+	public static final fun equals-impl0 (Ljava/lang/String;Ljava/lang/String;)Z
+	public final fun getRaw ()Ljava/lang/String;
+	public fun hashCode ()I
+	public static fun hashCode-impl (Ljava/lang/String;)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (Ljava/lang/String;)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/runtime/Handle$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/runtime/Handle$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize-ll2GKBY (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/String;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize-Z4ShT5Q (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/String;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/runtime/Handle$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/runtime/Language {
+	public static final field Companion Lio/github/kikin81/atproto/runtime/Language$Companion;
+	public static final synthetic fun box-impl (Ljava/lang/String;)Lio/github/kikin81/atproto/runtime/Language;
+	public static fun constructor-impl (Ljava/lang/String;)Ljava/lang/String;
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (Ljava/lang/String;Ljava/lang/Object;)Z
+	public static final fun equals-impl0 (Ljava/lang/String;Ljava/lang/String;)Z
+	public final fun getRaw ()Ljava/lang/String;
+	public fun hashCode ()I
+	public static fun hashCode-impl (Ljava/lang/String;)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (Ljava/lang/String;)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/runtime/Language$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/runtime/Language$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize-CGXi8W8 (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/String;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize-2jZb1e0 (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/String;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/runtime/Language$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/runtime/NoAuth : io/github/kikin81/atproto/runtime/AuthProvider {
+	public static final field INSTANCE Lio/github/kikin81/atproto/runtime/NoAuth;
+	public fun authHeaders (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun onUnauthorized (Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class io/github/kikin81/atproto/runtime/NoXrpcParams {
+	public static final field INSTANCE Lio/github/kikin81/atproto/runtime/NoXrpcParams;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/kikin81/atproto/runtime/NoXrpcParamsKt {
+	public static final fun getUnitResponseSerializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/runtime/Nsid {
+	public static final field Companion Lio/github/kikin81/atproto/runtime/Nsid$Companion;
+	public static final synthetic fun box-impl (Ljava/lang/String;)Lio/github/kikin81/atproto/runtime/Nsid;
+	public static fun constructor-impl (Ljava/lang/String;)Ljava/lang/String;
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (Ljava/lang/String;Ljava/lang/Object;)Z
+	public static final fun equals-impl0 (Ljava/lang/String;Ljava/lang/String;)Z
+	public final fun getRaw ()Ljava/lang/String;
+	public fun hashCode ()I
+	public static fun hashCode-impl (Ljava/lang/String;)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (Ljava/lang/String;)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/runtime/Nsid$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/runtime/Nsid$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize-YrO0HWc (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/String;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize-09joPAc (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/String;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/runtime/Nsid$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/runtime/OpenUnionKt {
+	public static final field DOLLAR_TYPE Ljava/lang/String;
+	public static final fun normalizeDollarType (Ljava/lang/String;)Ljava/lang/String;
+}
+
+public abstract interface class io/github/kikin81/atproto/runtime/OpenUnionMember {
+}
+
+public abstract class io/github/kikin81/atproto/runtime/OpenUnionSerializer : kotlinx/serialization/KSerializer {
+	public fun <init> (Lkotlin/reflect/KClass;)V
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/runtime/OpenUnionMember;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	protected abstract fun selectKnownDeserializer (Ljava/lang/String;)Lkotlinx/serialization/KSerializer;
+	protected abstract fun selectKnownSerializer (Lio/github/kikin81/atproto/runtime/OpenUnionMember;)Lkotlinx/serialization/KSerializer;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/runtime/OpenUnionMember;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	protected abstract fun unknownSerializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/runtime/PaginationKt {
+	public static final fun paginate (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun paginatePages (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lkotlinx/coroutines/flow/Flow;
+}
+
+public final class io/github/kikin81/atproto/runtime/RecordDecoderKt {
+	public static final fun decodeRecord (Lkotlinx/serialization/json/JsonObject;Lkotlinx/serialization/KSerializer;Lkotlinx/serialization/json/Json;)Ljava/lang/Object;
+	public static synthetic fun decodeRecord$default (Lkotlinx/serialization/json/JsonObject;Lkotlinx/serialization/KSerializer;Lkotlinx/serialization/json/Json;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun encodeRecord (Lkotlinx/serialization/KSerializer;Ljava/lang/Object;Ljava/lang/String;Lkotlinx/serialization/json/Json;)Lkotlinx/serialization/json/JsonObject;
+	public static synthetic fun encodeRecord$default (Lkotlinx/serialization/KSerializer;Ljava/lang/Object;Ljava/lang/String;Lkotlinx/serialization/json/Json;ILjava/lang/Object;)Lkotlinx/serialization/json/JsonObject;
+	public static final fun getRecordDecoderJson ()Lkotlinx/serialization/json/Json;
+	public static final fun getRecordEncoderJson ()Lkotlinx/serialization/json/Json;
+}
+
+public final class io/github/kikin81/atproto/runtime/RecordKey {
+	public static final field Companion Lio/github/kikin81/atproto/runtime/RecordKey$Companion;
+	public static final synthetic fun box-impl (Ljava/lang/String;)Lio/github/kikin81/atproto/runtime/RecordKey;
+	public static fun constructor-impl (Ljava/lang/String;)Ljava/lang/String;
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (Ljava/lang/String;Ljava/lang/Object;)Z
+	public static final fun equals-impl0 (Ljava/lang/String;Ljava/lang/String;)Z
+	public final fun getRaw ()Ljava/lang/String;
+	public fun hashCode ()I
+	public static fun hashCode-impl (Ljava/lang/String;)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (Ljava/lang/String;)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/runtime/RecordKey$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/runtime/RecordKey$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize-PYAUS88 (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/String;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize-YocjW-w (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/String;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/runtime/RecordKey$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/runtime/Tid {
+	public static final field Companion Lio/github/kikin81/atproto/runtime/Tid$Companion;
+	public static final synthetic fun box-impl (Ljava/lang/String;)Lio/github/kikin81/atproto/runtime/Tid;
+	public static fun constructor-impl (Ljava/lang/String;)Ljava/lang/String;
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (Ljava/lang/String;Ljava/lang/Object;)Z
+	public static final fun equals-impl0 (Ljava/lang/String;Ljava/lang/String;)Z
+	public final fun getRaw ()Ljava/lang/String;
+	public fun hashCode ()I
+	public static fun hashCode-impl (Ljava/lang/String;)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (Ljava/lang/String;)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/runtime/Tid$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/runtime/Tid$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize-VOLn5TQ (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/String;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize-Yp3DCYM (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/String;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/runtime/Tid$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract class io/github/kikin81/atproto/runtime/UnknownMemberSerializer : kotlinx/serialization/KSerializer {
+	public fun <init> (Ljava/lang/String;)V
+	protected abstract fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/runtime/UnknownOpenUnionMember;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/runtime/UnknownOpenUnionMember;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/runtime/UnknownOpenUnionMember;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+}
+
+public abstract interface class io/github/kikin81/atproto/runtime/UnknownOpenUnionMember : io/github/kikin81/atproto/runtime/OpenUnionMember {
+	public abstract fun getRaw ()Lkotlinx/serialization/json/JsonObject;
+	public abstract fun getType ()Ljava/lang/String;
+}
+
+public final class io/github/kikin81/atproto/runtime/Uri {
+	public static final field Companion Lio/github/kikin81/atproto/runtime/Uri$Companion;
+	public static final synthetic fun box-impl (Ljava/lang/String;)Lio/github/kikin81/atproto/runtime/Uri;
+	public static fun constructor-impl (Ljava/lang/String;)Ljava/lang/String;
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (Ljava/lang/String;Ljava/lang/Object;)Z
+	public static final fun equals-impl0 (Ljava/lang/String;Ljava/lang/String;)Z
+	public final fun getRaw ()Ljava/lang/String;
+	public fun hashCode ()I
+	public static fun hashCode-impl (Ljava/lang/String;)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (Ljava/lang/String;)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/runtime/Uri$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/runtime/Uri$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize-_yloLgI (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/String;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize-eM3CBdQ (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/String;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/runtime/Uri$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/runtime/XrpcClient {
+	public static final field Companion Lio/github/kikin81/atproto/runtime/XrpcClient$Companion;
+	public fun <init> (Ljava/lang/String;Lio/ktor/client/HttpClient;Lkotlinx/serialization/json/Json;Lio/github/kikin81/atproto/runtime/AuthProvider;)V
+	public synthetic fun <init> (Ljava/lang/String;Lio/ktor/client/HttpClient;Lkotlinx/serialization/json/Json;Lio/github/kikin81/atproto/runtime/AuthProvider;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getAuthProvider ()Lio/github/kikin81/atproto/runtime/AuthProvider;
+	public final fun getHttpClient ()Lio/ktor/client/HttpClient;
+	public final fun getJson ()Lkotlinx/serialization/json/Json;
+	public final fun procedure (Ljava/lang/String;Ljava/lang/Object;Lkotlinx/serialization/KSerializer;Ljava/lang/Object;Lkotlinx/serialization/KSerializer;Lkotlinx/serialization/KSerializer;Ljava/lang/String;Lio/github/kikin81/atproto/runtime/XrpcErrorMapper;Lio/github/kikin81/atproto/runtime/AuthProvider;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun procedure (Ljava/lang/String;Ljava/lang/Object;Lkotlinx/serialization/KSerializer;Lkotlinx/serialization/KSerializer;Lio/github/kikin81/atproto/runtime/XrpcErrorMapper;Lio/github/kikin81/atproto/runtime/AuthProvider;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun procedure (Ljava/lang/String;Ljava/lang/Object;Lkotlinx/serialization/KSerializer;[BLio/ktor/http/ContentType;Lkotlinx/serialization/KSerializer;Lio/github/kikin81/atproto/runtime/XrpcErrorMapper;Lio/github/kikin81/atproto/runtime/AuthProvider;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun procedure$default (Lio/github/kikin81/atproto/runtime/XrpcClient;Ljava/lang/String;Ljava/lang/Object;Lkotlinx/serialization/KSerializer;Ljava/lang/Object;Lkotlinx/serialization/KSerializer;Lkotlinx/serialization/KSerializer;Ljava/lang/String;Lio/github/kikin81/atproto/runtime/XrpcErrorMapper;Lio/github/kikin81/atproto/runtime/AuthProvider;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun procedure$default (Lio/github/kikin81/atproto/runtime/XrpcClient;Ljava/lang/String;Ljava/lang/Object;Lkotlinx/serialization/KSerializer;Lkotlinx/serialization/KSerializer;Lio/github/kikin81/atproto/runtime/XrpcErrorMapper;Lio/github/kikin81/atproto/runtime/AuthProvider;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun procedure$default (Lio/github/kikin81/atproto/runtime/XrpcClient;Ljava/lang/String;Ljava/lang/Object;Lkotlinx/serialization/KSerializer;[BLio/ktor/http/ContentType;Lkotlinx/serialization/KSerializer;Lio/github/kikin81/atproto/runtime/XrpcErrorMapper;Lio/github/kikin81/atproto/runtime/AuthProvider;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun query (Ljava/lang/String;Ljava/lang/Object;Lkotlinx/serialization/KSerializer;Lkotlinx/serialization/KSerializer;Lio/github/kikin81/atproto/runtime/XrpcErrorMapper;Lio/github/kikin81/atproto/runtime/AuthProvider;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun query$default (Lio/github/kikin81/atproto/runtime/XrpcClient;Ljava/lang/String;Ljava/lang/Object;Lkotlinx/serialization/KSerializer;Lkotlinx/serialization/KSerializer;Lio/github/kikin81/atproto/runtime/XrpcErrorMapper;Lio/github/kikin81/atproto/runtime/AuthProvider;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class io/github/kikin81/atproto/runtime/XrpcClient$Companion {
+	public final fun getDefaultJson ()Lkotlinx/serialization/json/Json;
+}
+
+public class io/github/kikin81/atproto/runtime/XrpcError : java/lang/RuntimeException {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;I)V
+	public final fun getErrorMessage ()Ljava/lang/String;
+	public final fun getErrorName ()Ljava/lang/String;
+	public final fun getStatus ()I
+}
+
+public final class io/github/kikin81/atproto/runtime/XrpcError$Unknown : io/github/kikin81/atproto/runtime/XrpcError {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;I)V
+}
+
+public final class io/github/kikin81/atproto/runtime/XrpcErrorKt {
+	public static final fun getDefaultXrpcErrorMapper ()Lio/github/kikin81/atproto/runtime/XrpcErrorMapper;
+}
+
+public abstract interface class io/github/kikin81/atproto/runtime/XrpcErrorMapper {
+	public abstract fun map (Ljava/lang/String;Ljava/lang/String;I)Lio/github/kikin81/atproto/runtime/XrpcError;
+}
+


### PR DESCRIPTION
## Summary

Track every public symbol in `:runtime`, `:models`, and `:oauth` via the [kotlinx-binary-compatibility-validator](https://github.com/Kotlin/binary-compatibility-validator) plugin. Each module gets an `api/<module>.api` text dump under version control. CI runs `./gradlew apiCheck` and fails on any unexpected diff.

This is the highest-leverage of the three test-safeguard issues filed yesterday — directly addresses the silent-regression worry that prompted the discussion: a Renovate-pushed Ktor dep change leaking a new type into a public signature would now fail CI instead of shipping unnoticed in a patch release. Intentional public API changes require an accompanying `./gradlew apiDump` commit, which becomes a clear review signal — reviewers see exactly what entered or left the public surface without spelunking through source.

## Configuration choices

- **Plugin applied at root `build.gradle.kts`** — auto-discovers Kotlin JVM and KMP modules.
- **`:generator` and `:samples:android` excluded** — neither is consumed externally, internal surface only.
- **`klib { enabled = false }`** — skips iOS klib validation. iOS targets are conditionally declared only on macOS hosts (per `runtime/build.gradle.kts`); Linux CI publishes JVM-only. When iOS publishing lands (separate work), flip this flag.
- **`:compose` and `:compose-material3` not in this PR** — Android library modules aren't auto-discovered by the validator. Tracked separately as `kikinlex-6ai` (filed in this PR's `.beads` diff) so the baseline stays narrow.
- **Pre-commit's `check-added-large-files` excludes `<module>/api/*.api`** — `models.api` is ~900 KB because it tracks the entire generated lexicon API surface. Size scales with API breadth, not bloat.

## Affected module

- [x] Docs / build / CI

## How it was verified

- [x] `./gradlew apiDump` produces clean baselines: `runtime.api` (553 lines), `oauth.api` (156 lines), `models.api` (~11 KB lines for the full generated surface).
- [x] `./gradlew apiCheck` round-trips green against the freshly committed baselines.
- [x] `./gradlew spotlessCheck` passes (`api/*.api` aren't under `src/` so Spotless doesn't touch them).
- [x] All pre-commit hooks pass (`actionlint`, json/yaml/toml, large-file with the new exclude, end-of-file fixer, ktlint).
- [x] Spot-checked one `api/runtime.api` line: `public abstract interface class io/github/kikin81/atproto/runtime/AtField` — captures the open-union shape correctly.

## Breaking changes

None. Pure additive infrastructure.

## Checklist

- [x] N/A, ci/docs only

Closes: kikinlex-bm1

🤖 Generated with [Claude Code](https://claude.com/claude-code)