### PR TITLE
chore(lexicons): bump @atproto/lex to 0.0.26

### DIFF
--- a/generator/package-lock.json
+++ b/generator/package-lock.json
@@ -8,7 +8,7 @@
       "name": "kikinlex-atproto-generator-lexicons",
       "version": "0.0.0",
       "dependencies": {
-        "@atproto/lex": "0.0.25"
+        "@atproto/lex": "0.0.26"
       }
     },
     "node_modules/@atproto-labs/did-resolver": {
@@ -108,17 +108,17 @@
       }
     },
     "node_modules/@atproto/lex": {
-      "version": "0.0.25",
-      "resolved": "https://registry.npmjs.org/@atproto/lex/-/lex-0.0.25.tgz",
-      "integrity": "sha512-kZk/Fjwpt7rz+XeS9D1jCdG14q8+FXdIOdlFWzXDbTzYxKE6Y3DBZablNgt1kI5ePNe3HYBNsdLSpdXusr8qzA==",
+      "version": "0.0.26",
+      "resolved": "https://registry.npmjs.org/@atproto/lex/-/lex-0.0.26.tgz",
+      "integrity": "sha512-grZoe+Aqh4Q/nr4nBYN+bVjv5EJyb4Oup57ZRbGueR+yOyy9zWrwen4k3qRmLBdoFlU2b9RNoR896ARxdi/gNg==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/lex-builder": "^0.0.22",
-        "@atproto/lex-client": "^0.0.20",
+        "@atproto/lex-builder": "^0.0.23",
+        "@atproto/lex-client": "^0.0.21",
         "@atproto/lex-data": "^0.0.15",
-        "@atproto/lex-installer": "^0.0.25",
+        "@atproto/lex-installer": "^0.0.26",
         "@atproto/lex-json": "^0.0.16",
-        "@atproto/lex-schema": "^0.0.19",
+        "@atproto/lex-schema": "^0.0.20",
         "tslib": "^2.8.1",
         "yargs": "^17.0.0"
       },
@@ -128,13 +128,13 @@
       }
     },
     "node_modules/@atproto/lex-builder": {
-      "version": "0.0.22",
-      "resolved": "https://registry.npmjs.org/@atproto/lex-builder/-/lex-builder-0.0.22.tgz",
-      "integrity": "sha512-XwnOloOS5VMkHmx3ZXHzNOh5NKx8F4aUKw/oRxKe028YWOCLiKu20fWQ11f0o8GHczKou5i6/8Qd89JRSCpibA==",
+      "version": "0.0.23",
+      "resolved": "https://registry.npmjs.org/@atproto/lex-builder/-/lex-builder-0.0.23.tgz",
+      "integrity": "sha512-3eHs4mUy9QRYET82Fh9R/jJD8hpGKIyzuUpmeiY6/o8fA4pcynfTew5O4AHIBns6eyGCbCnLLQEDwPTlrsXDSA==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/lex-document": "^0.0.20",
-        "@atproto/lex-schema": "^0.0.19",
+        "@atproto/lex-document": "^0.0.21",
+        "@atproto/lex-schema": "^0.0.20",
         "prettier": "^3.2.5",
         "ts-morph": "^27.0.0",
         "tslib": "^2.8.1"
@@ -151,14 +151,14 @@
       }
     },
     "node_modules/@atproto/lex-client": {
-      "version": "0.0.20",
-      "resolved": "https://registry.npmjs.org/@atproto/lex-client/-/lex-client-0.0.20.tgz",
-      "integrity": "sha512-K6x+kGWs67olnv1sEasI4NqlUJ+Gd1N9Rv1c6WkIqQnZff8WF1HDUyg3SpmGcYBG4pPPoeCmY5c9go/Box8OQA==",
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/@atproto/lex-client/-/lex-client-0.0.21.tgz",
+      "integrity": "sha512-xd4QieOU3TFsukB1EyPPRXBkr6znju/ECopM3lVCLI9CRt7i5R8FeaaGJ93M68BoGWmrdmuDaHEe9zD+1N8utQ==",
       "license": "MIT",
       "dependencies": {
         "@atproto/lex-data": "^0.0.15",
         "@atproto/lex-json": "^0.0.16",
-        "@atproto/lex-schema": "^0.0.19",
+        "@atproto/lex-schema": "^0.0.20",
         "tslib": "^2.8.1"
       }
     },
@@ -175,28 +175,28 @@
       }
     },
     "node_modules/@atproto/lex-document": {
-      "version": "0.0.20",
-      "resolved": "https://registry.npmjs.org/@atproto/lex-document/-/lex-document-0.0.20.tgz",
-      "integrity": "sha512-DO/ZK9sJTGbFUs99zUqJ60KXJID+NM0crMyeSc9G1v/u6j+WPpA3bFAVHNq0322KpINfL5izL5JmT4eUyt3HeQ==",
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/@atproto/lex-document/-/lex-document-0.0.21.tgz",
+      "integrity": "sha512-A437njagW01meDhAhT8L7y36jmYBaBCzuCBYwyfGYZjZdjoiwZU5W78k5tajKeJwTOLG/4NwfNVXhwy8gWQaAA==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/lex-schema": "^0.0.19",
+        "@atproto/lex-schema": "^0.0.20",
         "core-js": "^3",
         "tslib": "^2.8.1"
       }
     },
     "node_modules/@atproto/lex-installer": {
-      "version": "0.0.25",
-      "resolved": "https://registry.npmjs.org/@atproto/lex-installer/-/lex-installer-0.0.25.tgz",
-      "integrity": "sha512-KdSvojycYP7JQ+ejFnZdNwL1QJy8R8qoNNiwgrvCuikST2lTxivm7X744hstXJ2fo/EnOvoXwho9gkVaJAhIaQ==",
+      "version": "0.0.26",
+      "resolved": "https://registry.npmjs.org/@atproto/lex-installer/-/lex-installer-0.0.26.tgz",
+      "integrity": "sha512-D48ywgbmDhTf6vcbQJi8tVjs5dhxmXqGidKr7qf4flZYALJLL1CEDvvl3Wa9pOtmcl66bAp1m0eVnuq/iu1LhA==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/lex-builder": "^0.0.22",
+        "@atproto/lex-builder": "^0.0.23",
         "@atproto/lex-cbor": "^0.0.16",
         "@atproto/lex-data": "^0.0.15",
-        "@atproto/lex-document": "^0.0.20",
-        "@atproto/lex-resolver": "^0.0.22",
-        "@atproto/lex-schema": "^0.0.19",
+        "@atproto/lex-document": "^0.0.21",
+        "@atproto/lex-resolver": "^0.0.23",
+        "@atproto/lex-schema": "^0.0.20",
         "@atproto/syntax": "^0.5.4",
         "tslib": "^2.8.1"
       }
@@ -212,26 +212,26 @@
       }
     },
     "node_modules/@atproto/lex-resolver": {
-      "version": "0.0.22",
-      "resolved": "https://registry.npmjs.org/@atproto/lex-resolver/-/lex-resolver-0.0.22.tgz",
-      "integrity": "sha512-D2a1RHxuJSgMZGUy5SZNar+Ay5X3JHOGhP83CqbJSYLy/HMKthACobeP/h0yb7/ZiMCNPP0TP5XMXazaRv+spQ==",
+      "version": "0.0.23",
+      "resolved": "https://registry.npmjs.org/@atproto/lex-resolver/-/lex-resolver-0.0.23.tgz",
+      "integrity": "sha512-y0N0uopZl8Xen2MHPM+2ZYtFnyC/rNvOs/At15K2l6EL0LB6Efz58JRmvpR511TiH+0p3AOt/kGAjz5pkLCZgw==",
       "license": "MIT",
       "dependencies": {
         "@atproto-labs/did-resolver": "^0.2.6",
         "@atproto/crypto": "^0.4.5",
-        "@atproto/lex-client": "^0.0.20",
+        "@atproto/lex-client": "^0.0.21",
         "@atproto/lex-data": "^0.0.15",
-        "@atproto/lex-document": "^0.0.20",
-        "@atproto/lex-schema": "^0.0.19",
+        "@atproto/lex-document": "^0.0.21",
+        "@atproto/lex-schema": "^0.0.20",
         "@atproto/repo": "^0.9.1",
         "@atproto/syntax": "^0.5.4",
         "tslib": "^2.8.1"
       }
     },
     "node_modules/@atproto/lex-schema": {
-      "version": "0.0.19",
-      "resolved": "https://registry.npmjs.org/@atproto/lex-schema/-/lex-schema-0.0.19.tgz",
-      "integrity": "sha512-rEVTnbgYx4FwcvfrfnuACXvBcdkb4wqSOALG9leW302YIPB+HLRSwpBVC0iLun+yozEKg7BJdwiS0bvfje6tcQ==",
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/@atproto/lex-schema/-/lex-schema-0.0.20.tgz",
+      "integrity": "sha512-Q6BDt59A1XrLSDlMuxh6nyw8iNHIxmTpglC5fjVeEXYlntMBFBf4TmWjFotkThCdpcE3FPVVfpGGpU1bC6C9KQ==",
       "license": "MIT",
       "dependencies": {
         "@atproto/lex-data": "^0.0.15",
@@ -388,9 +388,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"

--- a/generator/package.json
+++ b/generator/package.json
@@ -4,6 +4,6 @@
   "private": true,
   "description": "Pins the @atproto/lex release whose lexicon JSON is consumed by :generator. Not published.",
   "dependencies": {
-    "@atproto/lex": "0.0.25"
+    "@atproto/lex": "0.0.26"
   }
 }


### PR DESCRIPTION
## Lexicon corpus update

Bumps `@atproto/lex` from `0.0.25` to `0.0.26`.

### lexicons.json changes

**Added** (0):
- _(none)_

**Removed** (0):
- _(none)_

**Updated** (0):
- _(none)_

### What reviewers should check

- [ ] CI passes (generator regeneration, runtime tests, sample APK build)
- [ ] Skim the generator golden-file diff if any generator logic was affected
- [ ] Verify no new lexicon references are missing Kotlin types (compile failure in `:models`)

### Release impact

If this PR merges with only additive changes (new types, new fields), expect a `feat:` release. If it removes or renames anything, expect a `BREAKING CHANGE:` release — update the PR title to `feat!: bump @atproto/lex to <version>` before merging.