### PR TITLE
feat(oauth)!: expose scope on AtOAuth to unblock transition:chat.bsky

### DIFF
--- a/docs/breaking-changes/v6.md
+++ b/docs/breaking-changes/v6.md
@@ -3,12 +3,14 @@
 ## Summary
 
 Adds AT Protocol service-routing support (the `atproto-proxy` HTTP
-header), which fixes `chat.bsky.convo.*` calls returning 403
-ScopeMissingError when routed to the chat appview. **Kotlin source
-code does not need changes** — every new parameter is optional and
-defaults to the right value. **Recompilation against 6.0.0 is
+header) and exposes the OAuth scope on `AtOAuth`, which together
+unblock `chat.bsky.convo.*` calls that previously returned 403
+ScopeMissingError. **Kotlin source code does not need changes for
+existing callers** — every new parameter is optional and defaults
+to the previous behavior. **Recompilation against 6.0.0 is
 required** because the JVM signatures of `XrpcClient.query` /
-`procedure` and the generated `ConvoService` constructor changed.
+`procedure`, the generated `ConvoService` constructor, and the
+`AtOAuth` constructor all changed.
 
 ## What changed
 
@@ -39,6 +41,24 @@ constructor parameter that holds the proxy DID:
 Generated services for non-proxied namespaces (`FeedService`,
 `ActorService`, etc.) are emitted byte-identical to v5 — their
 constructors and method signatures are unchanged.
+
+### OAuth — `AtOAuth`
+
+A new optional parameter `scope: String = "atproto transition:generic"`
+was appended to the `AtOAuth` constructor. The value is sent verbatim
+as the `scope` form parameter in the PAR request. In v5.x the scope
+was hardcoded at the call site, so consumers could not request
+umbrella scopes like `transition:chat.bsky` (chat AppView),
+`transition:email`, or any future per-service `transition:*` scope
+even if they were declared in the hosted `client-metadata.json`.
+
+| Class | Before | After |
+|---|---|---|
+| `AtOAuth` | `AtOAuth(clientMetadataUrl, sessionStore, httpClient, json)` | `AtOAuth(clientMetadataUrl, sessionStore, httpClient, json, scope = "atproto transition:generic")` |
+
+The requested `scope` must remain a subset of the `scope` advertised
+by the hosted client metadata document; the authorization server
+rejects requests for scopes not registered in metadata.
 
 ### Behavioral change (bug fix)
 
@@ -107,13 +127,33 @@ val convo = ConvoService(client, proxy = "did:web:custom.sandbox.example#bsky_ch
 val convo = ConvoService(client, proxy = null)
 ```
 
+### 5. Optional: request additional OAuth scopes
+
+The default `scope = "atproto transition:generic"` matches v5
+behavior. To request umbrella scopes, pass them via the new
+constructor argument and make sure the same scopes appear in your
+hosted `client-metadata.json`:
+
+```kotlin
+val oauth = AtOAuth(
+    clientMetadataUrl = "https://app.example.com/oauth/client-metadata.json",
+    sessionStore = mySessionStore,
+    httpClient = myKtorClient,
+    scope = "atproto transition:generic transition:chat.bsky",
+)
+```
+
+The consent screen will then show the additional scopes, and the
+minted access token will authorize the corresponding RPCs (e.g.
+`chat.bsky.convo.*` against `did:web:api.bsky.chat`).
+
 ## Why this isn't a no-op minor
 
 The new parameters all have defaults, so source-level Kotlin is
 unchanged. But the compiled JVM method descriptors for
-`XrpcClient.query` / `procedure` and the `ConvoService` constructor
-gained a `Ljava/lang/String;` slot. Pre-built bytecode against v5
-will fail with `NoSuchMethodError` at link time against the v6
-artifacts. Per JVM ABI conventions and the project's existing
-breaking-changes discipline (see `v5.md`), this warrants a major
-bump.
+`XrpcClient.query` / `procedure`, the `ConvoService` constructor,
+and the `AtOAuth` constructor all gained a `Ljava/lang/String;`
+slot. Pre-built bytecode against v5 will fail with
+`NoSuchMethodError` at link time against the v6 artifacts. Per JVM
+ABI conventions and the project's existing breaking-changes
+discipline (see `v5.md`), this warrants a major bump.

--- a/oauth/api/oauth.api
+++ b/oauth/api/oauth.api
@@ -1,6 +1,6 @@
 public final class io/github/kikin81/atproto/oauth/AtOAuth {
-	public fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/oauth/OAuthSessionStore;Lio/ktor/client/HttpClient;Lkotlinx/serialization/json/Json;)V
-	public synthetic fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/oauth/OAuthSessionStore;Lio/ktor/client/HttpClient;Lkotlinx/serialization/json/Json;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/oauth/OAuthSessionStore;Lio/ktor/client/HttpClient;Lkotlinx/serialization/json/Json;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/oauth/OAuthSessionStore;Lio/ktor/client/HttpClient;Lkotlinx/serialization/json/Json;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun beginLogin (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun completeLogin (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun createClient (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/oauth/src/main/kotlin/io/github/kikin81/atproto/oauth/AtOAuth.kt
+++ b/oauth/src/main/kotlin/io/github/kikin81/atproto/oauth/AtOAuth.kt
@@ -37,12 +37,32 @@ import kotlin.io.encoding.ExperimentalEncodingApi
  * val client = oauth.createClient()
  * FeedService(client).getTimeline()
  * ```
+ *
+ * ## Requesting additional scopes
+ *
+ * To request umbrella scopes beyond the default `atproto transition:generic`
+ * (e.g. `transition:chat.bsky` for Bluesky chat, `transition:email` for
+ * email), pass them via [scope]. The value must be a subset of the `scope`
+ * field declared in the hosted `client-metadata.json` document.
+ *
+ * ```kotlin
+ * val oauth = AtOAuth(
+ *     clientMetadataUrl = "...",
+ *     sessionStore = ...,
+ *     httpClient = ...,
+ *     scope = "atproto transition:generic transition:chat.bsky",
+ * )
+ * ```
+ *
+ * @param scope Space-delimited OAuth scope string sent in the PAR. Must be a
+ *   subset of the `scope` advertised by the hosted client metadata document.
  */
 class AtOAuth(
     private val clientMetadataUrl: String,
     private val sessionStore: OAuthSessionStore,
     private val httpClient: HttpClient,
     private val json: Json = Json { ignoreUnknownKeys = true },
+    private val scope: String = "atproto transition:generic",
 ) {
     // Transient state during the login flow (between beginLogin and completeLogin)
     private var pendingState: PendingAuthState? = null
@@ -291,7 +311,7 @@ class AtOAuth(
         append("client_id", clientMetadataUrl)
         append("response_type", "code")
         append("redirect_uri", redirectUri)
-        append("scope", "atproto transition:generic")
+        append("scope", scope)
         append("state", state)
         append("code_challenge", codeChallenge)
         append("code_challenge_method", "S256")

--- a/oauth/src/main/kotlin/io/github/kikin81/atproto/oauth/AtOAuth.kt
+++ b/oauth/src/main/kotlin/io/github/kikin81/atproto/oauth/AtOAuth.kt
@@ -54,8 +54,8 @@ import kotlin.io.encoding.ExperimentalEncodingApi
  * )
  * ```
  *
- * @param scope Space-delimited OAuth scope string sent in the PAR. Must be a
- *   subset of the `scope` advertised by the hosted client metadata document.
+ * The value must be a subset of the `scope` field declared in the hosted
+ * client metadata document.
  */
 class AtOAuth(
     private val clientMetadataUrl: String,

--- a/oauth/src/test/kotlin/io/github/kikin81/atproto/oauth/AtOAuthTest.kt
+++ b/oauth/src/test/kotlin/io/github/kikin81/atproto/oauth/AtOAuthTest.kt
@@ -2,7 +2,9 @@ package io.github.kikin81.atproto.oauth
 
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.MockRequestHandleScope
 import io.ktor.client.engine.mock.respond
+import io.ktor.client.request.HttpResponseData
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
@@ -30,38 +32,47 @@ class AtOAuthTest {
         }
     }
 
+    /**
+     * Returns the canned discovery response for the `did:plc:testuser` / alice.test
+     * fixture if [url] matches one of the AT Protocol discovery URLs, else null.
+     * Shared by mock builders so the discovery flow stays in one place.
+     */
+    private fun MockRequestHandleScope.respondToDiscovery(url: String): HttpResponseData? = when {
+        url.contains("/.well-known/atproto-did") ->
+            respond(ByteReadChannel("did:plc:testuser"), HttpStatusCode.OK)
+
+        url.contains("plc.directory/did:plc:testuser") ->
+            respond(
+                ByteReadChannel(
+                    """{"id":"did:plc:testuser","alsoKnownAs":["at://alice.test"],"service":[{"id":"#atproto_pds","type":"AtprotoPersonalDataServer","serviceEndpoint":"https://pds.test"}]}""",
+                ),
+                HttpStatusCode.OK,
+                jsonHeaders,
+            )
+
+        url.contains("/.well-known/oauth-protected-resource") ->
+            respond(
+                ByteReadChannel("""{"authorization_servers":["https://auth.test"]}"""),
+                HttpStatusCode.OK,
+                jsonHeaders,
+            )
+
+        url.contains("/.well-known/oauth-authorization-server") ->
+            respond(
+                ByteReadChannel(
+                    """{"issuer":"https://auth.test","authorization_endpoint":"https://auth.test/authorize","token_endpoint":"https://auth.test/token","pushed_authorization_request_endpoint":"https://auth.test/par"}""",
+                ),
+                HttpStatusCode.OK,
+                jsonHeaders,
+            )
+
+        else -> null
+    }
+
     private fun fullFlowMockClient(): HttpClient = HttpClient(
         MockEngine { request ->
             val url = request.url.toString()
-            when {
-                url.contains("/.well-known/atproto-did") ->
-                    respond(ByteReadChannel("did:plc:testuser"), HttpStatusCode.OK)
-
-                url.contains("plc.directory/did:plc:testuser") ->
-                    respond(
-                        ByteReadChannel(
-                            """{"id":"did:plc:testuser","alsoKnownAs":["at://alice.test"],"service":[{"id":"#atproto_pds","type":"AtprotoPersonalDataServer","serviceEndpoint":"https://pds.test"}]}""",
-                        ),
-                        HttpStatusCode.OK,
-                        jsonHeaders,
-                    )
-
-                url.contains("/.well-known/oauth-protected-resource") ->
-                    respond(
-                        ByteReadChannel("""{"authorization_servers":["https://auth.test"]}"""),
-                        HttpStatusCode.OK,
-                        jsonHeaders,
-                    )
-
-                url.contains("/.well-known/oauth-authorization-server") ->
-                    respond(
-                        ByteReadChannel(
-                            """{"issuer":"https://auth.test","authorization_endpoint":"https://auth.test/authorize","token_endpoint":"https://auth.test/token","pushed_authorization_request_endpoint":"https://auth.test/par"}""",
-                        ),
-                        HttpStatusCode.OK,
-                        jsonHeaders,
-                    )
-
+            respondToDiscovery(url) ?: when {
                 // PAR: first call returns use_dpop_nonce, second succeeds
                 url.contains("/par") -> {
                     val hasDpopHeader = request.headers["DPoP"] != null
@@ -100,35 +111,7 @@ class AtOAuthTest {
     private fun parCapturingClient(capture: (String) -> Unit): HttpClient = HttpClient(
         MockEngine { request ->
             val url = request.url.toString()
-            when {
-                url.contains("/.well-known/atproto-did") ->
-                    respond(ByteReadChannel("did:plc:testuser"), HttpStatusCode.OK)
-
-                url.contains("plc.directory/did:plc:testuser") ->
-                    respond(
-                        ByteReadChannel(
-                            """{"id":"did:plc:testuser","alsoKnownAs":["at://alice.test"],"service":[{"id":"#atproto_pds","type":"AtprotoPersonalDataServer","serviceEndpoint":"https://pds.test"}]}""",
-                        ),
-                        HttpStatusCode.OK,
-                        jsonHeaders,
-                    )
-
-                url.contains("/.well-known/oauth-protected-resource") ->
-                    respond(
-                        ByteReadChannel("""{"authorization_servers":["https://auth.test"]}"""),
-                        HttpStatusCode.OK,
-                        jsonHeaders,
-                    )
-
-                url.contains("/.well-known/oauth-authorization-server") ->
-                    respond(
-                        ByteReadChannel(
-                            """{"issuer":"https://auth.test","authorization_endpoint":"https://auth.test/authorize","token_endpoint":"https://auth.test/token","pushed_authorization_request_endpoint":"https://auth.test/par"}""",
-                        ),
-                        HttpStatusCode.OK,
-                        jsonHeaders,
-                    )
-
+            respondToDiscovery(url) ?: when {
                 url.contains("/par") -> {
                     val body = (request.body as io.ktor.http.content.OutgoingContent.ByteArrayContent).bytes().decodeToString()
                     capture(body)

--- a/oauth/src/test/kotlin/io/github/kikin81/atproto/oauth/AtOAuthTest.kt
+++ b/oauth/src/test/kotlin/io/github/kikin81/atproto/oauth/AtOAuthTest.kt
@@ -93,6 +93,90 @@ class AtOAuthTest {
         },
     )
 
+    /**
+     * Builds a mock that captures the PAR form body. Used by scope-propagation
+     * tests to assert the requested scope hits the wire verbatim.
+     */
+    private fun parCapturingClient(capture: (String) -> Unit): HttpClient = HttpClient(
+        MockEngine { request ->
+            val url = request.url.toString()
+            when {
+                url.contains("/.well-known/atproto-did") ->
+                    respond(ByteReadChannel("did:plc:testuser"), HttpStatusCode.OK)
+
+                url.contains("plc.directory/did:plc:testuser") ->
+                    respond(
+                        ByteReadChannel(
+                            """{"id":"did:plc:testuser","alsoKnownAs":["at://alice.test"],"service":[{"id":"#atproto_pds","type":"AtprotoPersonalDataServer","serviceEndpoint":"https://pds.test"}]}""",
+                        ),
+                        HttpStatusCode.OK,
+                        jsonHeaders,
+                    )
+
+                url.contains("/.well-known/oauth-protected-resource") ->
+                    respond(
+                        ByteReadChannel("""{"authorization_servers":["https://auth.test"]}"""),
+                        HttpStatusCode.OK,
+                        jsonHeaders,
+                    )
+
+                url.contains("/.well-known/oauth-authorization-server") ->
+                    respond(
+                        ByteReadChannel(
+                            """{"issuer":"https://auth.test","authorization_endpoint":"https://auth.test/authorize","token_endpoint":"https://auth.test/token","pushed_authorization_request_endpoint":"https://auth.test/par"}""",
+                        ),
+                        HttpStatusCode.OK,
+                        jsonHeaders,
+                    )
+
+                url.contains("/par") -> {
+                    val body = (request.body as io.ktor.http.content.OutgoingContent.ByteArrayContent).bytes().decodeToString()
+                    capture(body)
+                    respond(
+                        ByteReadChannel("""{"request_uri":"urn:test","expires_in":60}"""),
+                        HttpStatusCode.OK,
+                        jsonHeaders,
+                    )
+                }
+
+                else -> respond(ByteReadChannel(""), HttpStatusCode.NotFound)
+            }
+        },
+    )
+
+    @Test
+    fun parSendsDefaultScopeWhenNotOverridden() = runTest {
+        val store = InMemorySessionStore()
+        var parBody: String? = null
+        val oauth = AtOAuth(
+            clientMetadataUrl = "https://app.test/oauth/client-metadata.json",
+            sessionStore = store,
+            httpClient = parCapturingClient { parBody = it },
+        )
+        oauth.beginLogin("alice.test")
+
+        val body = parBody
+        assertNotNull(body)
+        assertContains(body, "scope=atproto+transition%3Ageneric")
+    }
+
+    @Test
+    fun parSendsCustomScopeWhenProvided() = runTest {
+        val store = InMemorySessionStore()
+        var parBody: String? = null
+        val oauth = AtOAuth(
+            clientMetadataUrl = "https://app.test/oauth/client-metadata.json",
+            sessionStore = store,
+            httpClient = parCapturingClient { parBody = it },
+            scope = "atproto transition:generic transition:chat.bsky",
+        )
+        oauth.beginLogin("alice.test")
+
+        val body = parBody
+        assertNotNull(body)
+        assertContains(body, "scope=atproto+transition%3Ageneric+transition%3Achat.bsky")
+    }
+
     @Test
     fun beginLoginReturnsAuthorizationUrl() = runTest {
         val store = InMemorySessionStore()


### PR DESCRIPTION
## Summary

- Fixes #89. `AtOAuth.parParams` hardcoded `scope = "atproto transition:generic"` in the PAR form body, so consumers couldn't request umbrella scopes like `transition:chat.bsky` even when those scopes were declared in their hosted `client-metadata.json`. Concretely this blocked nubecita-nn3 Chats MVP — every `chat.bsky.convo.*` call returned `403 ScopeMissingError`.
- Adds a constructor parameter `scope: String = "atproto transition:generic"` and threads it into `parParams()`. Default preserves v5 behavior. Consumers needing chat / email / future `transition:*` aggregates override at construction:
  ```kotlin
  AtOAuth(..., scope = "atproto transition:generic transition:chat.bsky")
  ```
- Refreshes `oauth/api/oauth.api` (kotlinx-binary-compatibility-validator). The JVM constructor descriptor changed, so this is a binary-breaking change and the commit carries a `BREAKING CHANGE:` footer. Bundled into the already-staged `v6.md` breaking-changes doc.

## Why constructor param (Option B) and not metadata fetching (Option A)

The hosted `client-metadata.json` and the requested scope must already line up per OAuth spec (requested ⊆ registered). Whichever shape we pick, the consumer still has to add `transition:chat.bsky` to both places. Option A adds a network round-trip and a new failure mode on every login for no consumer-side savings. Option B unblocks nubecita immediately with a one-line API change. Auto-discovering scope from metadata as the no-arg default is worth doing as a follow-up enhancement.

## Test plan

- [x] `./gradlew :oauth:test` — 11 tests pass (9 existing + 2 new). New tests assert the default and a custom `"atproto transition:generic transition:chat.bsky"` scope both land in the PAR form body verbatim.
- [x] `./gradlew spotlessCheck apiCheck :runtime:jvmTest :generator:test :oauth:test :samples:android:testDebugUnitTest :runtime:compileKotlinJvm :models:compileKotlinJvm` — green (matches CI).
- [x] `oauth/api/oauth.api` regenerated; diff shows only the constructor descriptor gaining `Ljava/lang/String;`.
- [ ] After 6.0.0 cuts, nubecita-nn3 bumps the dep and verifies the chat consent screen shows `transition:chat.bsky` and `chat.bsky.convo.listConvos` returns 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)