### PR TITLE
feat(ci): add lexicon-drift-detect workflow + helper script

### DIFF
--- a/.github/workflows/lexicon-drift-detect.yaml
+++ b/.github/workflows/lexicon-drift-detect.yaml
@@ -1,0 +1,113 @@
+name: Lexicon drift detection
+
+# Surfaces upstream NSIDs that exist in bluesky-social/atproto's lexicon
+# corpus but are not yet in our generator/lexicons.json manifest, plus
+# manifest NSIDs no longer present upstream (deprecations or renames).
+#
+# Complements .github/workflows/lexicon-bump.yaml. That workflow refreshes
+# CIDs for already-manifested NSIDs (corpus drift). This workflow detects
+# brand-new upstream namespaces that lex install --update will never
+# discover, so a maintainer can decide which to opt into.
+#
+# Maintains a single tracking issue labeled `lexicon-drift`:
+#   - drift detected with no open issue -> create one
+#   - drift detected with an open issue -> edit body in place
+#   - no drift detected with an open issue -> auto-close with comment
+
+on:
+  schedule:
+    # 13:00 UTC Mondays — one hour before lexicon-bump (14:00 UTC), so a
+    # fresh drift report is available when the bump PR (if any) opens.
+    - cron: "0 13 * * 1"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: lexicon-drift-detect
+  cancel-in-progress: false
+
+jobs:
+  detect:
+    name: Detect lexicon drift
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Set up JDK
+        uses: actions/setup-java@v5
+        with:
+          distribution: zulu
+          java-version-file: .java-version
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
+
+      - name: Ensure lexicon-drift label exists
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh label create lexicon-drift \
+            --color B60205 \
+            --description "Upstream lexicons exist but are not in our manifest" \
+            --force
+
+      - name: Run drift detection
+        id: detect
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./gradlew :generator:detectLexiconDrift --quiet --no-configuration-cache
+
+      - name: Find existing drift issue
+        id: find
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          existing=$(gh issue list \
+            --label lexicon-drift \
+            --state open \
+            --json number \
+            --jq '.[0].number // empty')
+          echo "issue_number=${existing}" >> "$GITHUB_OUTPUT"
+
+      - name: Open or update tracking issue
+        if: steps.detect.outputs.has_drift == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BODY: ${{ steps.detect.outputs.body }}
+          NEW_COUNT: ${{ steps.detect.outputs.new_count }}
+          REMOVED_COUNT: ${{ steps.detect.outputs.removed_count }}
+          EXISTING: ${{ steps.find.outputs.issue_number }}
+        run: |
+          set -euo pipefail
+          title="Lexicon drift: ${NEW_COUNT} new upstream NSID(s), ${REMOVED_COUNT} missing-from-upstream"
+          tmp=$(mktemp)
+          printf '%s' "$BODY" > "$tmp"
+          if [ -n "$EXISTING" ]; then
+            gh issue edit "$EXISTING" \
+              --title "$title" \
+              --body-file "$tmp"
+            echo "Updated existing drift issue #${EXISTING}"
+          else
+            gh issue create \
+              --title "$title" \
+              --body-file "$tmp" \
+              --label lexicon-drift
+            echo "Created new drift tracking issue"
+          fi
+
+      - name: Auto-close drift issue when manifest catches up
+        if: steps.detect.outputs.has_drift == 'false' && steps.find.outputs.issue_number != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EXISTING: ${{ steps.find.outputs.issue_number }}
+        run: |
+          set -euo pipefail
+          gh issue close "$EXISTING" \
+            --reason completed \
+            --comment "No drift detected on $(date -u +%Y-%m-%d). Closing automatically; will reopen if upstream diverges again."

--- a/generator/build.gradle.kts
+++ b/generator/build.gradle.kts
@@ -57,3 +57,30 @@ tasks.register<JavaExec>("generateModels") {
 
     onlyIf { lexiconsPresent }
 }
+
+/**
+ * Detects upstream lexicon drift against `generator/lexicons.json`.
+ * Surfaces new upstream NSIDs that `npx lex install --update` cannot
+ * discover (since it only refreshes already-manifested NSIDs).
+ *
+ * Used by `.github/workflows/lexicon-drift-detect.yaml`; locally
+ * runnable for manual gap audits.
+ *
+ * Usage:
+ *   ./gradlew :generator:detectLexiconDrift
+ */
+val lexiconsManifestFile = layout.projectDirectory.file("lexicons.json")
+
+tasks.register<JavaExec>("detectLexiconDrift") {
+    group = "verification"
+    description = "Detect upstream NSIDs missing from generator/lexicons.json."
+    notCompatibleWithConfigurationCache("drift task captures script-level path values")
+
+    classpath = sourceSets.main.get().runtimeClasspath
+    mainClass.set("io.github.kikin81.atproto.generator.tools.LexiconDriftDetectKt")
+    args = listOf(lexiconsManifestFile.asFile.absolutePath)
+
+    // The task always reaches over the network for an authoritative diff;
+    // intentional opt-out from up-to-date caching.
+    outputs.upToDateWhen { false }
+}

--- a/generator/src/main/kotlin/io/github/kikin81/atproto/generator/tools/LexiconDriftDetect.kt
+++ b/generator/src/main/kotlin/io/github/kikin81/atproto/generator/tools/LexiconDriftDetect.kt
@@ -1,0 +1,250 @@
+package io.github.kikin81.atproto.generator.tools
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardOpenOption
+import java.time.Duration
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+import java.util.TreeMap
+import kotlin.io.path.exists
+import kotlin.system.exitProcess
+
+/**
+ * Detects upstream lexicon drift against `generator/lexicons.json`.
+ *
+ * Compares NSIDs declared in this repo's manifest against the
+ * `bluesky-social/atproto` upstream lexicon corpus at main, and reports:
+ *   - new upstream NSIDs not yet in our manifest (coverage gap)
+ *   - manifest NSIDs no longer present upstream (deprecations / renames)
+ *
+ * Runnable locally (prints a markdown report to stdout) and from
+ * `.github/workflows/lexicon-drift-detect.yaml` (writes `has_drift`,
+ * counts, and `body` to `$GITHUB_OUTPUT`).
+ *
+ * Honors `GITHUB_TOKEN` — auth bumps the GitHub API rate limit from 60
+ * to 5000 req/hr. Unauthenticated also works (one call per run).
+ */
+
+private const val UPSTREAM_TREE_URL =
+    "https://api.github.com/repos/bluesky-social/atproto/git/trees/main?recursive=1"
+
+private val json = Json { ignoreUnknownKeys = true }
+
+@Serializable
+internal data class TreeResponse(
+    val tree: List<TreeEntry> = emptyList(),
+    val truncated: Boolean = false,
+)
+
+@Serializable
+internal data class TreeEntry(val path: String, val type: String = "")
+
+@Serializable
+internal data class Manifest(val lexicons: List<String> = emptyList())
+
+internal fun parseUpstreamNsids(treeJson: String): Set<String> {
+    val parsed = json.decodeFromString<TreeResponse>(treeJson)
+    if (parsed.truncated) {
+        System.err.println(
+            "WARNING: upstream tree response truncated; " +
+                "drift report may miss NSIDs",
+        )
+    }
+    return parsed.tree.asSequence()
+        .filter { it.path.startsWith("lexicons/") && it.path.endsWith(".json") }
+        .map {
+            it.path.removePrefix("lexicons/").removeSuffix(".json").replace('/', '.')
+        }
+        .filterNot { it.endsWith(".defs") }
+        .toSet()
+}
+
+internal fun parseManifestNsids(manifestJson: String): Set<String> = json.decodeFromString<Manifest>(manifestJson).lexicons.toSet()
+
+internal fun isSubscription(nsid: String): Boolean = nsid.substringAfterLast('.').startsWith("subscribe")
+
+/**
+ * Groups NSIDs by namespace.
+ *
+ * 4+ segment NSIDs (e.g. `app.bsky.feed.getTimeline`) bucket by their
+ * first three segments. 3-segment NSIDs (e.g. `app.bsky.authFullApp`
+ * OAuth scope tokens) bucket at the 2-segment level so they group
+ * together instead of each producing a solo bucket.
+ */
+internal fun bucketByNamespace(nsids: Set<String>): Map<String, List<String>> {
+    val grouped = nsids.groupBy { nsid ->
+        val parts = nsid.split('.')
+        when {
+            parts.size >= 4 -> parts.take(3).joinToString(".")
+            parts.size > 1 -> parts.dropLast(1).joinToString(".")
+            else -> nsid
+        }
+    }
+    return TreeMap<String, List<String>>().apply { putAll(grouped) }
+}
+
+private val timestampFormatter: DateTimeFormatter =
+    DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm 'UTC'")
+
+internal fun renderReport(
+    newNsids: Set<String>,
+    removedNsids: Set<String>,
+    now: OffsetDateTime,
+): String = buildString {
+    appendLine(
+        "_Generated ${timestampFormatter.format(now)} by " +
+            "`.github/workflows/lexicon-drift-detect.yaml`._",
+    )
+    appendLine()
+    appendLine(
+        "Compares `generator/lexicons.json` against " +
+            "[`bluesky-social/atproto@main`]" +
+            "(https://github.com/bluesky-social/atproto/tree/main/lexicons).",
+    )
+    appendLine()
+
+    appendLine("## New upstream NSIDs (${newNsids.size})")
+    appendLine()
+    if (newNsids.isEmpty()) {
+        appendLine("_(none — manifest is current with upstream.)_")
+        appendLine()
+    } else {
+        val (subs, regular) = newNsids.partition(::isSubscription)
+        if (subs.isNotEmpty()) {
+            appendLine(
+                "### Subscription type (${subs.size}) — architectural gap",
+            )
+            appendLine()
+            appendLine(
+                "These are `type=subscription` lexicons. The generator " +
+                    "currently skips them; adding requires runtime WebSocket " +
+                    "transport (tracking: `kikinlex-0j8`).",
+            )
+            appendLine()
+            for (nsid in subs.sorted()) appendLine("- `$nsid`")
+            appendLine()
+        }
+        if (regular.isNotEmpty()) {
+            for ((ns, members) in bucketByNamespace(regular.toSet())) {
+                appendLine("### `$ns.*` (${members.size})")
+                appendLine()
+                for (nsid in members.sorted()) appendLine("- `$nsid`")
+                appendLine()
+            }
+        }
+    }
+
+    appendLine("## Manifest NSIDs missing from upstream (${removedNsids.size})")
+    appendLine()
+    appendLine(
+        "NSIDs we list that no longer exist in `bluesky-social/atproto`. " +
+            "Possible deprecation, rename, or non-Bluesky publisher. " +
+            "Needs human triage before removal from the manifest.",
+    )
+    appendLine()
+    if (removedNsids.isEmpty()) {
+        appendLine("_(none — every manifest NSID exists upstream.)_")
+        appendLine()
+    } else {
+        for (nsid in removedNsids.sorted()) appendLine("- `$nsid`")
+        appendLine()
+    }
+
+    appendLine("---")
+    appendLine()
+    append(
+        "**Triage note.** Not every upstream NSID is a target for this SDK. " +
+            "Namespaces typically intentionally out of scope: `tools.ozone.*` " +
+            "(moderation tooling), `com.atproto.admin.*` (PDS-operator surface), " +
+            "`com.atproto.temp.*` (deprecated/internal), `app.bsky.unspecced.*` " +
+            "(experimental, churns). When you decide to opt into a new " +
+            "namespace, append the NSIDs to `generator/lexicons.json` and run " +
+            "the regen flow.",
+    )
+}
+
+private fun fetchUpstreamTree(token: String?): String {
+    val builder = HttpRequest.newBuilder()
+        .uri(URI.create(UPSTREAM_TREE_URL))
+        .timeout(Duration.ofSeconds(30))
+        .header("Accept", "application/vnd.github+json")
+        .header("User-Agent", "kikinlex-lexicon-drift-detect")
+        .GET()
+    if (!token.isNullOrEmpty()) builder.header("Authorization", "Bearer $token")
+    val client = HttpClient.newBuilder()
+        .connectTimeout(Duration.ofSeconds(15))
+        .build()
+    val response = client.send(builder.build(), HttpResponse.BodyHandlers.ofString())
+    check(response.statusCode() == 200) {
+        "GitHub API returned ${response.statusCode()}: ${response.body().take(200)}"
+    }
+    return response.body()
+}
+
+private fun emitActionsOutputs(
+    outputFile: Path,
+    body: String,
+    hasDrift: Boolean,
+    newCount: Int,
+    removedCount: Int,
+) {
+    val delim = "EOF_drift_body_marker"
+    val payload = buildString {
+        append("has_drift=").append(if (hasDrift) "true" else "false").append('\n')
+        append("new_count=").append(newCount).append('\n')
+        append("removed_count=").append(removedCount).append('\n')
+        append("body<<").append(delim).append('\n')
+        append(body)
+        append('\n').append(delim).append('\n')
+    }
+    Files.writeString(
+        outputFile,
+        payload,
+        StandardOpenOption.CREATE,
+        StandardOpenOption.APPEND,
+    )
+}
+
+/**
+ * CLI entry point: `java -jar generator.jar <manifestPath?>`.
+ *
+ * If no manifest path is given, defaults to `generator/lexicons.json`
+ * relative to the working directory (the layout when invoked via
+ * `./gradlew :generator:detectLexiconDrift` from the repo root).
+ */
+public fun main(args: Array<String>) {
+    val manifestPath =
+        if (args.isNotEmpty()) Path.of(args[0]) else Path.of("generator/lexicons.json")
+    if (!manifestPath.exists()) {
+        System.err.println("manifest not found: $manifestPath")
+        exitProcess(2)
+    }
+
+    val upstream = parseUpstreamNsids(fetchUpstreamTree(System.getenv("GITHUB_TOKEN")))
+    val manifest = parseManifestNsids(Files.readString(manifestPath))
+    val newNsids = upstream - manifest
+    val removedNsids = manifest - upstream
+    val hasDrift = newNsids.isNotEmpty() || removedNsids.isNotEmpty()
+    val body =
+        renderReport(newNsids, removedNsids, OffsetDateTime.now(ZoneOffset.UTC))
+
+    println(body)
+
+    System.getenv("GITHUB_OUTPUT")?.takeIf { it.isNotEmpty() }?.let { outFilePath ->
+        emitActionsOutputs(
+            Path.of(outFilePath),
+            body,
+            hasDrift,
+            newNsids.size,
+            removedNsids.size,
+        )
+    }
+}

--- a/generator/src/test/kotlin/io/github/kikin81/atproto/generator/tools/LexiconDriftDetectTest.kt
+++ b/generator/src/test/kotlin/io/github/kikin81/atproto/generator/tools/LexiconDriftDetectTest.kt
@@ -1,0 +1,190 @@
+package io.github.kikin81.atproto.generator.tools
+
+import java.time.OffsetDateTime
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class LexiconDriftDetectTest {
+
+    private val fixedNow: OffsetDateTime = OffsetDateTime.parse("2026-05-14T12:00:00Z")
+
+    @Test
+    fun `isSubscription matches the upstream subscribe prefix on leaves`() {
+        assertTrue(isSubscription("com.atproto.sync.subscribeRepos"))
+        assertTrue(isSubscription("com.atproto.label.subscribeLabels"))
+        assertTrue(isSubscription("chat.bsky.moderation.subscribeModEvents"))
+    }
+
+    @Test
+    fun `isSubscription rejects non-subscription leaves`() {
+        assertFalse(isSubscription("app.bsky.feed.getTimeline"))
+        assertFalse(isSubscription("com.atproto.repo.createRecord"))
+        assertFalse(isSubscription("app.bsky.actor.profile"))
+    }
+
+    @Test
+    fun `bucketByNamespace groups 4-segment NSIDs by first three segments`() {
+        val nsids = setOf(
+            "app.bsky.feed.getTimeline",
+            "app.bsky.feed.like",
+            "app.bsky.actor.profile",
+        )
+
+        val buckets = bucketByNamespace(nsids)
+
+        assertEquals(setOf("app.bsky.actor", "app.bsky.feed"), buckets.keys)
+        assertEquals(
+            listOf("app.bsky.feed.getTimeline", "app.bsky.feed.like"),
+            buckets.getValue("app.bsky.feed").sorted(),
+        )
+        assertEquals(
+            listOf("app.bsky.actor.profile"),
+            buckets.getValue("app.bsky.actor"),
+        )
+    }
+
+    @Test
+    fun `bucketByNamespace groups 3-segment OAuth scope leaves at the parent level`() {
+        // app.bsky.authFullApp etc. are scope token NSIDs with only 3 segments —
+        // they should group at `app.bsky`, not produce a solo bucket each.
+        val nsids = setOf(
+            "app.bsky.authFullApp",
+            "app.bsky.authCreatePosts",
+            "app.bsky.authViewAll",
+        )
+
+        val buckets = bucketByNamespace(nsids)
+
+        assertEquals(setOf("app.bsky"), buckets.keys)
+        assertEquals(3, buckets.getValue("app.bsky").size)
+    }
+
+    @Test
+    fun `bucketByNamespace returns a sorted map for deterministic output`() {
+        val nsids = setOf(
+            "com.atproto.repo.createRecord",
+            "app.bsky.feed.getTimeline",
+            "chat.bsky.convo.sendMessage",
+        )
+
+        val keys = bucketByNamespace(nsids).keys.toList()
+
+        assertEquals(
+            listOf("app.bsky.feed", "chat.bsky.convo", "com.atproto.repo"),
+            keys,
+        )
+    }
+
+    @Test
+    fun `parseUpstreamNsids extracts NSIDs from the GitHub tree response`() {
+        val payload = """
+            {
+              "tree": [
+                {"path": "lexicons/app/bsky/feed/getTimeline.json", "type": "blob"},
+                {"path": "lexicons/app/bsky/feed/post.json", "type": "blob"},
+                {"path": "lexicons/com/atproto/sync/subscribeRepos.json", "type": "blob"}
+              ],
+              "truncated": false
+            }
+        """.trimIndent()
+
+        val result = parseUpstreamNsids(payload)
+
+        assertEquals(
+            setOf(
+                "app.bsky.feed.getTimeline",
+                "app.bsky.feed.post",
+                "com.atproto.sync.subscribeRepos",
+            ),
+            result,
+        )
+    }
+
+    @Test
+    fun `parseUpstreamNsids skips defs files and non-lexicon paths`() {
+        val payload = """
+            {
+              "tree": [
+                {"path": "lexicons/app/bsky/feed/getTimeline.json", "type": "blob"},
+                {"path": "lexicons/app/bsky/feed/defs.json", "type": "blob"},
+                {"path": "lexicons/README.md", "type": "blob"},
+                {"path": "lexicons/app/bsky/feed", "type": "tree"},
+                {"path": "package.json", "type": "blob"}
+              ]
+            }
+        """.trimIndent()
+
+        assertEquals(setOf("app.bsky.feed.getTimeline"), parseUpstreamNsids(payload))
+    }
+
+    @Test
+    fun `parseManifestNsids reads the lexicons array and ignores resolutions`() {
+        val payload = """
+            {
+              "version": 1,
+              "lexicons": [
+                "app.bsky.feed.getTimeline",
+                "com.atproto.repo.createRecord"
+              ],
+              "resolutions": {
+                "app.bsky.feed.getTimeline": {
+                  "uri": "at://did:plc:xxx/com.atproto.lexicon.schema/app.bsky.feed.getTimeline",
+                  "cid": "bafy..."
+                }
+              }
+            }
+        """.trimIndent()
+
+        assertEquals(
+            setOf("app.bsky.feed.getTimeline", "com.atproto.repo.createRecord"),
+            parseManifestNsids(payload),
+        )
+    }
+
+    @Test
+    fun `renderReport produces the no-drift body when both sets are empty`() {
+        val body = renderReport(emptySet(), emptySet(), fixedNow)
+
+        assertContains(body, "_Generated 2026-05-14 12:00 UTC")
+        assertContains(body, "## New upstream NSIDs (0)")
+        assertContains(body, "_(none — manifest is current with upstream.)_")
+        assertContains(body, "## Manifest NSIDs missing from upstream (0)")
+        assertContains(body, "_(none — every manifest NSID exists upstream.)_")
+    }
+
+    @Test
+    fun `renderReport separates subscription NSIDs from regular NSIDs`() {
+        val newNsids = setOf(
+            "com.atproto.sync.subscribeRepos",
+            "chat.bsky.moderation.subscribeModEvents",
+            "app.bsky.bookmark.createBookmark",
+            "app.bsky.bookmark.deleteBookmark",
+        )
+
+        val body = renderReport(newNsids, emptySet(), fixedNow)
+
+        assertContains(body, "### Subscription type (2) — architectural gap")
+        assertContains(body, "- `com.atproto.sync.subscribeRepos`")
+        assertContains(body, "- `chat.bsky.moderation.subscribeModEvents`")
+        assertContains(body, "### `app.bsky.bookmark.*` (2)")
+        assertContains(body, "- `app.bsky.bookmark.createBookmark`")
+    }
+
+    @Test
+    fun `renderReport renders removed NSIDs section with sorted entries`() {
+        val removed = setOf(
+            "com.atproto.legacy.deprecated",
+            "app.bsky.old.thing",
+        )
+
+        val body = renderReport(emptySet(), removed, fixedNow)
+
+        assertContains(body, "## Manifest NSIDs missing from upstream (2)")
+        val appIdx = body.indexOf("app.bsky.old.thing")
+        val comIdx = body.indexOf("com.atproto.legacy.deprecated")
+        assertTrue(appIdx in 0 until comIdx, "removed entries should be sorted")
+    }
+}


### PR DESCRIPTION
Tracking: `kikinlex-yb8` (beads). Companion to `kikinlex-46v` (already shipped as `lexicon-bump.yaml`).

> _Force-pushed_: original draft used a Python script in `scripts/`. Rewritten in Kotlin per repo convention — spotless/ktlint coverage, unit tests, reuses `:generator`'s existing kotlinx-serialization. No new runtime deps (uses JDK 17 `java.net.http.HttpClient`).

## Summary

Adds a scheduled workflow that detects **new upstream NSIDs not in our manifest** — the gap that `lexicon-bump.yaml` can't see, since `lex install --update` only re-resolves NSIDs already declared in `lexicons.json`.

- `.github/workflows/lexicon-drift-detect.yaml` — schedule Mondays 13:00 UTC (one hour before `lexicon-bump` at 14:00 UTC) + `workflow_dispatch`. Maintains a single `lexicon-drift`-labeled tracking issue: creates on first drift, edits body in place on subsequent drift, auto-closes when the manifest catches up.
- `generator/src/main/kotlin/.../tools/LexiconDriftDetect.kt` — the detector. Fetches upstream's `lexicons/` tree via the GitHub `git/trees` API, diffs against `generator/lexicons.json`, separates `type=subscription` gaps from regular ones, buckets by namespace.
- `:generator:detectLexiconDrift` Gradle task (`JavaExec`) — runs the detector. Workflow invokes via `./gradlew :generator:detectLexiconDrift --quiet`.
- Unit tests under `generator/src/test/.../tools/LexiconDriftDetectTest.kt` covering: `parseUpstreamNsids` (defs.json filtering, non-lexicon paths, sub-NSID extraction), `parseManifestNsids` (resolutions section ignored), `isSubscription` (positive + negative leaves), `bucketByNamespace` (4-segment grouping, 3-segment OAuth scope edge case, sort order), `renderReport` (no-drift body, subscription/regular split, removed section sort).

## Why

The manual audit I ran earlier today found **230 new upstream NSIDs** (`app.bsky.bookmark`, `app.bsky.draft`, `app.bsky.contact`, `app.bsky.ageassurance`, all of `chat.bsky.group`, etc.) that have been accumulating invisibly. This workflow surfaces them proactively.

The auto-close behavior means the tracking issue is a live status indicator: closed → manifest matches upstream; open → body lists what's new.

## What the report looks like

Output of `./gradlew :generator:detectLexiconDrift --quiet` against today's state (truncated):

```
## New upstream NSIDs (230)

### Subscription type (3) — architectural gap
- `chat.bsky.moderation.subscribeModEvents`
- `com.atproto.label.subscribeLabels`
- `com.atproto.sync.subscribeRepos`

### `app.bsky.*` (9)
- `app.bsky.authCreatePosts`
- ...

### `app.bsky.bookmark.*` (3)
- `app.bsky.bookmark.createBookmark`
- ...

### `chat.bsky.group.*` (13)
- `chat.bsky.group.addMembers`
- ...
```

## Test plan

- [x] `./gradlew :generator:test` — 11 unit tests in `LexiconDriftDetectTest`, all passing.
- [x] `./gradlew :generator:detectLexiconDrift --quiet` — locally produces the expected drift report against the current manifest.
- [x] `./gradlew spotlessCheck apiCheck :runtime:jvmTest :generator:test :samples:android:testDebugUnitTest :runtime:compileKotlinJvm :models:compileKotlinJvm :samples:android:assembleDebug` — passes (CI-equivalent matrix).
- [x] `pre-commit run` on all changed files — ktlint, yamllint, actionlint all green.
- [ ] First production run will land on next Monday's schedule (or manual `workflow_dispatch` to trigger sooner).

## Notes

- Permissions: `contents: read` + `issues: write`. Uses `GITHUB_TOKEN`, no PAT needed.
- Concurrency-guarded so manual + scheduled runs can't race on issue creation.
- The label `lexicon-drift` is created idempotently via `gh label create --force`.
- The Gradle task opts out of up-to-date caching (`outputs.upToDateWhen { false }`) — drift detection always reaches the network for an authoritative diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)