### PR TITLE
ci: drop GITHUB_TOKEN from lexicon-drift-detect Gradle step

### DIFF
--- a/.github/workflows/lexicon-drift-detect.yaml
+++ b/.github/workflows/lexicon-drift-detect.yaml
@@ -59,8 +59,12 @@ jobs:
 
       - name: Run drift detection
         id: detect
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # GITHUB_TOKEN intentionally NOT exposed here. The detector makes
+        # one HTTPS request per run against a public bluesky-social/atproto
+        # endpoint; unauthenticated GitHub API allows 60/hr per runner IP,
+        # which is comfortably above our weekly cadence. Keeping the token
+        # scoped to the gh-issue-management steps below means the JVM
+        # process can't leak a credential it doesn't have.
         run: ./gradlew :generator:detectLexiconDrift --quiet --no-configuration-cache
 
       - name: Find existing drift issue


### PR DESCRIPTION
Tracking: `kikinlex-c91` (beads). Follow-up to #96 (security tightening).

## Summary

Removes `GITHUB_TOKEN` from the `Run drift detection` step's `env:` block. The token stays attached to the issue-management steps below where `issues: write` is actually exercised.

## Why

The detector only used `GITHUB_TOKEN` to bump the GitHub API rate limit from 60 to 5000/hr — but we make **one** HTTPS request per weekly run, against a **public-repo** endpoint. Unauthenticated rate limit is 60/hr per runner IP, comfortably above our cadence.

Removing the env block scopes credentials to the steps that actually need them. If the JVM dep chain ever has a credential-exfiltration bug, the blast radius is "no token in process memory" instead of "attacker has a `contents: read + issues: write` token for the org."

## Verification

```
$ env -u GITHUB_TOKEN ./gradlew :generator:detectLexiconDrift --quiet
_Generated 2026-05-14 17:58 UTC by ...
## New upstream NSIDs (230)
### Subscription type (3) — architectural gap
...
```

Unauthenticated request to the public tree endpoint succeeds; full report unchanged.

## Test plan

- [x] `env -u GITHUB_TOKEN ./gradlew :generator:detectLexiconDrift --quiet` — produces expected output.
- [x] `pre-commit run` on the workflow file (actionlint, yamllint) — passes.
- [ ] Post-merge: trigger via `gh workflow run "Lexicon drift detection"` and confirm the step succeeds with no token in env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)