### PR TITLE
feat(models): fill in app.bsky.graph.* gap (starter packs, relationships, list ops)

### DIFF
--- a/generator/lexicons.json
+++ b/generator/lexicons.json
@@ -27,16 +27,33 @@
     "app.bsky.feed.threadgate",
     "app.bsky.graph.block",
     "app.bsky.graph.follow",
+    "app.bsky.graph.getActorStarterPacks",
     "app.bsky.graph.getBlocks",
     "app.bsky.graph.getFollowers",
     "app.bsky.graph.getFollows",
+    "app.bsky.graph.getKnownFollowers",
+    "app.bsky.graph.getList",
+    "app.bsky.graph.getListBlocks",
+    "app.bsky.graph.getListMutes",
     "app.bsky.graph.getLists",
+    "app.bsky.graph.getListsWithMembership",
     "app.bsky.graph.getMutes",
+    "app.bsky.graph.getRelationships",
+    "app.bsky.graph.getStarterPack",
+    "app.bsky.graph.getStarterPacks",
+    "app.bsky.graph.getStarterPacksWithMembership",
+    "app.bsky.graph.getSuggestedFollowsByActor",
     "app.bsky.graph.list",
     "app.bsky.graph.listblock",
     "app.bsky.graph.listitem",
     "app.bsky.graph.muteActor",
+    "app.bsky.graph.muteActorList",
+    "app.bsky.graph.muteThread",
+    "app.bsky.graph.searchStarterPacks",
     "app.bsky.graph.starterpack",
+    "app.bsky.graph.unmuteActor",
+    "app.bsky.graph.unmuteActorList",
+    "app.bsky.graph.unmuteThread",
     "app.bsky.graph.verification",
     "app.bsky.labeler.getServices",
     "app.bsky.labeler.service",
@@ -234,6 +251,10 @@
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.graph.follow",
       "cid": "bafyreiav7u7jchqtsxr2yy3gsazfqqziw5tcrfniuprrmoariruj3cft5u"
     },
+    "app.bsky.graph.getActorStarterPacks": {
+      "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.graph.getActorStarterPacks",
+      "cid": "bafyreihm57pc7dmeig4lxcv3x53z53y27obkkxnopimax7dbtqx4enqf7i"
+    },
     "app.bsky.graph.getBlocks": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.graph.getBlocks",
       "cid": "bafyreic3yp4tuxthww5sidvv27gmg3ha3argl3moconhmcccwvooobggve"
@@ -246,13 +267,53 @@
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.graph.getFollows",
       "cid": "bafyreidwk3pssvzpzzmnr7ykl5piiyrp2c5rwadgnouwjbwysghpu3gaui"
     },
+    "app.bsky.graph.getKnownFollowers": {
+      "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.graph.getKnownFollowers",
+      "cid": "bafyreia3bjqeaj5uk2zlkhk5pipefehy2mlrdp3hoqtgu3np3tvbg6xjuq"
+    },
+    "app.bsky.graph.getList": {
+      "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.graph.getList",
+      "cid": "bafyreigplofixg524nkirazfh3loe36lvqqeg6jfqvrggzztspkefwm4re"
+    },
+    "app.bsky.graph.getListBlocks": {
+      "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.graph.getListBlocks",
+      "cid": "bafyreiagod73i7ecuzpyxwlibrwimo7u4ew75nzc2b3ajdocc5sg6eszpy"
+    },
+    "app.bsky.graph.getListMutes": {
+      "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.graph.getListMutes",
+      "cid": "bafyreictd7aefsbizbn66bmhfbyvxbirbuz4uiqcp4o5tb3eiyun42wm4a"
+    },
     "app.bsky.graph.getLists": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.graph.getLists",
       "cid": "bafyreiffrqdk7vdses2qzrmmfotwyvncuhvq7anaw64x7wmlz5cix5nihy"
     },
+    "app.bsky.graph.getListsWithMembership": {
+      "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.graph.getListsWithMembership",
+      "cid": "bafyreifgvypq6ahfxtkbdmudh7bb7vib6c7kvkit6ks3gjoagor747cxfy"
+    },
     "app.bsky.graph.getMutes": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.graph.getMutes",
       "cid": "bafyreif4wfqhk2eldaqwn4552ppul26p6z4e4epuqkngb6dkpll7akfqbm"
+    },
+    "app.bsky.graph.getRelationships": {
+      "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.graph.getRelationships",
+      "cid": "bafyreiabszfuqanet2tbyyx7plxmknfegygnfyaydhwyialt4cbo24k5dq"
+    },
+    "app.bsky.graph.getStarterPack": {
+      "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.graph.getStarterPack",
+      "cid": "bafyreia77gh56vqe3ws26ntm7pffj43uhvl6l66vpb7uhxrhpih6rvne6m"
+    },
+    "app.bsky.graph.getStarterPacks": {
+      "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.graph.getStarterPacks",
+      "cid": "bafyreighxbnsgugwwjnu37nzoca7qtpipvf2l5ijz2z74ghdfrgppqfoaa"
+    },
+    "app.bsky.graph.getStarterPacksWithMembership": {
+      "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.graph.getStarterPacksWithMembership",
+      "cid": "bafyreigpeb22avssmmfqiveh3hem6qnxrduyyhkxc3ixpfgehmhkskgssy"
+    },
+    "app.bsky.graph.getSuggestedFollowsByActor": {
+      "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.graph.getSuggestedFollowsByActor",
+      "cid": "bafyreih4zuul6xlijankc73dx7bax3gbeva2dlfnzabk335y7iaptxbmr4"
     },
     "app.bsky.graph.list": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.graph.list",
@@ -270,9 +331,33 @@
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.graph.muteActor",
       "cid": "bafyreiauvwzkpqibtwpegxofryhdwldk2aitvmz7g2gidchlfcdkamwk6a"
     },
+    "app.bsky.graph.muteActorList": {
+      "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.graph.muteActorList",
+      "cid": "bafyreihadi2x64bpzncb2xfo5ww4mvajftf4qd3nxmsjud7assloxzfm44"
+    },
+    "app.bsky.graph.muteThread": {
+      "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.graph.muteThread",
+      "cid": "bafyreib6ppci3qzye6wktkm4byxtb5mnl2vg22fm7oawcdvof2tfogx4dy"
+    },
+    "app.bsky.graph.searchStarterPacks": {
+      "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.graph.searchStarterPacks",
+      "cid": "bafyreia446ip6mbnwpml6hlvxab7jtsud7zczde3u6zmnsa3op4bpxu7um"
+    },
     "app.bsky.graph.starterpack": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.graph.starterpack",
       "cid": "bafyreiejgf46gibbkpmjtgt5yyiir3wyxgrtvnfxtcdeyxrdrdnsvwgjc4"
+    },
+    "app.bsky.graph.unmuteActor": {
+      "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.graph.unmuteActor",
+      "cid": "bafyreihqc6o54652e56jmvzpaf7ix4liws4bmnd2bklc2qkuqjozfcvka4"
+    },
+    "app.bsky.graph.unmuteActorList": {
+      "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.graph.unmuteActorList",
+      "cid": "bafyreiamqj5gh6x36dzdk6ve7kfjvzotqjfcg2nplgch7woshqrubbe2ee"
+    },
+    "app.bsky.graph.unmuteThread": {
+      "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.graph.unmuteThread",
+      "cid": "bafyreiahpkqj4v7b3ujk45ufdcvynu2dxjtunzi2oipu7kzdupybmysgzu"
     },
     "app.bsky.graph.verification": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.graph.verification",

--- a/models/api/models.api
+++ b/models/api/models.api
@@ -4786,6 +4786,68 @@ public final class io/github/kikin81/atproto/app/bsky/graph/Follow$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class io/github/kikin81/atproto/app/bsky/graph/GetActorStarterPacksRequest {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/graph/GetActorStarterPacksRequest$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-mlEIfv0 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/Long;
+	public final fun copy-zhZdu3M (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;)Lio/github/kikin81/atproto/app/bsky/graph/GetActorStarterPacksRequest;
+	public static synthetic fun copy-zhZdu3M$default (Lio/github/kikin81/atproto/app/bsky/graph/GetActorStarterPacksRequest;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/graph/GetActorStarterPacksRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActor-mlEIfv0 ()Ljava/lang/String;
+	public final fun getCursor ()Ljava/lang/String;
+	public final fun getLimit ()Ljava/lang/Long;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/graph/GetActorStarterPacksRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/graph/GetActorStarterPacksRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/graph/GetActorStarterPacksRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/graph/GetActorStarterPacksRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/GetActorStarterPacksRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/GetActorStarterPacksResponse {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/graph/GetActorStarterPacksResponse$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;)Lio/github/kikin81/atproto/app/bsky/graph/GetActorStarterPacksResponse;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/graph/GetActorStarterPacksResponse;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/graph/GetActorStarterPacksResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCursor ()Ljava/lang/String;
+	public final fun getStarterPacks ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/graph/GetActorStarterPacksResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/graph/GetActorStarterPacksResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/graph/GetActorStarterPacksResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/graph/GetActorStarterPacksResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/GetActorStarterPacksResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
 public final class io/github/kikin81/atproto/app/bsky/graph/GetBlocksRequest {
 	public static final field Companion Lio/github/kikin81/atproto/app/bsky/graph/GetBlocksRequest$Companion;
 	public fun <init> ()V
@@ -4975,6 +5037,256 @@ public final class io/github/kikin81/atproto/app/bsky/graph/GetFollowsResponse$C
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class io/github/kikin81/atproto/app/bsky/graph/GetKnownFollowersRequest {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/graph/GetKnownFollowersRequest$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-mlEIfv0 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/Long;
+	public final fun copy-zhZdu3M (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;)Lio/github/kikin81/atproto/app/bsky/graph/GetKnownFollowersRequest;
+	public static synthetic fun copy-zhZdu3M$default (Lio/github/kikin81/atproto/app/bsky/graph/GetKnownFollowersRequest;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/graph/GetKnownFollowersRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActor-mlEIfv0 ()Ljava/lang/String;
+	public final fun getCursor ()Ljava/lang/String;
+	public final fun getLimit ()Ljava/lang/Long;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/graph/GetKnownFollowersRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/graph/GetKnownFollowersRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/graph/GetKnownFollowersRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/graph/GetKnownFollowersRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/GetKnownFollowersRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/GetKnownFollowersResponse {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/graph/GetKnownFollowersResponse$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Lio/github/kikin81/atproto/app/bsky/actor/ProfileView;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Lio/github/kikin81/atproto/app/bsky/actor/ProfileView;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Lio/github/kikin81/atproto/app/bsky/actor/ProfileView;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;Lio/github/kikin81/atproto/app/bsky/actor/ProfileView;)Lio/github/kikin81/atproto/app/bsky/graph/GetKnownFollowersResponse;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/graph/GetKnownFollowersResponse;Ljava/lang/String;Ljava/util/List;Lio/github/kikin81/atproto/app/bsky/actor/ProfileView;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/graph/GetKnownFollowersResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCursor ()Ljava/lang/String;
+	public final fun getFollowers ()Ljava/util/List;
+	public final fun getSubject ()Lio/github/kikin81/atproto/app/bsky/actor/ProfileView;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/graph/GetKnownFollowersResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/graph/GetKnownFollowersResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/graph/GetKnownFollowersResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/graph/GetKnownFollowersResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/GetKnownFollowersResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/GetListBlocksRequest {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/graph/GetListBlocksRequest$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Long;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Long;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/Long;
+	public final fun copy (Ljava/lang/String;Ljava/lang/Long;)Lio/github/kikin81/atproto/app/bsky/graph/GetListBlocksRequest;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/graph/GetListBlocksRequest;Ljava/lang/String;Ljava/lang/Long;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/graph/GetListBlocksRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCursor ()Ljava/lang/String;
+	public final fun getLimit ()Ljava/lang/Long;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/graph/GetListBlocksRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/graph/GetListBlocksRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/graph/GetListBlocksRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/graph/GetListBlocksRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/GetListBlocksRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/GetListBlocksResponse {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/graph/GetListBlocksResponse$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;)Lio/github/kikin81/atproto/app/bsky/graph/GetListBlocksResponse;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/graph/GetListBlocksResponse;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/graph/GetListBlocksResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCursor ()Ljava/lang/String;
+	public final fun getLists ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/graph/GetListBlocksResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/graph/GetListBlocksResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/graph/GetListBlocksResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/graph/GetListBlocksResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/GetListBlocksResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/GetListMutesRequest {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/graph/GetListMutesRequest$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Long;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Long;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/Long;
+	public final fun copy (Ljava/lang/String;Ljava/lang/Long;)Lio/github/kikin81/atproto/app/bsky/graph/GetListMutesRequest;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/graph/GetListMutesRequest;Ljava/lang/String;Ljava/lang/Long;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/graph/GetListMutesRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCursor ()Ljava/lang/String;
+	public final fun getLimit ()Ljava/lang/Long;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/graph/GetListMutesRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/graph/GetListMutesRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/graph/GetListMutesRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/graph/GetListMutesRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/GetListMutesRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/GetListMutesResponse {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/graph/GetListMutesResponse$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;)Lio/github/kikin81/atproto/app/bsky/graph/GetListMutesResponse;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/graph/GetListMutesResponse;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/graph/GetListMutesResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCursor ()Ljava/lang/String;
+	public final fun getLists ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/graph/GetListMutesResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/graph/GetListMutesResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/graph/GetListMutesResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/graph/GetListMutesResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/GetListMutesResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/GetListRequest {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/graph/GetListRequest$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/Long;
+	public final fun component3-GUXd3rc ()Ljava/lang/String;
+	public final fun copy-SUTmSSk (Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/graph/GetListRequest;
+	public static synthetic fun copy-SUTmSSk$default (Lio/github/kikin81/atproto/app/bsky/graph/GetListRequest;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/graph/GetListRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCursor ()Ljava/lang/String;
+	public final fun getLimit ()Ljava/lang/Long;
+	public final fun getList-GUXd3rc ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/graph/GetListRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/graph/GetListRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/graph/GetListRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/graph/GetListRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/GetListRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/GetListResponse {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/graph/GetListResponse$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Lio/github/kikin81/atproto/app/bsky/graph/ListView;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Lio/github/kikin81/atproto/app/bsky/graph/ListView;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Lio/github/kikin81/atproto/app/bsky/graph/ListView;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;Lio/github/kikin81/atproto/app/bsky/graph/ListView;)Lio/github/kikin81/atproto/app/bsky/graph/GetListResponse;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/graph/GetListResponse;Ljava/lang/String;Ljava/util/List;Lio/github/kikin81/atproto/app/bsky/graph/ListView;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/graph/GetListResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCursor ()Ljava/lang/String;
+	public final fun getItems ()Ljava/util/List;
+	public final fun getList ()Lio/github/kikin81/atproto/app/bsky/graph/ListView;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/graph/GetListResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/graph/GetListResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/graph/GetListResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/graph/GetListResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/GetListResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
 public final class io/github/kikin81/atproto/app/bsky/graph/GetListsRequest {
 	public static final field Companion Lio/github/kikin81/atproto/app/bsky/graph/GetListsRequest$Companion;
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -5039,6 +5351,100 @@ public final class io/github/kikin81/atproto/app/bsky/graph/GetListsResponse$Com
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class io/github/kikin81/atproto/app/bsky/graph/GetListsWithMembershipListWithMembership {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/graph/GetListsWithMembershipListWithMembership$Companion;
+	public fun <init> (Lio/github/kikin81/atproto/app/bsky/graph/ListView;Lio/github/kikin81/atproto/app/bsky/graph/ListItemView;)V
+	public synthetic fun <init> (Lio/github/kikin81/atproto/app/bsky/graph/ListView;Lio/github/kikin81/atproto/app/bsky/graph/ListItemView;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/app/bsky/graph/ListView;
+	public final fun component2 ()Lio/github/kikin81/atproto/app/bsky/graph/ListItemView;
+	public final fun copy (Lio/github/kikin81/atproto/app/bsky/graph/ListView;Lio/github/kikin81/atproto/app/bsky/graph/ListItemView;)Lio/github/kikin81/atproto/app/bsky/graph/GetListsWithMembershipListWithMembership;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/graph/GetListsWithMembershipListWithMembership;Lio/github/kikin81/atproto/app/bsky/graph/ListView;Lio/github/kikin81/atproto/app/bsky/graph/ListItemView;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/graph/GetListsWithMembershipListWithMembership;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getList ()Lio/github/kikin81/atproto/app/bsky/graph/ListView;
+	public final fun getListItem ()Lio/github/kikin81/atproto/app/bsky/graph/ListItemView;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/graph/GetListsWithMembershipListWithMembership$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/graph/GetListsWithMembershipListWithMembership$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/graph/GetListsWithMembershipListWithMembership;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/graph/GetListsWithMembershipListWithMembership;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/GetListsWithMembershipListWithMembership$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/GetListsWithMembershipRequest {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/graph/GetListsWithMembershipRequest$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/util/List;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-mlEIfv0 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/Long;
+	public final fun component4 ()Ljava/util/List;
+	public final fun copy-icULqAM (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/util/List;)Lio/github/kikin81/atproto/app/bsky/graph/GetListsWithMembershipRequest;
+	public static synthetic fun copy-icULqAM$default (Lio/github/kikin81/atproto/app/bsky/graph/GetListsWithMembershipRequest;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/util/List;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/graph/GetListsWithMembershipRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActor-mlEIfv0 ()Ljava/lang/String;
+	public final fun getCursor ()Ljava/lang/String;
+	public final fun getLimit ()Ljava/lang/Long;
+	public final fun getPurposes ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/graph/GetListsWithMembershipRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/graph/GetListsWithMembershipRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/graph/GetListsWithMembershipRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/graph/GetListsWithMembershipRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/GetListsWithMembershipRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/GetListsWithMembershipResponse {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/graph/GetListsWithMembershipResponse$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;)Lio/github/kikin81/atproto/app/bsky/graph/GetListsWithMembershipResponse;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/graph/GetListsWithMembershipResponse;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/graph/GetListsWithMembershipResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCursor ()Ljava/lang/String;
+	public final fun getListsWithMembership ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/graph/GetListsWithMembershipResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/graph/GetListsWithMembershipResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/graph/GetListsWithMembershipResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/graph/GetListsWithMembershipResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/GetListsWithMembershipResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
 public final class io/github/kikin81/atproto/app/bsky/graph/GetMutesRequest {
 	public static final field Companion Lio/github/kikin81/atproto/app/bsky/graph/GetMutesRequest$Companion;
 	public fun <init> ()V
@@ -5100,19 +5506,401 @@ public final class io/github/kikin81/atproto/app/bsky/graph/GetMutesResponse$Com
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class io/github/kikin81/atproto/app/bsky/graph/GetRelationshipsRequest {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/graph/GetRelationshipsRequest$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-mlEIfv0 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy-hAgOyBw (Ljava/lang/String;Ljava/util/List;)Lio/github/kikin81/atproto/app/bsky/graph/GetRelationshipsRequest;
+	public static synthetic fun copy-hAgOyBw$default (Lio/github/kikin81/atproto/app/bsky/graph/GetRelationshipsRequest;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/graph/GetRelationshipsRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActor-mlEIfv0 ()Ljava/lang/String;
+	public final fun getOthers ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/graph/GetRelationshipsRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/graph/GetRelationshipsRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/graph/GetRelationshipsRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/graph/GetRelationshipsRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/GetRelationshipsRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/GetRelationshipsResponse {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/graph/GetRelationshipsResponse$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-4riKzFA ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy-XHMjumI (Ljava/lang/String;Ljava/util/List;)Lio/github/kikin81/atproto/app/bsky/graph/GetRelationshipsResponse;
+	public static synthetic fun copy-XHMjumI$default (Lio/github/kikin81/atproto/app/bsky/graph/GetRelationshipsResponse;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/graph/GetRelationshipsResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActor-4riKzFA ()Ljava/lang/String;
+	public final fun getRelationships ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/graph/GetRelationshipsResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/graph/GetRelationshipsResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/graph/GetRelationshipsResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/graph/GetRelationshipsResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/GetRelationshipsResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class io/github/kikin81/atproto/app/bsky/graph/GetRelationshipsResponseRelationshipsUnion : io/github/kikin81/atproto/runtime/OpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/graph/GetRelationshipsResponseRelationshipsUnion$Companion;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/GetRelationshipsResponseRelationshipsUnion$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/GetRelationshipsResponseRelationshipsUnion$Unknown : io/github/kikin81/atproto/app/bsky/graph/GetRelationshipsResponseRelationshipsUnion, io/github/kikin81/atproto/runtime/UnknownOpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/graph/GetRelationshipsResponseRelationshipsUnion$Unknown$Companion;
+	public fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/app/bsky/graph/GetRelationshipsResponseRelationshipsUnion$Unknown;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/graph/GetRelationshipsResponseRelationshipsUnion$Unknown;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/graph/GetRelationshipsResponseRelationshipsUnion$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getRaw ()Lkotlinx/serialization/json/JsonObject;
+	public fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/GetRelationshipsResponseRelationshipsUnion$Unknown$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/GetRelationshipsResponseRelationshipsUnionSerializer : io/github/kikin81/atproto/runtime/OpenUnionSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/graph/GetRelationshipsResponseRelationshipsUnionSerializer;
+	public fun selectKnownDeserializer (Ljava/lang/String;)Lkotlinx/serialization/KSerializer;
+	public fun selectKnownSerializer (Lio/github/kikin81/atproto/app/bsky/graph/GetRelationshipsResponseRelationshipsUnion;)Lkotlinx/serialization/KSerializer;
+	public synthetic fun selectKnownSerializer (Lio/github/kikin81/atproto/runtime/OpenUnionMember;)Lkotlinx/serialization/KSerializer;
+	public fun unknownSerializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/GetRelationshipsResponseRelationshipsUnionUnknownSerializer : io/github/kikin81/atproto/runtime/UnknownMemberSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/graph/GetRelationshipsResponseRelationshipsUnionUnknownSerializer;
+	public fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/app/bsky/graph/GetRelationshipsResponseRelationshipsUnion$Unknown;
+	public synthetic fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/runtime/UnknownOpenUnionMember;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/GetStarterPackRequest {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/graph/GetStarterPackRequest$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-GUXd3rc ()Ljava/lang/String;
+	public final fun copy-wvBT1Tk (Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/graph/GetStarterPackRequest;
+	public static synthetic fun copy-wvBT1Tk$default (Lio/github/kikin81/atproto/app/bsky/graph/GetStarterPackRequest;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/graph/GetStarterPackRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getStarterPack-GUXd3rc ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/graph/GetStarterPackRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/graph/GetStarterPackRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/graph/GetStarterPackRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/graph/GetStarterPackRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/GetStarterPackRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/GetStarterPackResponse {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/graph/GetStarterPackResponse$Companion;
+	public fun <init> (Lio/github/kikin81/atproto/app/bsky/graph/StarterPackView;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/app/bsky/graph/StarterPackView;
+	public final fun copy (Lio/github/kikin81/atproto/app/bsky/graph/StarterPackView;)Lio/github/kikin81/atproto/app/bsky/graph/GetStarterPackResponse;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/graph/GetStarterPackResponse;Lio/github/kikin81/atproto/app/bsky/graph/StarterPackView;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/graph/GetStarterPackResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getStarterPack ()Lio/github/kikin81/atproto/app/bsky/graph/StarterPackView;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/graph/GetStarterPackResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/graph/GetStarterPackResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/graph/GetStarterPackResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/graph/GetStarterPackResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/GetStarterPackResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/GetStarterPacksRequest {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/graph/GetStarterPacksRequest$Companion;
+	public fun <init> (Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lio/github/kikin81/atproto/app/bsky/graph/GetStarterPacksRequest;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/graph/GetStarterPacksRequest;Ljava/util/List;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/graph/GetStarterPacksRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUris ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/graph/GetStarterPacksRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/graph/GetStarterPacksRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/graph/GetStarterPacksRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/graph/GetStarterPacksRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/GetStarterPacksRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/GetStarterPacksResponse {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/graph/GetStarterPacksResponse$Companion;
+	public fun <init> (Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lio/github/kikin81/atproto/app/bsky/graph/GetStarterPacksResponse;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/graph/GetStarterPacksResponse;Ljava/util/List;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/graph/GetStarterPacksResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getStarterPacks ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/graph/GetStarterPacksResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/graph/GetStarterPacksResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/graph/GetStarterPacksResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/graph/GetStarterPacksResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/GetStarterPacksResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/GetStarterPacksWithMembershipRequest {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/graph/GetStarterPacksWithMembershipRequest$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-mlEIfv0 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/Long;
+	public final fun copy-zhZdu3M (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;)Lio/github/kikin81/atproto/app/bsky/graph/GetStarterPacksWithMembershipRequest;
+	public static synthetic fun copy-zhZdu3M$default (Lio/github/kikin81/atproto/app/bsky/graph/GetStarterPacksWithMembershipRequest;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/graph/GetStarterPacksWithMembershipRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActor-mlEIfv0 ()Ljava/lang/String;
+	public final fun getCursor ()Ljava/lang/String;
+	public final fun getLimit ()Ljava/lang/Long;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/graph/GetStarterPacksWithMembershipRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/graph/GetStarterPacksWithMembershipRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/graph/GetStarterPacksWithMembershipRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/graph/GetStarterPacksWithMembershipRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/GetStarterPacksWithMembershipRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/GetStarterPacksWithMembershipResponse {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/graph/GetStarterPacksWithMembershipResponse$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;)Lio/github/kikin81/atproto/app/bsky/graph/GetStarterPacksWithMembershipResponse;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/graph/GetStarterPacksWithMembershipResponse;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/graph/GetStarterPacksWithMembershipResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCursor ()Ljava/lang/String;
+	public final fun getStarterPacksWithMembership ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/graph/GetStarterPacksWithMembershipResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/graph/GetStarterPacksWithMembershipResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/graph/GetStarterPacksWithMembershipResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/graph/GetStarterPacksWithMembershipResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/GetStarterPacksWithMembershipResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/GetStarterPacksWithMembershipStarterPackWithMembership {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/graph/GetStarterPacksWithMembershipStarterPackWithMembership$Companion;
+	public fun <init> (Lio/github/kikin81/atproto/app/bsky/graph/ListItemView;Lio/github/kikin81/atproto/app/bsky/graph/StarterPackView;)V
+	public synthetic fun <init> (Lio/github/kikin81/atproto/app/bsky/graph/ListItemView;Lio/github/kikin81/atproto/app/bsky/graph/StarterPackView;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/app/bsky/graph/ListItemView;
+	public final fun component2 ()Lio/github/kikin81/atproto/app/bsky/graph/StarterPackView;
+	public final fun copy (Lio/github/kikin81/atproto/app/bsky/graph/ListItemView;Lio/github/kikin81/atproto/app/bsky/graph/StarterPackView;)Lio/github/kikin81/atproto/app/bsky/graph/GetStarterPacksWithMembershipStarterPackWithMembership;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/graph/GetStarterPacksWithMembershipStarterPackWithMembership;Lio/github/kikin81/atproto/app/bsky/graph/ListItemView;Lio/github/kikin81/atproto/app/bsky/graph/StarterPackView;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/graph/GetStarterPacksWithMembershipStarterPackWithMembership;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getListItem ()Lio/github/kikin81/atproto/app/bsky/graph/ListItemView;
+	public final fun getStarterPack ()Lio/github/kikin81/atproto/app/bsky/graph/StarterPackView;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/graph/GetStarterPacksWithMembershipStarterPackWithMembership$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/graph/GetStarterPacksWithMembershipStarterPackWithMembership$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/graph/GetStarterPacksWithMembershipStarterPackWithMembership;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/graph/GetStarterPacksWithMembershipStarterPackWithMembership;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/GetStarterPacksWithMembershipStarterPackWithMembership$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/GetSuggestedFollowsByActorRequest {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/graph/GetSuggestedFollowsByActorRequest$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-mlEIfv0 ()Ljava/lang/String;
+	public final fun copy-6PA111I (Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/graph/GetSuggestedFollowsByActorRequest;
+	public static synthetic fun copy-6PA111I$default (Lio/github/kikin81/atproto/app/bsky/graph/GetSuggestedFollowsByActorRequest;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/graph/GetSuggestedFollowsByActorRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActor-mlEIfv0 ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/graph/GetSuggestedFollowsByActorRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/graph/GetSuggestedFollowsByActorRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/graph/GetSuggestedFollowsByActorRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/graph/GetSuggestedFollowsByActorRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/GetSuggestedFollowsByActorRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/GetSuggestedFollowsByActorResponse {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/graph/GetSuggestedFollowsByActorResponse$Companion;
+	public fun <init> (Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Boolean;
+	public final fun component2 ()Ljava/lang/Long;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/String;Ljava/util/List;)Lio/github/kikin81/atproto/app/bsky/graph/GetSuggestedFollowsByActorResponse;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/graph/GetSuggestedFollowsByActorResponse;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/graph/GetSuggestedFollowsByActorResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getRecId ()Ljava/lang/Long;
+	public final fun getRecIdStr ()Ljava/lang/String;
+	public final fun getSuggestions ()Ljava/util/List;
+	public fun hashCode ()I
+	public final fun isFallback ()Ljava/lang/Boolean;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/graph/GetSuggestedFollowsByActorResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/graph/GetSuggestedFollowsByActorResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/graph/GetSuggestedFollowsByActorResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/graph/GetSuggestedFollowsByActorResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/GetSuggestedFollowsByActorResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
 public final class io/github/kikin81/atproto/app/bsky/graph/GraphService {
 	public fun <init> (Lio/github/kikin81/atproto/runtime/XrpcClient;)V
+	public final fun getActorStarterPacks (Lio/github/kikin81/atproto/app/bsky/graph/GetActorStarterPacksRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getBlocks (Lio/github/kikin81/atproto/app/bsky/graph/GetBlocksRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun getBlocks$default (Lio/github/kikin81/atproto/app/bsky/graph/GraphService;Lio/github/kikin81/atproto/app/bsky/graph/GetBlocksRequest;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun getFollowers (Lio/github/kikin81/atproto/app/bsky/graph/GetFollowersRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getFollows (Lio/github/kikin81/atproto/app/bsky/graph/GetFollowsRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getKnownFollowers (Lio/github/kikin81/atproto/app/bsky/graph/GetKnownFollowersRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getList (Lio/github/kikin81/atproto/app/bsky/graph/GetListRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getListBlocks (Lio/github/kikin81/atproto/app/bsky/graph/GetListBlocksRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getListBlocks$default (Lio/github/kikin81/atproto/app/bsky/graph/GraphService;Lio/github/kikin81/atproto/app/bsky/graph/GetListBlocksRequest;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getListMutes (Lio/github/kikin81/atproto/app/bsky/graph/GetListMutesRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getListMutes$default (Lio/github/kikin81/atproto/app/bsky/graph/GraphService;Lio/github/kikin81/atproto/app/bsky/graph/GetListMutesRequest;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun getLists (Lio/github/kikin81/atproto/app/bsky/graph/GetListsRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getListsWithMembership (Lio/github/kikin81/atproto/app/bsky/graph/GetListsWithMembershipRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getMutes (Lio/github/kikin81/atproto/app/bsky/graph/GetMutesRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun getMutes$default (Lio/github/kikin81/atproto/app/bsky/graph/GraphService;Lio/github/kikin81/atproto/app/bsky/graph/GetMutesRequest;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getRelationships (Lio/github/kikin81/atproto/app/bsky/graph/GetRelationshipsRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getStarterPack (Lio/github/kikin81/atproto/app/bsky/graph/GetStarterPackRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getStarterPacks (Lio/github/kikin81/atproto/app/bsky/graph/GetStarterPacksRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getStarterPacksWithMembership (Lio/github/kikin81/atproto/app/bsky/graph/GetStarterPacksWithMembershipRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getSuggestedFollowsByActor (Lio/github/kikin81/atproto/app/bsky/graph/GetSuggestedFollowsByActorRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun muteActor (Lio/github/kikin81/atproto/app/bsky/graph/MuteActorRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun muteActorList (Lio/github/kikin81/atproto/app/bsky/graph/MuteActorListRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun muteThread (Lio/github/kikin81/atproto/app/bsky/graph/MuteThreadRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun searchStarterPacks (Lio/github/kikin81/atproto/app/bsky/graph/SearchStarterPacksRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun unmuteActor (Lio/github/kikin81/atproto/app/bsky/graph/UnmuteActorRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun unmuteActorList (Lio/github/kikin81/atproto/app/bsky/graph/UnmuteActorListRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun unmuteThread (Lio/github/kikin81/atproto/app/bsky/graph/UnmuteThreadRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class io/github/kikin81/atproto/app/bsky/graph/GraphServiceKt {
+	public static final fun actorStarterPacksFlow (Lio/github/kikin81/atproto/app/bsky/graph/GraphService;Lio/github/kikin81/atproto/app/bsky/graph/GetActorStarterPacksRequest;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun actorStarterPacksPageFlow (Lio/github/kikin81/atproto/app/bsky/graph/GraphService;Lio/github/kikin81/atproto/app/bsky/graph/GetActorStarterPacksRequest;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun blocksFlow (Lio/github/kikin81/atproto/app/bsky/graph/GraphService;Lio/github/kikin81/atproto/app/bsky/graph/GetBlocksRequest;)Lkotlinx/coroutines/flow/Flow;
 	public static synthetic fun blocksFlow$default (Lio/github/kikin81/atproto/app/bsky/graph/GraphService;Lio/github/kikin81/atproto/app/bsky/graph/GetBlocksRequest;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun blocksPageFlow (Lio/github/kikin81/atproto/app/bsky/graph/GraphService;Lio/github/kikin81/atproto/app/bsky/graph/GetBlocksRequest;)Lkotlinx/coroutines/flow/Flow;
@@ -5121,12 +5909,30 @@ public final class io/github/kikin81/atproto/app/bsky/graph/GraphServiceKt {
 	public static final fun followersPageFlow (Lio/github/kikin81/atproto/app/bsky/graph/GraphService;Lio/github/kikin81/atproto/app/bsky/graph/GetFollowersRequest;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun followsFlow (Lio/github/kikin81/atproto/app/bsky/graph/GraphService;Lio/github/kikin81/atproto/app/bsky/graph/GetFollowsRequest;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun followsPageFlow (Lio/github/kikin81/atproto/app/bsky/graph/GraphService;Lio/github/kikin81/atproto/app/bsky/graph/GetFollowsRequest;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun knownFollowersFlow (Lio/github/kikin81/atproto/app/bsky/graph/GraphService;Lio/github/kikin81/atproto/app/bsky/graph/GetKnownFollowersRequest;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun knownFollowersPageFlow (Lio/github/kikin81/atproto/app/bsky/graph/GraphService;Lio/github/kikin81/atproto/app/bsky/graph/GetKnownFollowersRequest;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun listBlocksFlow (Lio/github/kikin81/atproto/app/bsky/graph/GraphService;Lio/github/kikin81/atproto/app/bsky/graph/GetListBlocksRequest;)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun listBlocksFlow$default (Lio/github/kikin81/atproto/app/bsky/graph/GraphService;Lio/github/kikin81/atproto/app/bsky/graph/GetListBlocksRequest;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun listBlocksPageFlow (Lio/github/kikin81/atproto/app/bsky/graph/GraphService;Lio/github/kikin81/atproto/app/bsky/graph/GetListBlocksRequest;)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun listBlocksPageFlow$default (Lio/github/kikin81/atproto/app/bsky/graph/GraphService;Lio/github/kikin81/atproto/app/bsky/graph/GetListBlocksRequest;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun listFlow (Lio/github/kikin81/atproto/app/bsky/graph/GraphService;Lio/github/kikin81/atproto/app/bsky/graph/GetListRequest;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun listMutesFlow (Lio/github/kikin81/atproto/app/bsky/graph/GraphService;Lio/github/kikin81/atproto/app/bsky/graph/GetListMutesRequest;)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun listMutesFlow$default (Lio/github/kikin81/atproto/app/bsky/graph/GraphService;Lio/github/kikin81/atproto/app/bsky/graph/GetListMutesRequest;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun listMutesPageFlow (Lio/github/kikin81/atproto/app/bsky/graph/GraphService;Lio/github/kikin81/atproto/app/bsky/graph/GetListMutesRequest;)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun listMutesPageFlow$default (Lio/github/kikin81/atproto/app/bsky/graph/GraphService;Lio/github/kikin81/atproto/app/bsky/graph/GetListMutesRequest;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun listPageFlow (Lio/github/kikin81/atproto/app/bsky/graph/GraphService;Lio/github/kikin81/atproto/app/bsky/graph/GetListRequest;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun listsFlow (Lio/github/kikin81/atproto/app/bsky/graph/GraphService;Lio/github/kikin81/atproto/app/bsky/graph/GetListsRequest;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun listsPageFlow (Lio/github/kikin81/atproto/app/bsky/graph/GraphService;Lio/github/kikin81/atproto/app/bsky/graph/GetListsRequest;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun listsWithMembershipFlow (Lio/github/kikin81/atproto/app/bsky/graph/GraphService;Lio/github/kikin81/atproto/app/bsky/graph/GetListsWithMembershipRequest;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun listsWithMembershipPageFlow (Lio/github/kikin81/atproto/app/bsky/graph/GraphService;Lio/github/kikin81/atproto/app/bsky/graph/GetListsWithMembershipRequest;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun mutesFlow (Lio/github/kikin81/atproto/app/bsky/graph/GraphService;Lio/github/kikin81/atproto/app/bsky/graph/GetMutesRequest;)Lkotlinx/coroutines/flow/Flow;
 	public static synthetic fun mutesFlow$default (Lio/github/kikin81/atproto/app/bsky/graph/GraphService;Lio/github/kikin81/atproto/app/bsky/graph/GetMutesRequest;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun mutesPageFlow (Lio/github/kikin81/atproto/app/bsky/graph/GraphService;Lio/github/kikin81/atproto/app/bsky/graph/GetMutesRequest;)Lkotlinx/coroutines/flow/Flow;
 	public static synthetic fun mutesPageFlow$default (Lio/github/kikin81/atproto/app/bsky/graph/GraphService;Lio/github/kikin81/atproto/app/bsky/graph/GetMutesRequest;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun searchStarterPacksFlow (Lio/github/kikin81/atproto/app/bsky/graph/GraphService;Lio/github/kikin81/atproto/app/bsky/graph/SearchStarterPacksRequest;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun searchStarterPacksPageFlow (Lio/github/kikin81/atproto/app/bsky/graph/GraphService;Lio/github/kikin81/atproto/app/bsky/graph/SearchStarterPacksRequest;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun starterPacksWithMembershipFlow (Lio/github/kikin81/atproto/app/bsky/graph/GraphService;Lio/github/kikin81/atproto/app/bsky/graph/GetStarterPacksWithMembershipRequest;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun starterPacksWithMembershipPageFlow (Lio/github/kikin81/atproto/app/bsky/graph/GraphService;Lio/github/kikin81/atproto/app/bsky/graph/GetStarterPacksWithMembershipRequest;)Lkotlinx/coroutines/flow/Flow;
 }
 
 public final class io/github/kikin81/atproto/app/bsky/graph/List {
@@ -5422,6 +6228,33 @@ public final class io/github/kikin81/atproto/app/bsky/graph/Listitem$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class io/github/kikin81/atproto/app/bsky/graph/MuteActorListRequest {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/graph/MuteActorListRequest$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-GUXd3rc ()Ljava/lang/String;
+	public final fun copy-wvBT1Tk (Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/graph/MuteActorListRequest;
+	public static synthetic fun copy-wvBT1Tk$default (Lio/github/kikin81/atproto/app/bsky/graph/MuteActorListRequest;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/graph/MuteActorListRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getList-GUXd3rc ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/graph/MuteActorListRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/graph/MuteActorListRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/graph/MuteActorListRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/graph/MuteActorListRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/MuteActorListRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
 public final class io/github/kikin81/atproto/app/bsky/graph/MuteActorRequest {
 	public static final field Companion Lio/github/kikin81/atproto/app/bsky/graph/MuteActorRequest$Companion;
 	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -5449,7 +6282,34 @@ public final class io/github/kikin81/atproto/app/bsky/graph/MuteActorRequest$Com
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class io/github/kikin81/atproto/app/bsky/graph/NotFoundActor {
+public final class io/github/kikin81/atproto/app/bsky/graph/MuteThreadRequest {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/graph/MuteThreadRequest$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-GUXd3rc ()Ljava/lang/String;
+	public final fun copy-wvBT1Tk (Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/graph/MuteThreadRequest;
+	public static synthetic fun copy-wvBT1Tk$default (Lio/github/kikin81/atproto/app/bsky/graph/MuteThreadRequest;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/graph/MuteThreadRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getRoot-GUXd3rc ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/graph/MuteThreadRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/graph/MuteThreadRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/graph/MuteThreadRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/graph/MuteThreadRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/MuteThreadRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/NotFoundActor : io/github/kikin81/atproto/app/bsky/graph/GetRelationshipsResponseRelationshipsUnion {
 	public static final field Companion Lio/github/kikin81/atproto/app/bsky/graph/NotFoundActor$Companion;
 	public synthetic fun <init> (Ljava/lang/String;ZLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1-mlEIfv0 ()Ljava/lang/String;
@@ -5478,7 +6338,7 @@ public final class io/github/kikin81/atproto/app/bsky/graph/NotFoundActor$Compan
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class io/github/kikin81/atproto/app/bsky/graph/Relationship {
+public final class io/github/kikin81/atproto/app/bsky/graph/Relationship : io/github/kikin81/atproto/app/bsky/graph/GetRelationshipsResponseRelationshipsUnion {
 	public static final field Companion Lio/github/kikin81/atproto/app/bsky/graph/Relationship$Companion;
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -5515,6 +6375,68 @@ public final synthetic class io/github/kikin81/atproto/app/bsky/graph/Relationsh
 }
 
 public final class io/github/kikin81/atproto/app/bsky/graph/Relationship$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/SearchStarterPacksRequest {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/graph/SearchStarterPacksRequest$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/Long;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/graph/SearchStarterPacksRequest;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/graph/SearchStarterPacksRequest;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/graph/SearchStarterPacksRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCursor ()Ljava/lang/String;
+	public final fun getLimit ()Ljava/lang/Long;
+	public final fun getQ ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/graph/SearchStarterPacksRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/graph/SearchStarterPacksRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/graph/SearchStarterPacksRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/graph/SearchStarterPacksRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/SearchStarterPacksRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/SearchStarterPacksResponse {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/graph/SearchStarterPacksResponse$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;)Lio/github/kikin81/atproto/app/bsky/graph/SearchStarterPacksResponse;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/graph/SearchStarterPacksResponse;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/graph/SearchStarterPacksResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCursor ()Ljava/lang/String;
+	public final fun getStarterPacks ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/graph/SearchStarterPacksResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/graph/SearchStarterPacksResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/graph/SearchStarterPacksResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/graph/SearchStarterPacksResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/SearchStarterPacksResponse$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -5672,6 +6594,87 @@ public final synthetic class io/github/kikin81/atproto/app/bsky/graph/Starterpac
 }
 
 public final class io/github/kikin81/atproto/app/bsky/graph/StarterpackFeedItem$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/UnmuteActorListRequest {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/graph/UnmuteActorListRequest$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-GUXd3rc ()Ljava/lang/String;
+	public final fun copy-wvBT1Tk (Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/graph/UnmuteActorListRequest;
+	public static synthetic fun copy-wvBT1Tk$default (Lio/github/kikin81/atproto/app/bsky/graph/UnmuteActorListRequest;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/graph/UnmuteActorListRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getList-GUXd3rc ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/graph/UnmuteActorListRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/graph/UnmuteActorListRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/graph/UnmuteActorListRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/graph/UnmuteActorListRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/UnmuteActorListRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/UnmuteActorRequest {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/graph/UnmuteActorRequest$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-mlEIfv0 ()Ljava/lang/String;
+	public final fun copy-6PA111I (Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/graph/UnmuteActorRequest;
+	public static synthetic fun copy-6PA111I$default (Lio/github/kikin81/atproto/app/bsky/graph/UnmuteActorRequest;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/graph/UnmuteActorRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActor-mlEIfv0 ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/graph/UnmuteActorRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/graph/UnmuteActorRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/graph/UnmuteActorRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/graph/UnmuteActorRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/UnmuteActorRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/UnmuteThreadRequest {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/graph/UnmuteThreadRequest$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-GUXd3rc ()Ljava/lang/String;
+	public final fun copy-wvBT1Tk (Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/graph/UnmuteThreadRequest;
+	public static synthetic fun copy-wvBT1Tk$default (Lio/github/kikin81/atproto/app/bsky/graph/UnmuteThreadRequest;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/graph/UnmuteThreadRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getRoot-GUXd3rc ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/graph/UnmuteThreadRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/graph/UnmuteThreadRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/graph/UnmuteThreadRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/graph/UnmuteThreadRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/graph/UnmuteThreadRequest$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 


### PR DESCRIPTION
Tracking: `kikinlex-4ys` (beads).

## Summary

Adds **17 new methods** on the generated `GraphService`:

- **Starter packs** (5): `getActorStarterPacks`, `getStarterPack`, `getStarterPacks`, `getStarterPacksWithMembership`, `searchStarterPacks`
- **Relationships & discovery** (3): `getKnownFollowers`, `getRelationships`, `getSuggestedFollowsByActor`
- **List operations** (6): `getList`, `getListBlocks`, `getListMutes`, `getListsWithMembership`, `muteActorList`, `unmuteActorList`
- **Thread muting** (2): `muteThread`, `unmuteThread`
- **Actor unmute** (1): `unmuteActor` (complements existing `muteActor`)

Pagination `Flow` extensions are emitted automatically for cursor-bearing queries.

## Why

Unlocks discovery UX (starter packs, suggested-follows-by-actor), social-graph traversal (relationships, known-followers), and full list lifecycle (mute/unmute lists, fetch list blocks/mutes/membership). Not blocking the nubecita Chats MVP, but heavily exercised by full Bluesky-style clients.

## Binary compatibility

Purely additive: +98 new public classes, 0 removed (verified via `comm` on pre/post `models/api/models.api`). Will land as a minor bump via semantic-release.

## Test plan

- [x] `./gradlew spotlessCheck apiCheck :runtime:jvmTest :generator:test :samples:android:testDebugUnitTest :runtime:compileKotlinJvm :models:compileKotlinJvm :samples:android:assembleDebug` — passes locally.
- [x] Inspected generated `GraphService.kt` — all 17 new methods present, request/response serializers correct, pagination flows on cursor queries.
- [x] Additive-only on `models/api/models.api` confirmed via diff (+98, -0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)