### PR TITLE
fix(oauth): require redirectUri parameter on AtOAuth constructor

### DIFF
--- a/docs/breaking-changes/v7.md
+++ b/docs/breaking-changes/v7.md
@@ -1,0 +1,130 @@
+# Breaking changes — v7.0.0
+
+## Summary
+
+`AtOAuth` now requires consumers to declare their OAuth `redirect_uri`
+at construction. Prior versions hardcoded the value to a placeholder
+(`io.github.kikin81:/oauth-redirect`) — a never-finished stub whose
+KDoc explicitly told consumers to "override or configure" it, but
+which exposed no override hook. Any consumer whose hosted
+`client-metadata.json` declared a different `redirect_uris[]` was
+rejected by the authorization server at PAR time with
+HTTP 400 `invalid_request: invalid redirect_uri`.
+
+**Source-level migration is required for every `AtOAuth` consumer**:
+add the new `redirectUri` argument to the constructor call.
+
+## What changed
+
+### OAuth — `AtOAuth`
+
+A new required parameter `redirectUri: String` was added to the
+`AtOAuth` constructor, in second position (immediately after
+`clientMetadataUrl`). The value is sent verbatim as the
+`redirect_uri` form parameter in PAR and reused unchanged during the
+token-exchange step. The library performs no transformation — what
+you pass is what hits the wire, and it must match an entry in your
+hosted `client-metadata.json`'s `redirect_uris[]` array exactly.
+
+| Class | Before | After |
+|---|---|---|
+| `AtOAuth` | `AtOAuth(clientMetadataUrl, sessionStore, httpClient, json, scope)` | `AtOAuth(clientMetadataUrl, redirectUri, sessionStore, httpClient, json, scope)` |
+
+The internal `extractRedirectUri()` placeholder method was deleted.
+
+### Behavioral change (bug fix)
+
+In v6.x and earlier, `AtOAuth.beginLogin(handle)` against any
+authorization server that actually validates the redirect_uri (i.e.
+all real-world servers, including `bsky.social`) would fail with:
+
+```
+PAR retry failed with HTTP 400:
+{"error":"invalid_request","error_description":"invalid redirect_uri \"io.github.kikin81:/oauth-redirect\""}
+```
+
+In v7.0.0 the same call succeeds when given a `redirectUri` that
+matches one of the entries in the consumer's published client
+metadata. Consumers that accidentally relied on the placeholder
+matching their metadata document (i.e. they happened to register
+`io.github.kikin81:/oauth-redirect` themselves) must switch to
+their own reverse-FQDN value per the AT Protocol Discoverable
+Client rule.
+
+## How to migrate
+
+### 1. Bump the dependency
+
+**Gradle Kotlin DSL:**
+
+```kotlin
+// before
+implementation("io.github.kikin81.atproto:oauth:6.x.x")
+
+// after
+implementation("io.github.kikin81.atproto:oauth:7.0.0")
+```
+
+### 2. Add `redirectUri` to your `AtOAuth(...)` call
+
+The value must equal one of the strings in your hosted
+`client-metadata.json`'s `redirect_uris[]` array. For native Android
+consumers, this is typically a reverse-FQDN custom-scheme URI that
+also matches an `<intent-filter>` deep link registered on your
+authorization activity.
+
+```kotlin
+// before (v6)
+val oauth = AtOAuth(
+    clientMetadataUrl = "https://app.example.com/oauth/client-metadata.json",
+    sessionStore = mySessionStore,
+    httpClient = myKtorClient,
+)
+
+// after (v7)
+val oauth = AtOAuth(
+    clientMetadataUrl = "https://app.example.com/oauth/client-metadata.json",
+    redirectUri = "app.example:/oauth-redirect",
+    sessionStore = mySessionStore,
+    httpClient = myKtorClient,
+)
+```
+
+Matching `client-metadata.json` excerpt:
+
+```json
+{
+  "client_id": "https://app.example.com/oauth/client-metadata.json",
+  "application_type": "native",
+  "redirect_uris": ["app.example:/oauth-redirect"],
+  ...
+}
+```
+
+### 3. Java callers
+
+Java does not see Kotlin's default parameter values, so explicit
+positional calls must add the new argument in the second slot:
+
+```java
+// before
+new AtOAuth(clientMetadataUrl, sessionStore, httpClient, json, scope);
+
+// after
+new AtOAuth(clientMetadataUrl, /* redirectUri */ "app.example:/oauth-redirect",
+            sessionStore, httpClient, json, scope);
+```
+
+## Why this is a major bump
+
+Adding a required (non-defaulted) parameter to a public constructor
+changes the JVM signature and the source-level call shape. Per the
+kotlinx-binary-compatibility-validator (which gates this repo at
+`:oauth:apiCheck`) and the project's existing breaking-changes
+discipline (see `v5.md`, `v6.md`), this warrants a major bump.
+
+Unlike v6's `scope` parameter — which defaulted to the previous
+behavior and only required recompilation — v7's `redirectUri` is
+required and demands a source-level edit. There is no safe default:
+the previous placeholder was broken against real authorization
+servers, so silently defaulting would re-introduce the bug.

--- a/docs/breaking-changes/v7.md
+++ b/docs/breaking-changes/v7.md
@@ -76,14 +76,14 @@ authorization activity.
 ```kotlin
 // before (v6)
 val oauth = AtOAuth(
-    clientMetadataUrl = "https://app.example.com/oauth/client-metadata.json",
+    clientMetadataUrl = "https://example.app/oauth/client-metadata.json",
     sessionStore = mySessionStore,
     httpClient = myKtorClient,
 )
 
 // after (v7)
 val oauth = AtOAuth(
-    clientMetadataUrl = "https://app.example.com/oauth/client-metadata.json",
+    clientMetadataUrl = "https://example.app/oauth/client-metadata.json",
     redirectUri = "app.example:/oauth-redirect",
     sessionStore = mySessionStore,
     httpClient = myKtorClient,
@@ -94,7 +94,7 @@ Matching `client-metadata.json` excerpt:
 
 ```json
 {
-  "client_id": "https://app.example.com/oauth/client-metadata.json",
+  "client_id": "https://example.app/oauth/client-metadata.json",
   "application_type": "native",
   "redirect_uris": ["app.example:/oauth-redirect"],
   ...

--- a/oauth/api/oauth.api
+++ b/oauth/api/oauth.api
@@ -1,6 +1,6 @@
 public final class io/github/kikin81/atproto/oauth/AtOAuth {
-	public fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/oauth/OAuthSessionStore;Lio/ktor/client/HttpClient;Lkotlinx/serialization/json/Json;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/oauth/OAuthSessionStore;Lio/ktor/client/HttpClient;Lkotlinx/serialization/json/Json;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lio/github/kikin81/atproto/oauth/OAuthSessionStore;Lio/ktor/client/HttpClient;Lkotlinx/serialization/json/Json;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lio/github/kikin81/atproto/oauth/OAuthSessionStore;Lio/ktor/client/HttpClient;Lkotlinx/serialization/json/Json;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun beginLogin (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun completeLogin (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun createClient (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/oauth/src/main/kotlin/io/github/kikin81/atproto/oauth/AtOAuth.kt
+++ b/oauth/src/main/kotlin/io/github/kikin81/atproto/oauth/AtOAuth.kt
@@ -25,6 +25,7 @@ import kotlin.io.encoding.ExperimentalEncodingApi
  * ```kotlin
  * val oauth = AtOAuth(
  *     clientMetadataUrl = "https://app.example.com/oauth/client-metadata.json",
+ *     redirectUri = "app.example:/oauth-redirect",
  *     sessionStore = mySessionStore,
  *     httpClient = myKtorClient,
  * )
@@ -48,6 +49,7 @@ import kotlin.io.encoding.ExperimentalEncodingApi
  * ```kotlin
  * val oauth = AtOAuth(
  *     clientMetadataUrl = "...",
+ *     redirectUri = "app.example:/oauth-redirect",
  *     sessionStore = ...,
  *     httpClient = ...,
  *     scope = "atproto transition:generic transition:chat.bsky",
@@ -59,6 +61,7 @@ import kotlin.io.encoding.ExperimentalEncodingApi
  */
 class AtOAuth(
     private val clientMetadataUrl: String,
+    private val redirectUri: String,
     private val sessionStore: OAuthSessionStore,
     private val httpClient: HttpClient,
     private val json: Json = Json { ignoreUnknownKeys = true },
@@ -88,7 +91,6 @@ class AtOAuth(
         val codeVerifier = Pkce.generateVerifier()
         val codeChallenge = Pkce.computeChallenge(codeVerifier)
         val state = generateState()
-        val redirectUri = extractRedirectUri()
 
         val requestUri = pushAuthorizationRequest(
             metadata = metadata,
@@ -373,13 +375,6 @@ class AtOAuth(
         }
 
         return json.decodeFromString(TokenResponse.serializer(), response.bodyAsText())
-    }
-
-    private fun extractRedirectUri(): String {
-        // For now, the redirect URI is derived from the client metadata URL's scheme.
-        // In a real app, this would come from the client metadata JSON.
-        // Placeholder: consumers should override or configure this.
-        return "io.github.kikin81:/oauth-redirect"
     }
 
     @OptIn(ExperimentalEncodingApi::class)

--- a/oauth/src/main/kotlin/io/github/kikin81/atproto/oauth/AtOAuth.kt
+++ b/oauth/src/main/kotlin/io/github/kikin81/atproto/oauth/AtOAuth.kt
@@ -24,7 +24,7 @@ import kotlin.io.encoding.ExperimentalEncodingApi
  *
  * ```kotlin
  * val oauth = AtOAuth(
- *     clientMetadataUrl = "https://app.example.com/oauth/client-metadata.json",
+ *     clientMetadataUrl = "https://example.app/oauth/client-metadata.json",
  *     redirectUri = "app.example:/oauth-redirect",
  *     sessionStore = mySessionStore,
  *     httpClient = myKtorClient,

--- a/oauth/src/test/kotlin/io/github/kikin81/atproto/oauth/AtOAuthTest.kt
+++ b/oauth/src/test/kotlin/io/github/kikin81/atproto/oauth/AtOAuthTest.kt
@@ -133,6 +133,7 @@ class AtOAuthTest {
         var parBody: String? = null
         val oauth = AtOAuth(
             clientMetadataUrl = "https://app.test/oauth/client-metadata.json",
+            redirectUri = "app.example:/oauth-redirect",
             sessionStore = store,
             httpClient = parCapturingClient { parBody = it },
         )
@@ -149,6 +150,7 @@ class AtOAuthTest {
         var parBody: String? = null
         val oauth = AtOAuth(
             clientMetadataUrl = "https://app.test/oauth/client-metadata.json",
+            redirectUri = "app.example:/oauth-redirect",
             sessionStore = store,
             httpClient = parCapturingClient { parBody = it },
             scope = "atproto transition:generic transition:chat.bsky",
@@ -161,10 +163,45 @@ class AtOAuthTest {
     }
 
     @Test
+    fun parRequestUsesProvidedRedirectUri() = runTest {
+        val store = InMemorySessionStore()
+        var parBody: String? = null
+        val oauth = AtOAuth(
+            clientMetadataUrl = "https://app.test/oauth/client-metadata.json",
+            redirectUri = "app.example:/oauth-redirect",
+            sessionStore = store,
+            httpClient = parCapturingClient { parBody = it },
+        )
+        oauth.beginLogin("alice.test")
+
+        val body = parBody
+        assertNotNull(body)
+        assertContains(body, "redirect_uri=app.example%3A%2Foauth-redirect")
+    }
+
+    @Test
+    fun redirectUriIsPassedThroughUntransformed() = runTest {
+        val store = InMemorySessionStore()
+        var parBody: String? = null
+        val oauth = AtOAuth(
+            clientMetadataUrl = "https://app.test/oauth/client-metadata.json",
+            redirectUri = "a",
+            sessionStore = store,
+            httpClient = parCapturingClient { parBody = it },
+        )
+        oauth.beginLogin("alice.test")
+
+        val body = parBody
+        assertNotNull(body)
+        assertContains(body, "redirect_uri=a&")
+    }
+
+    @Test
     fun beginLoginReturnsAuthorizationUrl() = runTest {
         val store = InMemorySessionStore()
         val oauth = AtOAuth(
             clientMetadataUrl = "https://app.test/oauth/client-metadata.json",
+            redirectUri = "app.example:/oauth-redirect",
             sessionStore = store,
             httpClient = fullFlowMockClient(),
         )
@@ -179,6 +216,7 @@ class AtOAuthTest {
         val store = InMemorySessionStore()
         val oauth = AtOAuth(
             clientMetadataUrl = "https://app.test/oauth/client-metadata.json",
+            redirectUri = "app.example:/oauth-redirect",
             sessionStore = store,
             httpClient = fullFlowMockClient(),
         )
@@ -186,7 +224,7 @@ class AtOAuthTest {
 
         // Simulate the browser redirect
         oauth.completeLogin(
-            "io.github.kikin81:/oauth-redirect?code=auth_code_123&state=${extractState(oauth)}&iss=https://auth.test",
+            "app.example:/oauth-redirect?code=auth_code_123&state=${extractState(oauth)}&iss=https://auth.test",
         )
 
         val session = store.session
@@ -203,6 +241,7 @@ class AtOAuthTest {
         val store = InMemorySessionStore()
         val oauth = AtOAuth(
             clientMetadataUrl = "https://app.test/oauth/client-metadata.json",
+            redirectUri = "app.example:/oauth-redirect",
             sessionStore = store,
             httpClient = fullFlowMockClient(),
         )
@@ -210,7 +249,7 @@ class AtOAuthTest {
 
         assertFailsWith<OAuthException> {
             oauth.completeLogin(
-                "io.github.kikin81:/oauth-redirect?code=abc&state=wrong_state&iss=https://auth.test",
+                "app.example:/oauth-redirect?code=abc&state=wrong_state&iss=https://auth.test",
             )
         }
     }
@@ -220,6 +259,7 @@ class AtOAuthTest {
         val store = InMemorySessionStore()
         val oauth = AtOAuth(
             clientMetadataUrl = "https://app.test/oauth/client-metadata.json",
+            redirectUri = "app.example:/oauth-redirect",
             sessionStore = store,
             httpClient = fullFlowMockClient(),
         )
@@ -227,7 +267,7 @@ class AtOAuthTest {
 
         assertFailsWith<OAuthException> {
             oauth.completeLogin(
-                "io.github.kikin81:/oauth-redirect?code=abc&state=${extractState(oauth)}&iss=https://evil.test",
+                "app.example:/oauth-redirect?code=abc&state=${extractState(oauth)}&iss=https://evil.test",
             )
         }
     }
@@ -281,12 +321,12 @@ class AtOAuthTest {
         )
 
         val store = InMemorySessionStore()
-        val oauth = AtOAuth("https://app.test/meta.json", store, client)
+        val oauth = AtOAuth("https://app.test/meta.json", "app.example:/oauth-redirect", store, client)
         oauth.beginLogin("alice.test")
 
         assertFailsWith<OAuthAccountMismatchException> {
             oauth.completeLogin(
-                "io.github.kikin81:/oauth-redirect?code=abc&state=${extractState(oauth)}&iss=https://auth.test",
+                "app.example:/oauth-redirect?code=abc&state=${extractState(oauth)}&iss=https://auth.test",
             )
         }
     }
@@ -349,7 +389,7 @@ class AtOAuthTest {
             },
         )
 
-        val oauth = AtOAuth("https://app.test/oauth/client-metadata.json", store, client)
+        val oauth = AtOAuth("https://app.test/oauth/client-metadata.json", "app.example:/oauth-redirect", store, client)
 
         // Step 1: beginLogin
         val authUrl = oauth.beginLogin("alice.test")
@@ -357,7 +397,7 @@ class AtOAuthTest {
 
         // Step 2: simulate browser redirect
         oauth.completeLogin(
-            "io.github.kikin81:/oauth-redirect?code=code123&state=${extractState(oauth)}&iss=https://auth.test",
+            "app.example:/oauth-redirect?code=code123&state=${extractState(oauth)}&iss=https://auth.test",
         )
 
         // Step 3: verify session persisted with all fields
@@ -429,7 +469,7 @@ class AtOAuthTest {
             },
         )
 
-        val oauth = AtOAuth("https://app.test/meta.json", store, client)
+        val oauth = AtOAuth("https://app.test/meta.json", "app.example:/oauth-redirect", store, client)
         val xrpcClient = oauth.createClient()
 
         val result = xrpcClient.query(
@@ -473,7 +513,7 @@ class AtOAuthTest {
             },
         )
 
-        val oauth = AtOAuth("https://app.test/meta.json", store, client)
+        val oauth = AtOAuth("https://app.test/meta.json", "app.example:/oauth-redirect", store, client)
         oauth.logout()
 
         assertTrue(revokeCalled, "Token revocation should have been called")
@@ -493,7 +533,12 @@ class AtOAuthTest {
             dpopPrivateKey = byteArrayOf(),
             dpopPublicKey = byteArrayOf(),
         )
-        val oauth = AtOAuth("https://app.test/meta.json", store, HttpClient(MockEngine { respond(ByteReadChannel(""), HttpStatusCode.OK) }))
+        val oauth = AtOAuth(
+            "https://app.test/meta.json",
+            "app.example:/oauth-redirect",
+            store,
+            HttpClient(MockEngine { respond(ByteReadChannel(""), HttpStatusCode.OK) }),
+        )
         oauth.logout()
         assertTrue(store.session == null)
     }

--- a/oauth/src/test/kotlin/io/github/kikin81/atproto/oauth/AtOAuthTest.kt
+++ b/oauth/src/test/kotlin/io/github/kikin81/atproto/oauth/AtOAuthTest.kt
@@ -127,6 +127,39 @@ class AtOAuthTest {
         },
     )
 
+    /**
+     * Builds a mock that runs the full discovery + PAR + token flow and captures
+     * the token-exchange form body. Used to assert that values threaded from
+     * beginLogin (e.g. redirect_uri) are forwarded unchanged to the token POST.
+     */
+    private fun tokenCapturingClient(capture: (String) -> Unit): HttpClient = HttpClient(
+        MockEngine { request ->
+            val url = request.url.toString()
+            respondToDiscovery(url) ?: when {
+                url.contains("/par") ->
+                    respond(
+                        ByteReadChannel("""{"request_uri":"urn:test:par","expires_in":60}"""),
+                        HttpStatusCode.OK,
+                        jsonHeaders,
+                    )
+
+                url.contains("/token") -> {
+                    val body = (request.body as io.ktor.http.content.OutgoingContent.ByteArrayContent).bytes().decodeToString()
+                    capture(body)
+                    respond(
+                        ByteReadChannel(
+                            """{"access_token":"at","refresh_token":"rt","token_type":"DPoP","sub":"did:plc:testuser"}""",
+                        ),
+                        HttpStatusCode.OK,
+                        jsonHeaders,
+                    )
+                }
+
+                else -> respond(ByteReadChannel(""), HttpStatusCode.NotFound)
+            }
+        },
+    )
+
     @Test
     fun parSendsDefaultScopeWhenNotOverridden() = runTest {
         val store = InMemorySessionStore()
@@ -194,6 +227,26 @@ class AtOAuthTest {
         val body = parBody
         assertNotNull(body)
         assertContains(body, "redirect_uri=a&")
+    }
+
+    @Test
+    fun tokenRequestUsesProvidedRedirectUri() = runTest {
+        val store = InMemorySessionStore()
+        var tokenBody: String? = null
+        val oauth = AtOAuth(
+            clientMetadataUrl = "https://app.test/oauth/client-metadata.json",
+            redirectUri = "app.example:/oauth-redirect",
+            sessionStore = store,
+            httpClient = tokenCapturingClient { tokenBody = it },
+        )
+        oauth.beginLogin("alice.test")
+        oauth.completeLogin(
+            "app.example:/oauth-redirect?code=code_xyz&state=${extractState(oauth)}&iss=https://auth.test",
+        )
+
+        val body = tokenBody
+        assertNotNull(body)
+        assertContains(body, "redirect_uri=app.example%3A%2Foauth-redirect")
     }
 
     @Test

--- a/samples/android/src/main/kotlin/io/github/kikin81/atproto/samples/bluesky/di/AppModule.kt
+++ b/samples/android/src/main/kotlin/io/github/kikin81/atproto/samples/bluesky/di/AppModule.kt
@@ -32,6 +32,7 @@ object AppModule {
         httpClient: HttpClient,
     ): AtOAuth = AtOAuth(
         clientMetadataUrl = "https://kikin81.github.io/atproto-kotlin/oauth/client-metadata.json",
+        redirectUri = "io.github.kikin81:/oauth-redirect",
         sessionStore = sessionStore,
         httpClient = httpClient,
     )


### PR DESCRIPTION
## Summary

- Closes #105 — `AtOAuth` was always sending the hardcoded placeholder `io.github.kikin81:/oauth-redirect` as `redirect_uri` in PAR, which any real authorization server rejects with HTTP 400 `invalid_request: invalid redirect_uri` when the consumer's hosted `client-metadata.json` declares anything else.
- Adds required `redirectUri: String` as the second constructor parameter of `AtOAuth` (passthrough, no transformation). Deletes the `extractRedirectUri()` placeholder.
- Pins the contract with two new tests asserting the wire value matches the constructor argument verbatim.
- Updates the sample app to pass its existing redirect explicitly.
- Refreshes `oauth/api/oauth.api` and ships `docs/breaking-changes/v7.md`.

This is a **BREAKING CHANGE** — the commit footer is set so semantic-release will cut **v7.0.0** on merge.

## Test plan

- [x] `./gradlew :oauth:test` — 13 tests pass (11 existing + 2 new `parRequestUsesProvidedRedirectUri`, `redirectUriIsPassedThroughUntransformed`)
- [x] `./gradlew :oauth:apiCheck` — refreshed `oauth.api` reflects the new constructor signature
- [x] `./gradlew spotlessApply` clean
- [x] `./gradlew :samples:android:compileDebugKotlin` — sample passes its existing redirect `io.github.kikin81:/oauth-redirect` (matches the hosted metadata at `kikin81.github.io/atproto-kotlin/oauth/client-metadata.json`)
- [ ] CI green on this PR

## Migration

See `docs/breaking-changes/v7.md`. tl;dr — every `AtOAuth(...)` call site must add `redirectUri = "<value-from-your-client-metadata.json>"` in the second positional slot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)