### PR TITLE
test(oauth): parse PAR/token body for redirect_uri assertions

### DIFF
--- a/oauth/src/test/kotlin/io/github/kikin81/atproto/oauth/AtOAuthTest.kt
+++ b/oauth/src/test/kotlin/io/github/kikin81/atproto/oauth/AtOAuthTest.kt
@@ -8,11 +8,13 @@ import io.ktor.client.request.HttpResponseData
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
+import io.ktor.http.parseQueryString
 import io.ktor.utils.io.ByteReadChannel
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.JsonObject
 import kotlin.test.Test
 import kotlin.test.assertContains
+import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
@@ -207,9 +209,7 @@ class AtOAuthTest {
         )
         oauth.beginLogin("alice.test")
 
-        val body = parBody
-        assertNotNull(body)
-        assertContains(body, "redirect_uri=app.example%3A%2Foauth-redirect")
+        assertEquals("app.example:/oauth-redirect", redirectUriParamFrom(parBody))
     }
 
     @Test
@@ -224,9 +224,7 @@ class AtOAuthTest {
         )
         oauth.beginLogin("alice.test")
 
-        val body = parBody
-        assertNotNull(body)
-        assertContains(body, "redirect_uri=a&")
+        assertEquals("a", redirectUriParamFrom(parBody))
     }
 
     @Test
@@ -244,9 +242,7 @@ class AtOAuthTest {
             "app.example:/oauth-redirect?code=code_xyz&state=${extractState(oauth)}&iss=https://auth.test",
         )
 
-        val body = tokenBody
-        assertNotNull(body)
-        assertContains(body, "redirect_uri=app.example%3A%2Foauth-redirect")
+        assertEquals("app.example:/oauth-redirect", redirectUriParamFrom(tokenBody))
     }
 
     @Test
@@ -607,5 +603,17 @@ class AtOAuthTest {
         val stateField = pending::class.java.getDeclaredField("state")
         stateField.isAccessible = true
         return stateField.get(pending) as String
+    }
+
+    /**
+     * Parses an `application/x-www-form-urlencoded` request body and returns the
+     * decoded `redirect_uri` parameter. Asserting against the decoded value (rather
+     * than substring-matching the raw encoded string) keeps the test resilient to
+     * future parameter-ordering or encoding changes while still pinning the
+     * passthrough contract.
+     */
+    private fun redirectUriParamFrom(body: String?): String? {
+        val captured = assertNotNull(body)
+        return parseQueryString(captured)["redirect_uri"]
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to #106 (already merged) — addresses Copilot's review feedback on the new `redirect_uri` tests.

The three tests added in #106 (`parRequestUsesProvidedRedirectUri`, `redirectUriIsPassedThroughUntransformed`, `tokenRequestUsesProvidedRedirectUri`) asserted against the raw `application/x-www-form-urlencoded` body via `assertContains(body, "redirect_uri=app.example%3A%2Foauth-redirect")` and `assertContains(body, "redirect_uri=a&")`. That baked **parameter ordering** AND the **exact URL encoding** (`%3A%2F`) into the test expectation — a future Ktor upgrade that reordered form params or normalized encoding would break these tests without indicating any real contract regression.

This PR parses the body with Ktor's `parseQueryString` and asserts the **decoded** value via a small `redirectUriParamFrom(body: String?): String?` helper. The contract being pinned — "what you pass in goes out untransformed" — is unchanged; only the test is more resilient.

## Test plan

- [x] `./gradlew :oauth:test` — 14 tests pass (the 3 refactored tests still pin the same contract through a parsed-param assertion).
- [x] `./gradlew :oauth:apiCheck` — no public API change.
- [x] `./gradlew spotlessApply` clean.

## Notes

- A stray branch `fix/kikinlex-csn-oauth-redirect-uri` exists on origin from a push made before I realized #106 was already merged. That branch is not bound to any PR and can be safely deleted — let me know if you'd like me to delete it (I held off because branch deletion needs explicit consent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)