### PR TITLE
fix(samples,android): suppress Hilt Instantiatable false-positive + wire lint into CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -126,3 +126,9 @@ jobs:
 
       - name: Build Android sample APK
         run: ./gradlew :samples:android:assembleDebug
+
+      # Catches Android Lint regressions (Instantiatable, NewApi, accessibility,
+      # etc.) on :samples:android. Kept here rather than in the Lint job because
+      # this job has the Android SDK + lexicon corpus already set up.
+      - name: Android sample lint
+        run: ./gradlew :samples:android:lintDebug

--- a/samples/android/src/main/AndroidManifest.xml
+++ b/samples/android/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
 
@@ -11,12 +12,20 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.BlueskySample">
+        <!--
+            tools:ignore="Instantiatable" suppresses a Hilt-related false
+            positive: MainActivity extends ComponentActivity (which extends
+            android.app.Activity transitively), but @AndroidEntryPoint triggers
+            a bytecode rewrite to a generated Hilt_MainActivity superclass, and
+            Lint's pre-transform analysis can't follow the chain.
+        -->
         <activity
             android:name=".MainActivity"
             android:exported="true"
             android:launchMode="singleTask"
             android:theme="@style/Theme.BlueskySample"
-            android:windowSoftInputMode="adjustResize">
+            android:windowSoftInputMode="adjustResize"
+            tools:ignore="Instantiatable">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />


### PR DESCRIPTION
Tracking: `kikinlex-rs0` (beads).

## Summary

Two changes, one bug class. The Hilt-induced false-positive on `MainActivity` has been quietly failing local `./gradlew build` runs — and CI never noticed because CI didn't run Android Lint at all.

### 1. Suppress the Instantiatable false-positive

`MainActivity` extends `androidx.activity.ComponentActivity`, which inherits from `android.app.Activity` transitively. But `@AndroidEntryPoint` triggers a Hilt bytecode rewrite that injects a generated `Hilt_MainActivity` superclass. Android Lint's `Instantiatable` check runs on pre-transform sources and can't follow the inheritance chain through the synthetic class, so it reports:

```
samples/android/src/main/AndroidManifest.xml:15: Error: MainActivity must extend android.app.Activity [Instantiatable]
            android:name=".MainActivity"
                          ~~~~~~~~~~~~~
```

Fix: `tools:ignore="Instantiatable"` on the `<activity>` element with an inline comment explaining the root cause. Element-scoped suppression so future activity registrations still get the full `Instantiatable` check.

### 2. Wire `:samples:android:lintDebug` into the CI Build job

The CI workflow previously ran `spotlessCheck`, `:runtime:jvmTest`, `:generator:test`, `:samples:android:testDebugUnitTest`, `apiCheck`, `:runtime:compileKotlinJvm`, `:models:compileKotlinJvm`, `:samples:android:assembleDebug` — **but no Android Lint**. That's exactly why this false-positive sat indefinitely: CI green, `./gradlew build` broken locally, only surfaced when a developer hit it manually.

New step added to the Build job (which already has the Android SDK + lexicon corpus prerequisites in place):

```yaml
- name: Android sample lint
  run: ./gradlew :samples:android:lintDebug
```

Future lint regressions on `:samples:android` (NewApi, accessibility, Instantiatable, etc.) now fail CI loud instead of accumulating silently.

## Test plan

- [x] `./gradlew :samples:android:lintDebug` — BUILD SUCCESSFUL (was FAILED with `Instantiatable` before fix #1).
- [x] `./gradlew build` — BUILD SUCCESSFUL in 1m 43s. The full local build that was previously broken now works.
- [x] `pre-commit run --files .github/workflows/ci.yaml samples/android/src/main/AndroidManifest.xml` — actionlint, yamllint, etc. all pass.
- [ ] CI run on this PR is itself the integration test for change #2 — the new lint step should appear in the Build job and pass.

## Cascading cleanup once merged

- Close `kikinlex-orp` (docs note about the local-only build failure) — the docs workaround is no longer needed; the bug class is fixed and CI-enforced.
- The bd memory `don-t-use-gradlew-build-to-verify-locally`'s "don't" warning becomes obsolete (the targeted CI task list it documents is still useful trivia, but no longer required).

🤖 Generated with [Claude Code](https://claude.com/claude-code)