### PR TITLE
feat(runtime): add Datetime.toInstant() / toInstantOrNull() extensions

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 kotlin = "2.3.21"
 kotlinx-coroutines = "1.11.0"
+kotlinx-datetime = "0.6.1"
 kotlinx-serialization = "1.11.0"
 ktor = "3.5.0"
 kotlinpoet = "2.3.0"
@@ -29,6 +30,7 @@ coil = "2.7.0"
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
 kotlinx-serialization-core = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", version.ref = "kotlinx-serialization" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
+kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinx-datetime" }
 kotlin-test-junit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }
 
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }

--- a/runtime/api/runtime.api
+++ b/runtime/api/runtime.api
@@ -460,6 +460,11 @@ public final class io/github/kikin81/atproto/runtime/RecordKey$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class io/github/kikin81/atproto/runtime/StringFormatsKt {
+	public static final fun toInstant-Xa6jipg (Ljava/lang/String;)Lkotlinx/datetime/Instant;
+	public static final fun toInstantOrNull-Xa6jipg (Ljava/lang/String;)Lkotlinx/datetime/Instant;
+}
+
 public final class io/github/kikin81/atproto/runtime/Tid {
 	public static final field Companion Lio/github/kikin81/atproto/runtime/Tid$Companion;
 	public static final synthetic fun box-impl (Ljava/lang/String;)Lio/github/kikin81/atproto/runtime/Tid;

--- a/runtime/build.gradle.kts
+++ b/runtime/build.gradle.kts
@@ -37,6 +37,7 @@ kotlin {
         commonMain.dependencies {
             api(libs.kotlinx.serialization.core)
             api(libs.kotlinx.serialization.json)
+            api(libs.kotlinx.datetime)
             api(libs.ktor.client.core)
             api(libs.ktor.client.content.negotiation)
             api(libs.ktor.serialization.kotlinx.json)

--- a/runtime/src/commonMain/kotlin/io/github/kikin81/atproto/runtime/StringFormats.kt
+++ b/runtime/src/commonMain/kotlin/io/github/kikin81/atproto/runtime/StringFormats.kt
@@ -1,5 +1,6 @@
 package io.github.kikin81.atproto.runtime
 
+import kotlinx.datetime.Instant
 import kotlinx.serialization.Serializable
 import kotlin.jvm.JvmInline
 
@@ -57,6 +58,34 @@ public value class Tid(public val raw: String)
 @JvmInline
 @Serializable
 public value class Datetime(public val raw: String)
+
+/**
+ * Parse this AT Protocol [Datetime] as a [kotlinx.datetime.Instant].
+ *
+ * The AT Protocol spec requires `datetime` values to be valid RFC 3339
+ * timestamps with timezone, so this rarely throws for server-emitted
+ * records. Throws [IllegalArgumentException] (via [Instant.parse]) if
+ * `raw` is malformed — typically because the value was constructed
+ * locally rather than received over the wire.
+ *
+ * @see toInstantOrNull for the non-throwing variant.
+ */
+public fun Datetime.toInstant(): Instant = Instant.parse(raw)
+
+/**
+ * Parse this AT Protocol [Datetime] as a [kotlinx.datetime.Instant],
+ * returning `null` on malformed input instead of throwing.
+ *
+ * Prefer this when reading [Datetime] values that may have been
+ * constructed locally or sourced from an untrusted producer. For
+ * server-emitted records prefer [toInstant], which surfaces malformed
+ * data as a programming error.
+ */
+public fun Datetime.toInstantOrNull(): Instant? = try {
+    Instant.parse(raw)
+} catch (_: IllegalArgumentException) {
+    null
+}
 
 /** A BCP-47 language tag. Format: `language`. */
 @JvmInline

--- a/runtime/src/commonTest/kotlin/io/github/kikin81/atproto/runtime/StringFormatsTest.kt
+++ b/runtime/src/commonTest/kotlin/io/github/kikin81/atproto/runtime/StringFormatsTest.kt
@@ -1,9 +1,12 @@
 package io.github.kikin81.atproto.runtime
 
+import kotlinx.datetime.Instant
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.json.Json
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
 
 class StringFormatsTest {
 
@@ -45,4 +48,48 @@ class StringFormatsTest {
     @Test fun language_roundTrip() = assertRoundTrip(Language.serializer(), Language("en-US"), "\"en-US\"")
 
     @Test fun uri_roundTrip() = assertRoundTrip(Uri.serializer(), Uri("https://example.com/thing"), "\"https://example.com/thing\"")
+
+    @Test fun datetime_toInstant_parsesZuluLiteral() {
+        val parsed = Datetime("2026-04-13T12:34:56Z").toInstant()
+        assertEquals(Instant.parse("2026-04-13T12:34:56Z"), parsed)
+    }
+
+    @Test fun datetime_toInstant_parsesFractionalSeconds() {
+        val parsed = Datetime("2026-04-13T12:34:56.789Z").toInstant()
+        assertEquals(Instant.parse("2026-04-13T12:34:56.789Z"), parsed)
+    }
+
+    @Test fun datetime_toInstant_parsesOffsetTimezone() {
+        // RFC 3339 accepts a numeric offset in place of 'Z' — same instant,
+        // different on-the-wire form.
+        val parsed = Datetime("2026-04-13T05:34:56-07:00").toInstant()
+        assertEquals(Instant.parse("2026-04-13T12:34:56Z"), parsed)
+    }
+
+    @Test fun datetime_toInstant_throwsOnMalformedInput() {
+        assertFailsWith<IllegalArgumentException> {
+            Datetime("not a timestamp").toInstant()
+        }
+    }
+
+    @Test fun datetime_toInstantOrNull_returnsParsedOnValidInput() {
+        val parsed = Datetime("2026-04-13T12:34:56.789Z").toInstantOrNull()
+        assertEquals(Instant.parse("2026-04-13T12:34:56.789Z"), parsed)
+    }
+
+    @Test fun datetime_toInstantOrNull_returnsNullOnMalformedInput() {
+        assertNull(Datetime("not a timestamp").toInstantOrNull())
+        assertNull(Datetime("").toInstantOrNull())
+        // Missing required timezone — RFC 3339 violation.
+        assertNull(Datetime("2026-04-13T12:34:56").toInstantOrNull())
+    }
+
+    @Test fun datetime_toInstant_roundTripsViaInstantToString() {
+        // Datetime → Instant → wire string → Datetime preserves the instant
+        // (formatting may normalize, but the moment in time is the same).
+        val original = Datetime("2026-04-13T12:34:56.000Z")
+        val instant = original.toInstant()
+        val reconstructed = Datetime(instant.toString()).toInstant()
+        assertEquals(instant, reconstructed)
+    }
 }


### PR DESCRIPTION
Closes #21. Tracking: `kikinlex-dmk`.

## Summary

Adds two extension functions on the `Datetime` value class (`runtime/src/commonMain/.../StringFormats.kt`) so consumers can convert AT Protocol RFC 3339 timestamps to `kotlinx.datetime.Instant` without re-parsing at every call site:

```kotlin
public fun Datetime.toInstant(): Instant
public fun Datetime.toInstantOrNull(): Instant?
```

- `toInstant()` — throws `IllegalArgumentException` on malformed input. Prefer for server-emitted records, where the AT Protocol spec guarantees well-formed datetimes; malformed data is a programming error worth surfacing.
- `toInstantOrNull()` — returns `null` on malformed input. Prefer for locally-constructed `Datetime` values or untrusted producers.

## Why

Filed by the nubecita team while implementing relative-time formatting for feed / profile / notification timestamps. Without these helpers, every consumer that wants to *do* anything time-related (sort, format relative-time, age calc, expiry check) reaches into `.raw` and re-implements `Instant.parse` at every call site. The value class gives type-safety but doesn't deliver on the domain-type promise (\"this thing is an RFC 3339 timestamp; the SDK knows how to interpret it\").

## Dependency

`kotlinx-datetime` 0.6.1 added as an `api`-scoped commonMain dependency on `:runtime`, so the `Instant` type appears transitively for consumers. Acceptable cost: `kotlinx-datetime` is a stable KMP dep used throughout the ecosystem; downstream apps almost certainly already pull it in.

## Binary compatibility

Purely additive — one new public top-level container class `StringFormatsKt` with two static functions. `:runtime:apiDump` refreshed. Zero removals.

## Test plan

- [x] `./gradlew :runtime:jvmTest --tests '*StringFormatsTest*'` — 18 tests pass (11 existing + 7 new).
- [x] New tests cover: valid Zulu literal, fractional seconds, RFC 3339 numeric-offset timezone, malformed input (both throwing and null-returning variants), and round-trip via `Instant.toString`.
- [x] `./gradlew spotlessCheck apiCheck :runtime:jvmTest :generator:test :samples:android:testDebugUnitTest :runtime:compileKotlinJvm :models:compileKotlinJvm :samples:android:assembleDebug :samples:android:lintDebug` — passes (CI-equivalent matrix, including the new lint step from #99).

🤖 Generated with [Claude Code](https://claude.com/claude-code)