### PR TITLE
feat(oauth): add beginSignup with OIDC prompt=create

### DIFF
--- a/docs/breaking-changes/v8.md
+++ b/docs/breaking-changes/v8.md
@@ -1,0 +1,178 @@
+# Breaking changes — v8.0.0
+
+## Summary
+
+`AtOAuth` gains a `beginSignup` entry point that begins an OAuth flow
+against a known authorization server (default `bsky.social`) with no
+handle/DID, sending OIDC `prompt=create` so the auth server renders its
+signup UI. The user lands back in the app already signed in to the
+freshly-minted account — no handle re-entry, no separate signup screen.
+
+To support this, several public types relax their nullability and gain
+new fields:
+
+- `AuthServerMetadata.did`, `.handle`, `.pdsUrl` are now `String?` (were
+  required `String`). The eager login path still populates all three; the
+  signup path leaves them null until post-token-exchange identity hydration.
+- `AuthServerMetadata` gains a `promptValuesSupported: List<String>` field
+  parsed from the auth server's metadata, used by `beginSignup` to gate
+  on `"create"` support.
+- `OAuthSession.did`, `.handle`, `.pdsUrl` are now `String?` to mirror the
+  above. Login-flow sessions remain fully populated; signup-flow sessions
+  may transiently have null handle/pdsUrl if the new account's DID
+  document is not yet resolvable via the PLC directory (bounded retry
+  inside `completeLogin` mitigates this).
+
+A new `OAuthSignupNotSupportedException` is thrown when an auth server's
+`/.well-known/oauth-authorization-server` does not advertise `"create"`
+in `prompt_values_supported`. Pass `requirePromptCreateSupport = false`
+to `beginSignup` to override.
+
+## What changed
+
+### OAuth — `AtOAuth`
+
+A new public suspending entry point was added:
+
+```kotlin
+suspend fun beginSignup(
+    authServer: String = "bsky.social",
+    requirePromptCreateSupport: Boolean = true,
+): String
+```
+
+Returns the authorization URL to open in a Custom Tab — same shape as
+`beginLogin(handle)`. Complete the flow with the existing
+`completeLogin(redirectUri)`.
+
+### OAuth — `AuthServerMetadata`
+
+| Field | Before | After |
+|---|---|---|
+| `did` | `String` | `String?` |
+| `handle` | `String` | `String?` |
+| `pdsUrl` | `String` | `String?` |
+| `promptValuesSupported` | (absent) | `List<String>` (new field, defaults `emptyList()`) |
+
+Constructor positional order: a new `promptValuesSupported` parameter
+was appended (ninth position). Callers using copy constructors or the
+positional constructor will need to add it.
+
+### OAuth — `OAuthSession`
+
+| Field | Before | After |
+|---|---|---|
+| `did` | `String` | `String?` |
+| `handle` | `String` | `String?` |
+| `pdsUrl` | `String` | `String?` |
+
+No positional changes; existing on-disk `OAuthSession`s deserialize
+unchanged (their stored values were always non-null and continue to be
+read as non-null).
+
+`createClient()` now throws `OAuthException` if the loaded session has
+a null `pdsUrl` (a signup whose post-token DID resolution failed and
+exhausted its retry budget). Consumers can recover by calling
+`oauth.logout()` and retrying signup, or by manually resolving the
+session's `did` and writing the result back to the store.
+
+### OAuth — `DiscoveryChain`
+
+A new method was added:
+
+```kotlin
+suspend fun resolveKnownAuthServer(authServerUrl: String): AuthServerMetadata
+```
+
+Short-circuits the discovery chain for signup-style flows where the
+auth server is already known. Returns metadata with `did`, `handle`,
+`pdsUrl` all null and `promptValuesSupported` populated from the auth
+server's advertised metadata.
+
+### OAuth — new exception
+
+```kotlin
+class OAuthSignupNotSupportedException(
+    val authServerUrl: String,
+    val advertisedPromptValues: List<String>,
+) : RuntimeException(...)
+```
+
+Thrown by `beginSignup` when the configured auth server does not
+advertise `"create"` in `prompt_values_supported`. Pass
+`requirePromptCreateSupport = false` to bypass.
+
+## How to migrate
+
+### 1. Bump the dependency
+
+```kotlin
+// before
+implementation("io.github.kikin81.atproto:oauth:7.x.x")
+
+// after
+implementation("io.github.kikin81.atproto:oauth:8.0.0")
+```
+
+### 2. Handle nullable identity fields
+
+If you read `session.did`, `session.handle`, or `session.pdsUrl` (or
+the same on `AuthServerMetadata`), they are now nullable. For consumers
+that only use the login flow, these will be non-null at runtime — but
+the compiler will require an explicit unwrap.
+
+```kotlin
+// before
+val handle: String = session.handle
+val displayName = "Hello, ${session.handle}"
+
+// after
+val handle: String = session.handle ?: session.did ?: error("no identity")
+val displayName = session.handle?.let { "Hello, $it" } ?: "Hello"
+```
+
+### 3. (Optional) Add a signup CTA
+
+```kotlin
+// In your login screen ViewModel:
+viewModelScope.launch {
+    runCatching { oauth.beginSignup() }
+        .onSuccess { url -> emitToCustomTab(url) }
+        .onFailure { t -> showError(t.message ?: "Signup failed") }
+}
+```
+
+The redirect handling is shared with `beginLogin` — the existing
+`completeLogin(redirectUri)` invocation works for both paths.
+
+### 4. (Optional) Bypass the gate for non-conformant auth servers
+
+If you're targeting an entryway that supports signup but doesn't yet
+advertise `"create"` in `prompt_values_supported`:
+
+```kotlin
+oauth.beginSignup(
+    authServer = "my-entryway.example",
+    requirePromptCreateSupport = false,
+)
+```
+
+## Why this is a major bump
+
+Per the kotlinx-binary-compatibility-validator (gating this repo at
+`:oauth:apiCheck`):
+
+- `AuthServerMetadata`'s constructor and `copy` signatures changed
+  (extra `List<String>` parameter).
+- `OAuthSession` and `AuthServerMetadata` identity fields became
+  nullable — a source-level breaking change for any caller that
+  reads them without `?:`.
+- New public types (`OAuthSignupNotSupportedException`) and methods
+  (`AtOAuth.beginSignup`, `DiscoveryChain.resolveKnownAuthServer`)
+  are additive but still warrant version-tracking via the api dump.
+
+Per repo discipline (see `v5.md`, `v6.md`, `v7.md`) and the project's
+binary-compat memory, adding any parameter to a public API — even one
+with a default — is binary-breaking even when source-compatible, and
+requires a `BREAKING CHANGE:` footer on the merge commit so
+semantic-release cuts a major version.

--- a/oauth/api/oauth.api
+++ b/oauth/api/oauth.api
@@ -2,13 +2,16 @@ public final class io/github/kikin81/atproto/oauth/AtOAuth {
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lio/github/kikin81/atproto/oauth/OAuthSessionStore;Lio/ktor/client/HttpClient;Lkotlinx/serialization/json/Json;Ljava/lang/String;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lio/github/kikin81/atproto/oauth/OAuthSessionStore;Lio/ktor/client/HttpClient;Lkotlinx/serialization/json/Json;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun beginLogin (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun beginSignup (Ljava/lang/String;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun beginSignup$default (Lio/github/kikin81/atproto/oauth/AtOAuth;Ljava/lang/String;ZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun completeLogin (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun createClient (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun logout (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class io/github/kikin81/atproto/oauth/AuthServerMetadata {
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/String;
@@ -17,8 +20,9 @@ public final class io/github/kikin81/atproto/oauth/AuthServerMetadata {
 	public final fun component6 ()Ljava/lang/String;
 	public final fun component7 ()Ljava/lang/String;
 	public final fun component8 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/github/kikin81/atproto/oauth/AuthServerMetadata;
-	public static synthetic fun copy$default (Lio/github/kikin81/atproto/oauth/AuthServerMetadata;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/oauth/AuthServerMetadata;
+	public final fun component9 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)Lio/github/kikin81/atproto/oauth/AuthServerMetadata;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/oauth/AuthServerMetadata;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lio/github/kikin81/atproto/oauth/AuthServerMetadata;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAuthorizationEndpoint ()Ljava/lang/String;
 	public final fun getDid ()Ljava/lang/String;
@@ -26,6 +30,7 @@ public final class io/github/kikin81/atproto/oauth/AuthServerMetadata {
 	public final fun getIssuer ()Ljava/lang/String;
 	public final fun getParEndpoint ()Ljava/lang/String;
 	public final fun getPdsUrl ()Ljava/lang/String;
+	public final fun getPromptValuesSupported ()Ljava/util/List;
 	public final fun getRevocationEndpoint ()Ljava/lang/String;
 	public final fun getTokenEndpoint ()Ljava/lang/String;
 	public fun hashCode ()I
@@ -36,6 +41,7 @@ public final class io/github/kikin81/atproto/oauth/DiscoveryChain {
 	public fun <init> (Lio/ktor/client/HttpClient;Lkotlinx/serialization/json/Json;)V
 	public synthetic fun <init> (Lio/ktor/client/HttpClient;Lkotlinx/serialization/json/Json;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun resolve (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun resolveKnownAuthServer (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class io/github/kikin81/atproto/oauth/DpopAuthProvider : io/github/kikin81/atproto/runtime/AuthProvider {
@@ -152,5 +158,11 @@ public abstract interface class io/github/kikin81/atproto/oauth/OAuthSessionStor
 	public abstract fun clear (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun load (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun save (Lio/github/kikin81/atproto/oauth/OAuthSession;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class io/github/kikin81/atproto/oauth/OAuthSignupNotSupportedException : java/lang/RuntimeException {
+	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
+	public final fun getAdvertisedPromptValues ()Ljava/util/List;
+	public final fun getAuthServerUrl ()Ljava/lang/String;
 }
 

--- a/oauth/src/main/kotlin/io/github/kikin81/atproto/oauth/AtOAuth.kt
+++ b/oauth/src/main/kotlin/io/github/kikin81/atproto/oauth/AtOAuth.kt
@@ -20,6 +20,15 @@ import kotlin.io.encoding.ExperimentalEncodingApi
  * authorization, token exchange, and session management with transparent
  * refresh.
  *
+ * Supports two entry points:
+ *
+ * - [beginLogin] — keyed on a user's handle/DID; full discovery chain.
+ * - [beginSignup] — keyed on a known auth server (default `bsky.social`);
+ *   short-circuits discovery and sends OIDC `prompt=create` so the auth
+ *   server renders its signup UI. Identity is hydrated post-token-exchange.
+ *
+ * Both flows complete via [completeLogin] — the redirect handling is shared.
+ *
  * ## Consumer usage
  *
  * ```kotlin
@@ -29,14 +38,13 @@ import kotlin.io.encoding.ExperimentalEncodingApi
  *     sessionStore = mySessionStore,
  *     httpClient = myKtorClient,
  * )
- * // Step 1: get the authorization URL
+ * // Login path:
  * val authUrl = oauth.beginLogin("alice.bsky.social")
- * // Step 2: open authUrl in a browser (Custom Tabs on Android)
- * // Step 3: capture the redirect URI
+ * // Signup path:
+ * val signupUrl = oauth.beginSignup() // defaults to bsky.social
+ * // Both paths: open the URL in a browser, then call:
  * oauth.completeLogin(redirectUri)
- * // Step 4: use the authenticated client
  * val client = oauth.createClient()
- * FeedService(client).getTimeline()
  * ```
  *
  * ## Requesting additional scopes
@@ -67,7 +75,7 @@ class AtOAuth(
     private val json: Json = Json { ignoreUnknownKeys = true },
     private val scope: String = "atproto transition:generic",
 ) {
-    // Transient state during the login flow (between beginLogin and completeLogin)
+    // Transient state during the login/signup flow (between beginX and completeLogin)
     private var pendingState: PendingAuthState? = null
 
     /**
@@ -87,6 +95,61 @@ class AtOAuth(
     suspend fun beginLogin(handleOrDid: String): String {
         val discovery = DiscoveryChain(httpClient, json)
         val metadata = discovery.resolve(handleOrDid)
+        return startAuthFlow(
+            metadata = metadata,
+            loginHint = handleOrDid,
+            prompt = null,
+            flowOrigin = FlowOrigin.Login,
+        )
+    }
+
+    /**
+     * Starts the OAuth signup flow against a known authorization server.
+     *
+     * Unlike [beginLogin], no handle or DID is required: the auth server
+     * is named directly, the discovery chain is short-circuited to fetch
+     * only its metadata, and PAR carries OIDC `prompt=create` so the
+     * server renders its signup UI. After the user signs up in the
+     * browser and the redirect lands, [completeLogin] derives the new
+     * account's DID from the token-response `sub`, then resolves the
+     * handle and PDS URL from the DID document.
+     *
+     * @param authServer The authorization server hostname or URL.
+     *   Defaults to `bsky.social`. Accepts either a bare hostname or a
+     *   full `https://` URL.
+     * @param requirePromptCreateSupport When `true` (the default), the
+     *   module verifies that the auth server's metadata advertises
+     *   `"create"` in `prompt_values_supported` and throws
+     *   [OAuthSignupNotSupportedException] otherwise. Pass `false` to
+     *   bypass the check for non-conformant entryways.
+     * @return The authorization URL to open in a Custom Tab or system browser.
+     */
+    suspend fun beginSignup(
+        authServer: String = "bsky.social",
+        requirePromptCreateSupport: Boolean = true,
+    ): String {
+        val discovery = DiscoveryChain(httpClient, json)
+        val metadata = discovery.resolveKnownAuthServer(authServer)
+        if (requirePromptCreateSupport && !metadata.promptValuesSupported.contains("create")) {
+            throw OAuthSignupNotSupportedException(
+                authServerUrl = metadata.issuer,
+                advertisedPromptValues = metadata.promptValuesSupported,
+            )
+        }
+        return startAuthFlow(
+            metadata = metadata,
+            loginHint = null,
+            prompt = "create",
+            flowOrigin = FlowOrigin.Signup,
+        )
+    }
+
+    private suspend fun startAuthFlow(
+        metadata: AuthServerMetadata,
+        loginHint: String?,
+        prompt: String?,
+        flowOrigin: FlowOrigin,
+    ): String {
         val signer = DpopSigner.generate()
         val codeVerifier = Pkce.generateVerifier()
         val codeChallenge = Pkce.computeChallenge(codeVerifier)
@@ -98,7 +161,8 @@ class AtOAuth(
             codeChallenge = codeChallenge,
             state = state,
             redirectUri = redirectUri,
-            loginHint = handleOrDid,
+            loginHint = loginHint,
+            prompt = prompt,
         )
 
         pendingState = PendingAuthState(
@@ -107,6 +171,7 @@ class AtOAuth(
             codeVerifier = codeVerifier,
             state = state,
             redirectUri = redirectUri,
+            flowOrigin = flowOrigin,
         )
 
         return "${metadata.authorizationEndpoint}?client_id=$clientMetadataUrl&request_uri=$requestUri"
@@ -118,15 +183,17 @@ class AtOAuth(
      * 1. Validates the `state` parameter matches.
      * 2. Validates the `iss` parameter matches the discovered auth server.
      * 3. Exchanges the authorization code for tokens with PKCE + DPoP.
-     * 4. Verifies the `sub` (DID) in the token response matches the
-     *    resolved DID from discovery.
+     * 4. For the login flow, verifies the `sub` (DID) in the token
+     *    response matches the resolved DID from discovery. For the signup
+     *    flow, accepts `sub` as authoritative and hydrates handle + PDS
+     *    URL from the new DID document.
      * 5. Persists the session.
      *
      * @param redirectUri The full redirect URI from the browser callback
      *   (e.g. `myapp://oauth/callback?code=...&state=...&iss=...`).
      */
     suspend fun completeLogin(redirectUri: String) {
-        val pending = pendingState ?: throw OAuthException("No pending login — call beginLogin first")
+        val pending = pendingState ?: throw OAuthException("No pending login — call beginLogin or beginSignup first")
         pendingState = null
 
         val params = parseRedirectParams(redirectUri)
@@ -152,19 +219,38 @@ class AtOAuth(
             redirectUri = pending.redirectUri,
         )
 
-        if (tokenResponse.sub != null && tokenResponse.sub != pending.metadata.did) {
-            throw OAuthAccountMismatchException(
-                "Token response sub '${tokenResponse.sub}' does not match resolved DID '${pending.metadata.did}'",
-            )
+        val resolvedDid: String?
+        val resolvedHandle: String?
+        val resolvedPdsUrl: String?
+
+        when (pending.flowOrigin) {
+            FlowOrigin.Login -> {
+                if (tokenResponse.sub != null && tokenResponse.sub != pending.metadata.did) {
+                    throw OAuthAccountMismatchException(
+                        "Token response sub '${tokenResponse.sub}' does not match resolved DID '${pending.metadata.did}'",
+                    )
+                }
+                resolvedDid = pending.metadata.did
+                resolvedHandle = pending.metadata.handle
+                resolvedPdsUrl = pending.metadata.pdsUrl
+            }
+            FlowOrigin.Signup -> {
+                val signupDid = tokenResponse.sub
+                    ?: throw OAuthException("Token response from signup flow has no 'sub' field")
+                resolvedDid = signupDid
+                val hydrated = DiscoveryChain(httpClient, json).hydrateIdentityFromDid(signupDid)
+                resolvedHandle = hydrated.handle
+                resolvedPdsUrl = hydrated.pdsUrl
+            }
         }
 
         val exported = pending.signer.exportKeyPair()
         val session = OAuthSession(
             accessToken = tokenResponse.access_token,
             refreshToken = tokenResponse.refresh_token ?: throw OAuthException("No refresh_token in token response"),
-            did = pending.metadata.did,
-            handle = pending.metadata.handle,
-            pdsUrl = pending.metadata.pdsUrl,
+            did = resolvedDid,
+            handle = resolvedHandle,
+            pdsUrl = resolvedPdsUrl,
             tokenEndpoint = pending.metadata.tokenEndpoint,
             revocationEndpoint = pending.metadata.revocationEndpoint,
             clientId = clientMetadataUrl,
@@ -183,6 +269,11 @@ class AtOAuth(
     suspend fun createClient(): XrpcClient {
         val session = sessionStore.load()
             ?: throw OAuthException("No session — call beginLogin/completeLogin first or restore a persisted session")
+        val pdsUrl = session.pdsUrl
+            ?: throw OAuthException(
+                "Session has no pdsUrl. This usually means a signup-flow session whose " +
+                    "post-signup DID resolution did not complete; the PDS endpoint is unknown.",
+            )
         val signer = DpopSigner.fromExported(
             DpopSigner.ExportedKeyPair(session.dpopPrivateKey, session.dpopPublicKey),
         )
@@ -194,7 +285,7 @@ class AtOAuth(
             refreshClient = httpClient,
         )
         return XrpcClient(
-            baseUrl = session.pdsUrl,
+            baseUrl = pdsUrl,
             httpClient = httpClient,
             authProvider = authProvider,
         )
@@ -263,13 +354,14 @@ class AtOAuth(
         codeChallenge: String,
         state: String,
         redirectUri: String,
-        loginHint: String,
+        loginHint: String?,
+        prompt: String?,
     ): String {
         // First attempt: no nonce (expected to fail with use_dpop_nonce)
         val firstProof = signer.sign(method = "POST", url = metadata.parEndpoint)
         val firstResponse = httpClient.submitForm(
             url = metadata.parEndpoint,
-            formParameters = parParams(codeChallenge, state, redirectUri, loginHint),
+            formParameters = parParams(codeChallenge, state, redirectUri, loginHint, prompt),
         ) {
             header("DPoP", firstProof)
         }
@@ -291,7 +383,7 @@ class AtOAuth(
         val retryProof = signer.sign(method = "POST", url = metadata.parEndpoint, nonce = nonce)
         val retryResponse = httpClient.submitForm(
             url = metadata.parEndpoint,
-            formParameters = parParams(codeChallenge, state, redirectUri, loginHint),
+            formParameters = parParams(codeChallenge, state, redirectUri, loginHint, prompt),
         ) {
             header("DPoP", retryProof)
         }
@@ -308,7 +400,8 @@ class AtOAuth(
         codeChallenge: String,
         state: String,
         redirectUri: String,
-        loginHint: String,
+        loginHint: String?,
+        prompt: String?,
     ): Parameters = Parameters.build {
         append("client_id", clientMetadataUrl)
         append("response_type", "code")
@@ -317,7 +410,8 @@ class AtOAuth(
         append("state", state)
         append("code_challenge", codeChallenge)
         append("code_challenge_method", "S256")
-        append("login_hint", loginHint)
+        if (loginHint != null) append("login_hint", loginHint)
+        if (prompt != null) append("prompt", prompt)
     }
 
     private suspend fun exchangeCode(
@@ -399,12 +493,15 @@ class AtOAuth(
             }
     }
 
+    internal enum class FlowOrigin { Login, Signup }
+
     private data class PendingAuthState(
         val metadata: AuthServerMetadata,
         val signer: DpopSigner,
         val codeVerifier: String,
         val state: String,
         val redirectUri: String,
+        val flowOrigin: FlowOrigin,
     )
 }
 

--- a/oauth/src/main/kotlin/io/github/kikin81/atproto/oauth/AtOAuth.kt
+++ b/oauth/src/main/kotlin/io/github/kikin81/atproto/oauth/AtOAuth.kt
@@ -219,9 +219,23 @@ class AtOAuth(
             redirectUri = pending.redirectUri,
         )
 
-        val resolvedDid: String?
-        val resolvedHandle: String?
-        val resolvedPdsUrl: String?
+        val exported = pending.signer.exportKeyPair()
+        val refreshToken = tokenResponse.refresh_token
+            ?: throw OAuthException("No refresh_token in token response")
+
+        fun buildSession(did: String?, handle: String?, pdsUrl: String?): OAuthSession = OAuthSession(
+            accessToken = tokenResponse.access_token,
+            refreshToken = refreshToken,
+            did = did,
+            handle = handle,
+            pdsUrl = pdsUrl,
+            tokenEndpoint = pending.metadata.tokenEndpoint,
+            revocationEndpoint = pending.metadata.revocationEndpoint,
+            clientId = clientMetadataUrl,
+            dpopPrivateKey = exported.privateKeyEncoded,
+            dpopPublicKey = exported.publicKeyEncoded,
+            clockOffsetSeconds = pending.signer.clockOffsetSeconds,
+        )
 
         when (pending.flowOrigin) {
             FlowOrigin.Login -> {
@@ -230,35 +244,36 @@ class AtOAuth(
                         "Token response sub '${tokenResponse.sub}' does not match resolved DID '${pending.metadata.did}'",
                     )
                 }
-                resolvedDid = pending.metadata.did
-                resolvedHandle = pending.metadata.handle
-                resolvedPdsUrl = pending.metadata.pdsUrl
+                // Login already has fully resolved identity — one write is enough.
+                sessionStore.save(
+                    buildSession(
+                        did = pending.metadata.did,
+                        handle = pending.metadata.handle,
+                        pdsUrl = pending.metadata.pdsUrl,
+                    ),
+                )
             }
             FlowOrigin.Signup -> {
                 val signupDid = tokenResponse.sub
                     ?: throw OAuthException("Token response from signup flow has no 'sub' field")
-                resolvedDid = signupDid
+                // Crash-resilience: persist tokens + DID before hydration runs. If
+                // the process dies during the bounded backoff below, the session is
+                // recoverable (the consumer can re-resolve identity off the DID).
+                sessionStore.save(buildSession(did = signupDid, handle = null, pdsUrl = null))
+
                 val hydrated = DiscoveryChain(httpClient, json).hydrateIdentityFromDid(signupDid)
-                resolvedHandle = hydrated.handle
-                resolvedPdsUrl = hydrated.pdsUrl
+                // Re-persist with whatever resolved. If both fields are still null
+                // after the retry budget exhausts, this is effectively a no-op write
+                // — kept for clarity that hydration completed.
+                sessionStore.save(
+                    buildSession(
+                        did = signupDid,
+                        handle = hydrated.handle,
+                        pdsUrl = hydrated.pdsUrl,
+                    ),
+                )
             }
         }
-
-        val exported = pending.signer.exportKeyPair()
-        val session = OAuthSession(
-            accessToken = tokenResponse.access_token,
-            refreshToken = tokenResponse.refresh_token ?: throw OAuthException("No refresh_token in token response"),
-            did = resolvedDid,
-            handle = resolvedHandle,
-            pdsUrl = resolvedPdsUrl,
-            tokenEndpoint = pending.metadata.tokenEndpoint,
-            revocationEndpoint = pending.metadata.revocationEndpoint,
-            clientId = clientMetadataUrl,
-            dpopPrivateKey = exported.privateKeyEncoded,
-            dpopPublicKey = exported.publicKeyEncoded,
-            clockOffsetSeconds = pending.signer.clockOffsetSeconds,
-        )
-        sessionStore.save(session)
     }
 
     /**

--- a/oauth/src/main/kotlin/io/github/kikin81/atproto/oauth/DiscoveryChain.kt
+++ b/oauth/src/main/kotlin/io/github/kikin81/atproto/oauth/DiscoveryChain.kt
@@ -5,6 +5,7 @@ import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.delay
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 
@@ -12,6 +13,11 @@ import kotlinx.serialization.json.Json
  * Resolved authorization server metadata — everything the OAuth flow
  * needs to construct PAR requests, authorization URLs, and token
  * exchange calls.
+ *
+ * [did], [handle], and [pdsUrl] are nullable to support the signup flow,
+ * which discovers only the auth-server endpoints up front and hydrates
+ * identity post-token-exchange. The login flow always populates all
+ * three eagerly via [DiscoveryChain.resolve].
  */
 data class AuthServerMetadata(
     val issuer: String,
@@ -19,9 +25,10 @@ data class AuthServerMetadata(
     val tokenEndpoint: String,
     val parEndpoint: String,
     val revocationEndpoint: String?,
-    val pdsUrl: String,
-    val did: String,
-    val handle: String,
+    val pdsUrl: String?,
+    val did: String?,
+    val handle: String?,
+    val promptValuesSupported: List<String> = emptyList(),
 )
 
 /**
@@ -38,6 +45,11 @@ data class AuthServerMetadata(
  *    → extract all OAuth endpoint URLs.
  * 4. **Bidirectional handle verification**: verify the DID document's
  *    `alsoKnownAs` field claims the original handle.
+ *
+ * For signup flows where no handle/DID is known up front, use
+ * [resolveKnownAuthServer] to short-circuit the chain and fetch only the
+ * auth-server metadata; identity is hydrated post-token-exchange via
+ * [hydrateIdentityFromDid].
  */
 class DiscoveryChain(
     private val httpClient: HttpClient,
@@ -76,8 +88,74 @@ class DiscoveryChain(
             pdsUrl = pdsUrl,
             did = did,
             handle = handle,
+            promptValuesSupported = metadata.promptValuesSupported ?: emptyList(),
         )
     }
+
+    /**
+     * Short-circuits the discovery chain for flows where the auth server
+     * is already known (e.g. signup, where the user has no handle/DID yet).
+     * Fetches only the auth-server metadata; [AuthServerMetadata.did],
+     * [AuthServerMetadata.handle], and [AuthServerMetadata.pdsUrl] are
+     * left null — populate them post-token-exchange via
+     * [hydrateIdentityFromDid].
+     *
+     * Accepts either a bare hostname (`"bsky.social"`) or a full URL
+     * (`"https://bsky.social"`); both are normalized to a URL prefix.
+     */
+    suspend fun resolveKnownAuthServer(authServerUrl: String): AuthServerMetadata {
+        val normalized = if (authServerUrl.startsWith("http")) authServerUrl else "https://$authServerUrl"
+        val metadata = fetchAuthServerMetadata(normalized)
+        return AuthServerMetadata(
+            issuer = metadata.issuer ?: normalized,
+            authorizationEndpoint = metadata.authorizationEndpoint
+                ?: throw OAuthDiscoveryException("authorization_endpoint missing from auth server metadata at $normalized"),
+            tokenEndpoint = metadata.tokenEndpoint
+                ?: throw OAuthDiscoveryException("token_endpoint missing from auth server metadata at $normalized"),
+            parEndpoint = metadata.pushedAuthorizationRequestEndpoint
+                ?: throw OAuthDiscoveryException("pushed_authorization_request_endpoint missing from auth server metadata at $normalized"),
+            revocationEndpoint = metadata.revocationEndpoint,
+            pdsUrl = null,
+            did = null,
+            handle = null,
+            promptValuesSupported = metadata.promptValuesSupported ?: emptyList(),
+        )
+    }
+
+    /**
+     * Resolves a DID to a (`handle`, `pdsUrl`) pair using the same logic
+     * the eager chain uses for the second half of `resolve`. Used by the
+     * signup path post-token-exchange, where the token response carries
+     * a freshly-minted `sub` DID that the consumer has no handle for.
+     *
+     * Retries on transient `OAuthDiscoveryException` (typically a PLC
+     * propagation delay) with bounded exponential backoff. Returns `null`
+     * for whichever field could not be resolved when the retry budget
+     * exhausts; the access token remains usable for DID-keyed calls.
+     */
+    internal suspend fun hydrateIdentityFromDid(did: String): HydratedIdentity {
+        var lastError: OAuthDiscoveryException? = null
+        val delaysMs = longArrayOf(0, 100, 400, 1200)
+        for (attemptDelay in delaysMs) {
+            if (attemptDelay > 0) delay(attemptDelay)
+            try {
+                val doc = resolveDid(did)
+                val pdsUrl = doc.service?.firstOrNull { it.id == "#atproto_pds" }?.serviceEndpoint
+                val handle = doc.alsoKnownAs?.firstOrNull { it.startsWith("at://") }?.removePrefix("at://")
+                return HydratedIdentity(handle = handle, pdsUrl = pdsUrl)
+            } catch (e: OAuthDiscoveryException) {
+                lastError = e
+            }
+        }
+        // Budget exhausted: surface what we never got, let caller persist nulls
+        return HydratedIdentity(handle = null, pdsUrl = null, lastError = lastError)
+    }
+
+    internal data class HydratedIdentity(
+        val handle: String?,
+        val pdsUrl: String?,
+        val lastError: OAuthDiscoveryException? = null,
+    )
 
     /**
      * Handle → DID resolution. Tries two methods in order:
@@ -272,11 +350,13 @@ internal data class AuthorizationServerMetadata(
     val revocation_endpoint: String? = null,
     val dpop_signing_alg_values_supported: List<String>? = null,
     val scopes_supported: List<String>? = null,
+    val prompt_values_supported: List<String>? = null,
 ) {
     val authorizationEndpoint: String? get() = authorization_endpoint
     val tokenEndpoint: String? get() = token_endpoint
     val pushedAuthorizationRequestEndpoint: String? get() = pushed_authorization_request_endpoint
     val revocationEndpoint: String? get() = revocation_endpoint
+    val promptValuesSupported: List<String>? get() = prompt_values_supported
 }
 
 @Serializable

--- a/oauth/src/main/kotlin/io/github/kikin81/atproto/oauth/DiscoveryChain.kt
+++ b/oauth/src/main/kotlin/io/github/kikin81/atproto/oauth/DiscoveryChain.kt
@@ -100,11 +100,20 @@ class DiscoveryChain(
      * left null — populate them post-token-exchange via
      * [hydrateIdentityFromDid].
      *
-     * Accepts either a bare hostname (`"bsky.social"`) or a full URL
-     * (`"https://bsky.social"`); both are normalized to a URL prefix.
+     * Accepts either a bare hostname (`"bsky.social"`) or an `https://`
+     * URL (`"https://bsky.social"`); both are normalized. Plain `http://`
+     * URLs are rejected because OAuth 2.0 requires the authorization
+     * server be reached over TLS.
      */
     suspend fun resolveKnownAuthServer(authServerUrl: String): AuthServerMetadata {
-        val normalized = if (authServerUrl.startsWith("http")) authServerUrl else "https://$authServerUrl"
+        val normalized = when {
+            authServerUrl.startsWith("https://") -> authServerUrl
+            authServerUrl.startsWith("http://") ->
+                throw OAuthDiscoveryException(
+                    "Authorization server URL must use HTTPS, got: $authServerUrl",
+                )
+            else -> "https://$authServerUrl"
+        }
         val metadata = fetchAuthServerMetadata(normalized)
         return AuthServerMetadata(
             issuer = metadata.issuer ?: normalized,
@@ -128,13 +137,23 @@ class DiscoveryChain(
      * signup path post-token-exchange, where the token response carries
      * a freshly-minted `sub` DID that the consumer has no handle for.
      *
-     * Retries on transient `OAuthDiscoveryException` (typically a PLC
-     * propagation delay) with bounded exponential backoff. Returns `null`
-     * for whichever field could not be resolved when the retry budget
-     * exhausts; the access token remains usable for DID-keyed calls.
+     * Retries with bounded exponential backoff in two failure modes:
+     * - the DID document fetch itself throws (PLC not yet aware of the DID),
+     * - the document was fetched but is missing the `#atproto_pds` service
+     *   or the `at://` handle in `alsoKnownAs` (PLC has the record but the
+     *   PDS hasn't published yet).
+     *
+     * Across attempts, the best-resolved value of each field is retained —
+     * so if attempt 2 returns a handle but no PDS and attempt 3 throws,
+     * the caller still gets the handle. Early-exits as soon as both fields
+     * are populated; otherwise returns the best-known pair when the budget
+     * exhausts. The access token remains usable for DID-keyed calls even
+     * if `pdsUrl` is never resolved.
      */
     internal suspend fun hydrateIdentityFromDid(did: String): HydratedIdentity {
         var lastError: OAuthDiscoveryException? = null
+        var bestHandle: String? = null
+        var bestPdsUrl: String? = null
         val delaysMs = longArrayOf(0, 100, 400, 1200)
         for (attemptDelay in delaysMs) {
             if (attemptDelay > 0) delay(attemptDelay)
@@ -142,13 +161,18 @@ class DiscoveryChain(
                 val doc = resolveDid(did)
                 val pdsUrl = doc.service?.firstOrNull { it.id == "#atproto_pds" }?.serviceEndpoint
                 val handle = doc.alsoKnownAs?.firstOrNull { it.startsWith("at://") }?.removePrefix("at://")
-                return HydratedIdentity(handle = handle, pdsUrl = pdsUrl)
+                if (handle != null) bestHandle = handle
+                if (pdsUrl != null) bestPdsUrl = pdsUrl
+                if (bestHandle != null && bestPdsUrl != null) {
+                    return HydratedIdentity(handle = bestHandle, pdsUrl = bestPdsUrl)
+                }
+                // Partial doc — retry; another attempt may publish the missing fields.
             } catch (e: OAuthDiscoveryException) {
                 lastError = e
             }
         }
-        // Budget exhausted: surface what we never got, let caller persist nulls
-        return HydratedIdentity(handle = null, pdsUrl = null, lastError = lastError)
+        // Budget exhausted: persist whatever resolved (possibly partial / both null).
+        return HydratedIdentity(handle = bestHandle, pdsUrl = bestPdsUrl, lastError = lastError)
     }
 
     internal data class HydratedIdentity(

--- a/oauth/src/main/kotlin/io/github/kikin81/atproto/oauth/OAuthExceptions.kt
+++ b/oauth/src/main/kotlin/io/github/kikin81/atproto/oauth/OAuthExceptions.kt
@@ -5,3 +5,22 @@ class OAuthAccountMismatchException(message: String) : RuntimeException(message)
 class OAuthSessionExpiredException(message: String, cause: Throwable? = null) : RuntimeException(message, cause)
 
 class OAuthException(message: String, cause: Throwable? = null) : RuntimeException(message, cause)
+
+/**
+ * Thrown by [AtOAuth.beginSignup] when the configured authorization server's
+ * `/.well-known/oauth-authorization-server` metadata does not advertise
+ * `"create"` in `prompt_values_supported`. Per OIDC Prompt Create 1.0 the
+ * `prompt=create` value tells the server "render the signup UI"; servers
+ * that don't advertise the value may silently ignore it or reject the PAR.
+ *
+ * Consumers targeting non-conformant entryways can bypass the check via
+ * `beginSignup(authServer, requirePromptCreateSupport = false)`.
+ */
+class OAuthSignupNotSupportedException(
+    val authServerUrl: String,
+    val advertisedPromptValues: List<String>,
+) : RuntimeException(
+    "Authorization server '$authServerUrl' does not advertise 'create' in " +
+        "prompt_values_supported (advertised: $advertisedPromptValues). " +
+        "Pass requirePromptCreateSupport=false to override.",
+)

--- a/oauth/src/main/kotlin/io/github/kikin81/atproto/oauth/OAuthSession.kt
+++ b/oauth/src/main/kotlin/io/github/kikin81/atproto/oauth/OAuthSession.kt
@@ -11,14 +11,20 @@ import kotlinx.serialization.Serializable
  * X509 public key) rather than as JWK JSON. The consumer's
  * [OAuthSessionStore] implementation is responsible for encrypting these
  * at rest (e.g. via EncryptedSharedPreferences on Android).
+ *
+ * [did], [handle], and [pdsUrl] are nullable to accommodate the signup
+ * flow's brief window between token exchange and identity hydration. Once
+ * hydration completes (or its bounded retry budget exhausts) the session
+ * is re-persisted with whatever values resolved. The login flow always
+ * populates all three eagerly.
  */
 @Serializable
 data class OAuthSession(
     val accessToken: String,
     val refreshToken: String,
-    val did: String,
-    val handle: String,
-    val pdsUrl: String,
+    val did: String?,
+    val handle: String?,
+    val pdsUrl: String?,
     val tokenEndpoint: String,
     val revocationEndpoint: String? = null,
     val clientId: String? = null,
@@ -34,7 +40,7 @@ data class OAuthSession(
         return did == other.did && accessToken == other.accessToken
     }
 
-    override fun hashCode(): Int = did.hashCode() * 31 + accessToken.hashCode()
+    override fun hashCode(): Int = (did?.hashCode() ?: 0) * 31 + accessToken.hashCode()
 }
 
 /**

--- a/oauth/src/test/kotlin/io/github/kikin81/atproto/oauth/AtOAuthTest.kt
+++ b/oauth/src/test/kotlin/io/github/kikin81/atproto/oauth/AtOAuthTest.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.JsonObject
 import kotlin.test.Test
 import kotlin.test.assertContains
+import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
@@ -594,6 +595,305 @@ class AtOAuthTest {
         )
         oauth.logout()
         assertTrue(store.session == null)
+    }
+
+    // ---------- Signup flow tests ----------
+
+    /**
+     * Auth-server metadata advertising prompt=create — the bsky.social shape.
+     */
+    private val bskySocialAuthServerMetadata =
+        """{"issuer":"https://bsky.social","authorization_endpoint":"https://bsky.social/oauth/authorize","token_endpoint":"https://bsky.social/oauth/token","pushed_authorization_request_endpoint":"https://bsky.social/oauth/par","prompt_values_supported":["none","login","consent","select_account","create"]}"""
+
+    @Test
+    fun beginSignupShortCircuitsDiscoveryAndSendsPromptCreate() = runTest {
+        val store = InMemorySessionStore()
+        val requestedUrls = mutableListOf<String>()
+        var parBody: String? = null
+        val client = HttpClient(
+            MockEngine { request ->
+                requestedUrls.add(request.url.toString())
+                when {
+                    request.url.toString().contains("/.well-known/oauth-authorization-server") ->
+                        respond(ByteReadChannel(bskySocialAuthServerMetadata), HttpStatusCode.OK, jsonHeaders)
+
+                    request.url.toString().contains("/par") -> {
+                        parBody = (request.body as io.ktor.http.content.OutgoingContent.ByteArrayContent).bytes().decodeToString()
+                        respond(
+                            ByteReadChannel("""{"request_uri":"urn:ietf:params:oauth:request_uri:signup-test","expires_in":60}"""),
+                            HttpStatusCode.OK,
+                            jsonHeaders,
+                        )
+                    }
+
+                    else -> respond(ByteReadChannel(""), HttpStatusCode.NotFound)
+                }
+            },
+        )
+
+        val oauth = AtOAuth(
+            clientMetadataUrl = "https://app.test/oauth/client-metadata.json",
+            redirectUri = "app.example:/oauth-redirect",
+            sessionStore = store,
+            httpClient = client,
+        )
+        val authUrl = oauth.beginSignup()
+
+        // No PLC, no atproto-did, no oauth-protected-resource fetched
+        val discoveryUrls = requestedUrls.filter { it.contains("/.well-known") }
+        assertEquals(1, discoveryUrls.size, "expected exactly 1 well-known fetch (the auth-server metadata), got: $discoveryUrls")
+        assertTrue(discoveryUrls[0].contains("oauth-authorization-server"))
+
+        // PAR body carries prompt=create and no login_hint
+        val body = parBody
+        assertNotNull(body)
+        assertContains(body, "prompt=create")
+        assertTrue(!body.contains("login_hint"), "PAR body should not contain login_hint, got: $body")
+
+        // Authorization URL points at the known auth server
+        assertContains(authUrl, "https://bsky.social/oauth/authorize")
+    }
+
+    @Test
+    fun completeLoginAfterSignupAcceptsTokenSubAsAuthority() = runTest {
+        val store = InMemorySessionStore()
+        val client = HttpClient(
+            MockEngine { request ->
+                val url = request.url.toString()
+                when {
+                    url.contains("/.well-known/oauth-authorization-server") ->
+                        respond(ByteReadChannel(bskySocialAuthServerMetadata), HttpStatusCode.OK, jsonHeaders)
+
+                    url.contains("/par") ->
+                        respond(
+                            ByteReadChannel("""{"request_uri":"urn:test","expires_in":60}"""),
+                            HttpStatusCode.OK,
+                            jsonHeaders,
+                        )
+
+                    url.contains("/token") ->
+                        respond(
+                            ByteReadChannel(
+                                """{"access_token":"at_signup","refresh_token":"rt_signup","sub":"did:plc:freshlyminted"}""",
+                            ),
+                            HttpStatusCode.OK,
+                            jsonHeaders,
+                        )
+
+                    url.contains("plc.directory/did:plc:freshlyminted") ->
+                        respond(
+                            ByteReadChannel(
+                                """{"id":"did:plc:freshlyminted","alsoKnownAs":["at://newbie.bsky.social"],"service":[{"id":"#atproto_pds","type":"AtprotoPersonalDataServer","serviceEndpoint":"https://newbie-pds.test"}]}""",
+                            ),
+                            HttpStatusCode.OK,
+                            jsonHeaders,
+                        )
+
+                    else -> respond(ByteReadChannel(""), HttpStatusCode.NotFound)
+                }
+            },
+        )
+
+        val oauth = AtOAuth(
+            clientMetadataUrl = "https://app.test/oauth/client-metadata.json",
+            redirectUri = "app.example:/oauth-redirect",
+            sessionStore = store,
+            httpClient = client,
+        )
+        oauth.beginSignup()
+        oauth.completeLogin(
+            "app.example:/oauth-redirect?code=signup_code&state=${extractState(oauth)}&iss=https://bsky.social",
+        )
+
+        val session = store.session
+        assertNotNull(session)
+        // sub from the token response is the authoritative DID — no prior comparison
+        assertEquals("did:plc:freshlyminted", session.did)
+        // handle and pdsUrl hydrated from the DID doc
+        assertEquals("newbie.bsky.social", session.handle)
+        assertEquals("https://newbie-pds.test", session.pdsUrl)
+    }
+
+    @Test
+    fun signupHydrationRetriesAndPersistsNullIdentityWhenBudgetExhausts() = runTest {
+        val store = InMemorySessionStore()
+        var plcCallCount = 0
+        val client = HttpClient(
+            MockEngine { request ->
+                val url = request.url.toString()
+                when {
+                    url.contains("/.well-known/oauth-authorization-server") ->
+                        respond(ByteReadChannel(bskySocialAuthServerMetadata), HttpStatusCode.OK, jsonHeaders)
+
+                    url.contains("/par") ->
+                        respond(
+                            ByteReadChannel("""{"request_uri":"urn:t","expires_in":60}"""),
+                            HttpStatusCode.OK,
+                            jsonHeaders,
+                        )
+
+                    url.contains("/token") ->
+                        respond(
+                            ByteReadChannel(
+                                """{"access_token":"at","refresh_token":"rt","sub":"did:plc:slowpropagation"}""",
+                            ),
+                            HttpStatusCode.OK,
+                            jsonHeaders,
+                        )
+
+                    url.contains("plc.directory") -> {
+                        plcCallCount++
+                        // Always 404 — simulate propagation delay never resolving in-window
+                        respond(ByteReadChannel(""), HttpStatusCode.NotFound)
+                    }
+
+                    else -> respond(ByteReadChannel(""), HttpStatusCode.NotFound)
+                }
+            },
+        )
+
+        val oauth = AtOAuth(
+            clientMetadataUrl = "https://app.test/oauth/client-metadata.json",
+            redirectUri = "app.example:/oauth-redirect",
+            sessionStore = store,
+            httpClient = client,
+        )
+        oauth.beginSignup()
+        oauth.completeLogin(
+            "app.example:/oauth-redirect?code=c&state=${extractState(oauth)}&iss=https://bsky.social",
+        )
+
+        // Retried multiple times before giving up (4 attempts: immediate + 3 backoff slots)
+        assertTrue(plcCallCount >= 2, "expected at least 2 PLC attempts under backoff, got $plcCallCount")
+
+        // Session persisted with DID populated but handle/pds null
+        val session = store.session
+        assertNotNull(session)
+        assertEquals("did:plc:slowpropagation", session.did)
+        assertEquals(null, session.handle)
+        assertEquals(null, session.pdsUrl)
+    }
+
+    @Test
+    fun beginLoginStillRejectsMismatchedSubAfterSignupBranching() = runTest {
+        // Regression: signup-flow branching must NOT disable login-flow's DID mismatch check.
+        val store = InMemorySessionStore()
+        val client = HttpClient(
+            MockEngine { request ->
+                val url = request.url.toString()
+                when {
+                    url.contains("/.well-known/atproto-did") ->
+                        respond(ByteReadChannel("did:plc:expected"), HttpStatusCode.OK)
+
+                    url.contains("plc.directory") ->
+                        respond(
+                            ByteReadChannel(
+                                """{"id":"did:plc:expected","alsoKnownAs":["at://alice.test"],"service":[{"id":"#atproto_pds","type":"AtprotoPersonalDataServer","serviceEndpoint":"https://pds.test"}]}""",
+                            ),
+                            HttpStatusCode.OK,
+                            jsonHeaders,
+                        )
+
+                    url.contains("/.well-known/oauth-protected-resource") ->
+                        respond(ByteReadChannel("""{"authorization_servers":["https://auth.test"]}"""), HttpStatusCode.OK, jsonHeaders)
+
+                    url.contains("/.well-known/oauth-authorization-server") ->
+                        respond(
+                            ByteReadChannel(
+                                """{"issuer":"https://auth.test","authorization_endpoint":"https://auth.test/authorize","token_endpoint":"https://auth.test/token","pushed_authorization_request_endpoint":"https://auth.test/par"}""",
+                            ),
+                            HttpStatusCode.OK,
+                            jsonHeaders,
+                        )
+
+                    url.contains("/par") ->
+                        respond(ByteReadChannel("""{"request_uri":"urn:t","expires_in":60}"""), HttpStatusCode.OK, jsonHeaders)
+
+                    url.contains("/token") ->
+                        respond(
+                            ByteReadChannel("""{"access_token":"at","refresh_token":"rt","sub":"did:plc:WRONG"}"""),
+                            HttpStatusCode.OK,
+                            jsonHeaders,
+                        )
+
+                    else -> respond(ByteReadChannel(""), HttpStatusCode.NotFound)
+                }
+            },
+        )
+
+        val oauth = AtOAuth("https://app.test/m.json", "app.example:/oauth-redirect", store, client)
+        oauth.beginLogin("alice.test")
+        assertFailsWith<OAuthAccountMismatchException> {
+            oauth.completeLogin(
+                "app.example:/oauth-redirect?code=c&state=${extractState(oauth)}&iss=https://auth.test",
+            )
+        }
+    }
+
+    @Test
+    fun beginSignupRejectsServerWithoutPromptCreateSupport() = runTest {
+        val store = InMemorySessionStore()
+        val client = HttpClient(
+            MockEngine { request ->
+                if (request.url.toString().contains("/.well-known/oauth-authorization-server")) {
+                    respond(
+                        ByteReadChannel(
+                            """{"issuer":"https://entryway.test","authorization_endpoint":"https://entryway.test/a","token_endpoint":"https://entryway.test/t","pushed_authorization_request_endpoint":"https://entryway.test/p","prompt_values_supported":["none","login","consent"]}""",
+                        ),
+                        HttpStatusCode.OK,
+                        jsonHeaders,
+                    )
+                } else {
+                    respond(ByteReadChannel(""), HttpStatusCode.NotFound)
+                }
+            },
+        )
+
+        val oauth = AtOAuth("https://app.test/m.json", "app.example:/oauth-redirect", store, client)
+        val ex = assertFailsWith<OAuthSignupNotSupportedException> {
+            oauth.beginSignup(authServer = "entryway.test")
+        }
+        assertContains(ex.advertisedPromptValues, "none")
+        assertTrue(!ex.advertisedPromptValues.contains("create"))
+    }
+
+    @Test
+    fun beginSignupBypassesGateWhenRequirePromptCreateSupportFalse() = runTest {
+        val store = InMemorySessionStore()
+        var parBody: String? = null
+        val client = HttpClient(
+            MockEngine { request ->
+                when {
+                    request.url.toString().contains("/.well-known/oauth-authorization-server") ->
+                        respond(
+                            ByteReadChannel(
+                                """{"issuer":"https://entryway.test","authorization_endpoint":"https://entryway.test/a","token_endpoint":"https://entryway.test/t","pushed_authorization_request_endpoint":"https://entryway.test/p","prompt_values_supported":["none","login"]}""",
+                            ),
+                            HttpStatusCode.OK,
+                            jsonHeaders,
+                        )
+
+                    request.url.toString().contains("/p") -> {
+                        parBody = (request.body as io.ktor.http.content.OutgoingContent.ByteArrayContent).bytes().decodeToString()
+                        respond(
+                            ByteReadChannel("""{"request_uri":"urn:t","expires_in":60}"""),
+                            HttpStatusCode.OK,
+                            jsonHeaders,
+                        )
+                    }
+
+                    else -> respond(ByteReadChannel(""), HttpStatusCode.NotFound)
+                }
+            },
+        )
+
+        val oauth = AtOAuth("https://app.test/m.json", "app.example:/oauth-redirect", store, client)
+        // Must NOT throw despite missing "create" in prompt_values_supported
+        oauth.beginSignup(authServer = "entryway.test", requirePromptCreateSupport = false)
+
+        val body = parBody
+        assertNotNull(body)
+        assertContains(body, "prompt=create")
     }
 
     /**

--- a/oauth/src/test/kotlin/io/github/kikin81/atproto/oauth/AtOAuthTest.kt
+++ b/oauth/src/test/kotlin/io/github/kikin81/atproto/oauth/AtOAuthTest.kt
@@ -775,6 +775,100 @@ class AtOAuthTest {
     }
 
     @Test
+    fun signupPersistsTokensBeforeHydrationCompletes() = runTest {
+        // Two-write semantics: first save carries the new DID + null identity
+        // (crash-resilience guarantee), second save carries the hydrated identity.
+        val saves = mutableListOf<OAuthSession>()
+        val store = object : OAuthSessionStore {
+            override suspend fun load(): OAuthSession? = saves.lastOrNull()
+            override suspend fun save(session: OAuthSession) {
+                saves.add(session)
+            }
+            override suspend fun clear() {
+                saves.clear()
+            }
+        }
+        val client = HttpClient(
+            MockEngine { request ->
+                val url = request.url.toString()
+                when {
+                    url.contains("/.well-known/oauth-authorization-server") ->
+                        respond(ByteReadChannel(bskySocialAuthServerMetadata), HttpStatusCode.OK, jsonHeaders)
+
+                    url.contains("/par") ->
+                        respond(ByteReadChannel("""{"request_uri":"urn:t","expires_in":60}"""), HttpStatusCode.OK, jsonHeaders)
+
+                    url.contains("/token") ->
+                        respond(
+                            ByteReadChannel(
+                                """{"access_token":"at","refresh_token":"rt","sub":"did:plc:newuser"}""",
+                            ),
+                            HttpStatusCode.OK,
+                            jsonHeaders,
+                        )
+
+                    url.contains("plc.directory/did:plc:newuser") ->
+                        respond(
+                            ByteReadChannel(
+                                """{"id":"did:plc:newuser","alsoKnownAs":["at://newbie.bsky.social"],"service":[{"id":"#atproto_pds","type":"AtprotoPersonalDataServer","serviceEndpoint":"https://newbie-pds.test"}]}""",
+                            ),
+                            HttpStatusCode.OK,
+                            jsonHeaders,
+                        )
+
+                    else -> respond(ByteReadChannel(""), HttpStatusCode.NotFound)
+                }
+            },
+        )
+
+        val oauth = AtOAuth("https://app.test/m.json", "app.example:/oauth-redirect", store, client)
+        oauth.beginSignup()
+        oauth.completeLogin(
+            "app.example:/oauth-redirect?code=c&state=${extractState(oauth)}&iss=https://bsky.social",
+        )
+
+        assertEquals(2, saves.size, "signup flow should persist twice: pre- and post-hydration")
+        // First save: DID known, identity not yet hydrated
+        assertEquals("did:plc:newuser", saves[0].did)
+        assertEquals(null, saves[0].handle)
+        assertEquals(null, saves[0].pdsUrl)
+        assertEquals("at", saves[0].accessToken)
+        // Second save: identity hydrated
+        assertEquals("did:plc:newuser", saves[1].did)
+        assertEquals("newbie.bsky.social", saves[1].handle)
+        assertEquals("https://newbie-pds.test", saves[1].pdsUrl)
+    }
+
+    @Test
+    fun loginFlowPersistsSessionOnce() = runTest {
+        // Regression: login path remains single-write (no benefit to a second save
+        // since identity is fully resolved before the first persist).
+        val saves = mutableListOf<OAuthSession>()
+        val store = object : OAuthSessionStore {
+            override suspend fun load(): OAuthSession? = saves.lastOrNull()
+            override suspend fun save(session: OAuthSession) {
+                saves.add(session)
+            }
+            override suspend fun clear() {
+                saves.clear()
+            }
+        }
+        val oauth = AtOAuth(
+            clientMetadataUrl = "https://app.test/oauth/client-metadata.json",
+            redirectUri = "app.example:/oauth-redirect",
+            sessionStore = store,
+            httpClient = fullFlowMockClient(),
+        )
+        oauth.beginLogin("alice.test")
+        oauth.completeLogin(
+            "app.example:/oauth-redirect?code=c&state=${extractState(oauth)}&iss=https://auth.test",
+        )
+
+        assertEquals(1, saves.size, "login flow should persist exactly once")
+        assertEquals("alice.test", saves[0].handle)
+    }
+
+    @Test
     fun beginLoginStillRejectsMismatchedSubAfterSignupBranching() = runTest {
         // Regression: signup-flow branching must NOT disable login-flow's DID mismatch check.
         val store = InMemorySessionStore()

--- a/oauth/src/test/kotlin/io/github/kikin81/atproto/oauth/DiscoveryChainTest.kt
+++ b/oauth/src/test/kotlin/io/github/kikin81/atproto/oauth/DiscoveryChainTest.kt
@@ -216,4 +216,69 @@ class DiscoveryChainTest {
         assertEquals("did:plc:direct", metadata.did)
         assertEquals("direct.example.com", metadata.handle)
     }
+
+    @Test
+    fun resolveKnownAuthServerSkipsIdentityResolution() = runTest {
+        var requestedUrls = mutableListOf<String>()
+        val client = HttpClient(
+            MockEngine { request ->
+                requestedUrls.add(request.url.toString())
+                if (request.url.toString().contains("/.well-known/oauth-authorization-server")) {
+                    respond(
+                        ByteReadChannel(
+                            """{"issuer":"https://bsky.social","authorization_endpoint":"https://bsky.social/oauth/authorize","token_endpoint":"https://bsky.social/oauth/token","pushed_authorization_request_endpoint":"https://bsky.social/oauth/par","prompt_values_supported":["none","login","consent","select_account","create"]}""",
+                        ),
+                        HttpStatusCode.OK,
+                        jsonHeaders,
+                    )
+                } else {
+                    respond(ByteReadChannel(""), HttpStatusCode.NotFound)
+                }
+            },
+        )
+
+        val metadata = DiscoveryChain(client).resolveKnownAuthServer("bsky.social")
+
+        // Endpoints populated
+        assertEquals("https://bsky.social", metadata.issuer)
+        assertEquals("https://bsky.social/oauth/authorize", metadata.authorizationEndpoint)
+        assertEquals("https://bsky.social/oauth/token", metadata.tokenEndpoint)
+        assertEquals("https://bsky.social/oauth/par", metadata.parEndpoint)
+
+        // prompt_values_supported parsed
+        assertTrue(metadata.promptValuesSupported.contains("create"))
+
+        // Identity fields null — discovery was short-circuited
+        assertEquals(null, metadata.did)
+        assertEquals(null, metadata.handle)
+        assertEquals(null, metadata.pdsUrl)
+
+        // Only one HTTP call — the auth-server metadata fetch
+        assertEquals(1, requestedUrls.size, "expected single HTTP call, got: $requestedUrls")
+        assertTrue(requestedUrls[0].contains("/.well-known/oauth-authorization-server"))
+    }
+
+    @Test
+    fun resolveKnownAuthServerAcceptsFullUrl() = runTest {
+        val client = HttpClient(
+            MockEngine { request ->
+                if (request.url.toString().contains("/.well-known/oauth-authorization-server")) {
+                    respond(
+                        ByteReadChannel(
+                            """{"issuer":"https://entryway.test","authorization_endpoint":"https://entryway.test/a","token_endpoint":"https://entryway.test/t","pushed_authorization_request_endpoint":"https://entryway.test/p"}""",
+                        ),
+                        HttpStatusCode.OK,
+                        jsonHeaders,
+                    )
+                } else {
+                    respond(ByteReadChannel(""), HttpStatusCode.NotFound)
+                }
+            },
+        )
+
+        val metadata = DiscoveryChain(client).resolveKnownAuthServer("https://entryway.test")
+        assertEquals("https://entryway.test", metadata.issuer)
+        // promptValuesSupported empty when server doesn't advertise it
+        assertTrue(metadata.promptValuesSupported.isEmpty())
+    }
 }

--- a/oauth/src/test/kotlin/io/github/kikin81/atproto/oauth/DiscoveryChainTest.kt
+++ b/oauth/src/test/kotlin/io/github/kikin81/atproto/oauth/DiscoveryChainTest.kt
@@ -281,4 +281,73 @@ class DiscoveryChainTest {
         // promptValuesSupported empty when server doesn't advertise it
         assertTrue(metadata.promptValuesSupported.isEmpty())
     }
+
+    @Test
+    fun resolveKnownAuthServerRejectsPlainHttpUrl() = runTest {
+        val client = HttpClient(MockEngine { respond(ByteReadChannel(""), HttpStatusCode.OK) })
+        val ex = assertFailsWith<OAuthDiscoveryException> {
+            DiscoveryChain(client).resolveKnownAuthServer("http://insecure.test")
+        }
+        assertTrue(ex.message!!.contains("HTTPS"), "expected HTTPS-related error, got: ${ex.message}")
+    }
+
+    @Test
+    fun hydrateIdentityRetriesWhenDocReturnsPartialThenComplete() = runTest {
+        var attempt = 0
+        val client = HttpClient(
+            MockEngine { request ->
+                if (request.url.toString().contains("plc.directory/did:plc:partial")) {
+                    attempt++
+                    val body = when (attempt) {
+                        // First attempt: DID doc exists but service[] is empty and alsoKnownAs is empty
+                        1 -> """{"id":"did:plc:partial","alsoKnownAs":[],"service":[]}"""
+                        // Second attempt: handle is now in alsoKnownAs, still no PDS
+                        2 -> """{"id":"did:plc:partial","alsoKnownAs":["at://late.bsky.social"],"service":[]}"""
+                        // Third attempt: both fields populated
+                        else ->
+                            """{"id":"did:plc:partial","alsoKnownAs":["at://late.bsky.social"],"service":[{"id":"#atproto_pds","type":"AtprotoPersonalDataServer","serviceEndpoint":"https://late-pds.test"}]}"""
+                    }
+                    respond(ByteReadChannel(body), HttpStatusCode.OK, jsonHeaders)
+                } else {
+                    respond(ByteReadChannel(""), HttpStatusCode.NotFound)
+                }
+            },
+        )
+
+        val hydrated = DiscoveryChain(client).hydrateIdentityFromDid("did:plc:partial")
+        assertEquals("late.bsky.social", hydrated.handle)
+        assertEquals("https://late-pds.test", hydrated.pdsUrl)
+        assertTrue(attempt >= 3, "expected at least 3 attempts under retry budget, got $attempt")
+    }
+
+    @Test
+    fun hydrateIdentityRetainsBestKnownAcrossAttempts() = runTest {
+        var attempt = 0
+        val client = HttpClient(
+            MockEngine { request ->
+                if (request.url.toString().contains("plc.directory/did:plc:flaky")) {
+                    attempt++
+                    when (attempt) {
+                        // Attempt 1: handle present, no PDS
+                        1 -> respond(
+                            ByteReadChannel(
+                                """{"id":"did:plc:flaky","alsoKnownAs":["at://flaky.test"],"service":[]}""",
+                            ),
+                            HttpStatusCode.OK,
+                            jsonHeaders,
+                        )
+                        // Attempts 2-4: 404 (PLC fluttered offline)
+                        else -> respond(ByteReadChannel(""), HttpStatusCode.NotFound)
+                    }
+                } else {
+                    respond(ByteReadChannel(""), HttpStatusCode.NotFound)
+                }
+            },
+        )
+
+        val hydrated = DiscoveryChain(client).hydrateIdentityFromDid("did:plc:flaky")
+        // Best-known handle from attempt 1 is preserved through subsequent failures
+        assertEquals("flaky.test", hydrated.handle)
+        assertEquals(null, hydrated.pdsUrl)
+    }
 }

--- a/openspec/changes/add-oauth-signup-flow/.openspec.yaml
+++ b/openspec/changes/add-oauth-signup-flow/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-20

--- a/openspec/changes/add-oauth-signup-flow/design.md
+++ b/openspec/changes/add-oauth-signup-flow/design.md
@@ -1,0 +1,90 @@
+## Context
+
+`AtOAuth.beginLogin(handle)` runs the full discovery chain (`resolveHandle` → `resolveDid` → `resolvePds` → `resolveAuthServer` → `fetchAuthServerMetadata`) before issuing the PAR request. The chain produces an `AuthServerMetadata` value that carries the discovered `did`, `handle`, and `pdsUrl` alongside the OAuth endpoints. Downstream, `completeLogin` validates the token-response `sub` claim against that pre-resolved DID (`AtOAuth.kt:155-159`), and the session is persisted with those identity fields.
+
+For a brand-new user, none of those fields exist yet. The auth server (`bsky.social`) advertises `prompt=create` in its `prompt_values_supported` and OIDC Prompt Create 1.0 imposes no identifier requirement; the atproto OAuth spec explicitly permits hostname-only flows with no `login_hint`. The challenge is therefore not the wire shape — it's that the SDK's internal state machine assumes identity is known up front.
+
+Downstream consumer `kikin81/nubecita` (beads ticket `nubecita-lq9t.3.5`) is blocked on this; it expects a single suspending entry point that returns an authorization URL parallel to `beginLogin`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add a public entry point on `AtOAuth` that begins an OAuth flow with no handle/DID, against a known auth server (default `bsky.social`), with OIDC `prompt=create` in the PAR body.
+- Reuse the existing `completeLogin(redirectUri)` redirect handler — consumers do not write new redirect plumbing.
+- After the user signs up in the browser and the redirect lands, the consuming app is signed in as the new account with no manual handle re-entry.
+- Keep the binary-compat blast radius confined to a single major release: refresh `.api` files, commit with a `BREAKING CHANGE:` footer, ship a `docs/breaking-changes/vN.md` entry.
+
+**Non-Goals:**
+- Handle-picker UI inside the SDK (the auth server renders that).
+- Custom-PDS signup (most users target `bsky.social`; defer until a real consumer asks).
+- Direct-XRPC `com.atproto.server.createAccount` flow (different shape entirely).
+- Supporting `prompt=login` / `prompt=select_account` in this change (out of scope; see Open Questions for whether the API should be named to leave room for them).
+
+## Decisions
+
+### Decision 1: API shape — `beginSignup(authServer)` vs `beginAnonymousAuth(authServer, prompt)`
+
+**Chosen:** `beginSignup(authServer: String = "bsky.social"): String`.
+
+**Rationale:** The narrow, intent-revealing name matches the only consumer use case we have today (signup) and reads naturally next to `beginLogin(handle)`. Callers don't have to know the OIDC `prompt` vocabulary.
+
+**Alternative considered:** A generic `beginAnonymousAuth(authServer: String, prompt: String): String`. Would also unlock future `prompt=login` and `prompt=select_account` flows without another binary-breaking API addition. **Rejected for v1** because: (a) it leaks an OIDC-spec parameter name into our public surface, which we've otherwise kept abstract; (b) per the repo memory, *any* parameter addition is binary-breaking even with defaults, so adding `prompt=login` later is just as expensive as adding a second narrow entry point — no future-proofing win. We will keep the option open by *not* taking the name `beginSignup` for any broader meaning later.
+
+### Decision 2: Discovery short-circuit lives in `DiscoveryChain`
+
+Add `DiscoveryChain.resolveKnownAuthServer(authServerUrl: String): AuthServerMetadata` that calls only `fetchAuthServerMetadata` and returns a value with `did = null`, `handle = null`, `pdsUrl = null`. The existing `resolve(handle)` path is unchanged. This keeps discovery logic in one place and avoids `AtOAuth` learning to do partial chains.
+
+### Decision 3: Make `did`, `handle`, `pdsUrl` nullable on `AuthServerMetadata` and `OAuthSession`
+
+These three fields become `String?` to express "not known until after token exchange." This is the breaking change. Login path populates them as before; signup path populates them from the token response.
+
+**Alternative considered:** Introduce a parallel `PendingSignupMetadata` type with a sealed-class hierarchy over `AuthServerMetadata`. Rejected: doubles the type surface for a flag's worth of state, and `OAuthSession` would need a sealed split too. The nullable approach is uglier in one place but contains the blast radius.
+
+### Decision 4: `PendingAuthState` gains a flow-origin flag
+
+Add `flowOrigin: FlowOrigin` (enum: `Login`, `Signup`). `completeLogin` branches on it:
+- **Login:** existing behavior — `tokenResponse.sub` MUST equal `metadata.did`, else throw `OAuthAccountMismatchException`.
+- **Signup:** `metadata.did` is null; accept `tokenResponse.sub` as authoritative, populate `did` from it, and populate `handle` + `pdsUrl` by running the *remainder* of the discovery chain in reverse (DID → DID doc → PDS service endpoint → handle from `alsoKnownAs`).
+
+This keeps the login path's strict mix-up-attack protection intact while giving the signup path a way to learn the identity it just minted.
+
+### Decision 5: PAR injection — single line in `parParams()`
+
+`parParams()` at `AtOAuth.kt:307-321` gains an optional `prompt: String? = null` parameter; when non-null, `append("prompt", prompt)`. `loginHint` becomes nullable (the signup path has no hint). The PAR request is otherwise unchanged — same PKCE, same DPoP nonce dance.
+
+### Decision 6: Sample app gets a "Create account" CTA, not a separate signup screen
+
+Add a button to the existing `LoginScreen` that calls `oauth.beginSignup()` and emits the resulting URL to the same Custom Tab flow the login button uses. The redirect handler is shared. Keeps the sample's surface minimal and demonstrates that signup is "the same flow, different entry point."
+
+### Decision 7: Gate signup on the auth server advertising `prompt=create`
+
+Before issuing the PAR, fetch `fetchAuthServerMetadata` and verify `prompt_values_supported` contains `"create"`. If not, throw a typed `OAuthSignupNotSupportedException`. Keeps us portable across entryways per RFC 8414 metadata discovery and protects against surprise failures on non-bsky auth servers.
+
+## Risks / Trade-offs
+
+- **[Binary break is unavoidable]** Nullable identity fields on `AuthServerMetadata` change the public API surface (Kotlin nullability is encoded in metadata and tracked by the binary-compat validator). → Mitigation: bundle this with any other queued breaking work; ship `docs/breaking-changes/vN.md` + `BREAKING CHANGE:` footer to ensure semantic-release cuts a major bump. Per repo memory on binary-breaking changes, refresh `:runtime:apiDump` and `:models:apiDump` and commit refreshed `*.api` files.
+
+- **[Identity-resolution failure post-signup]** After token exchange, we still need to resolve handle + PDS from the new DID. If the freshly-minted DID isn't immediately resolvable via the PLC directory (propagation delay), session persistence fails. → Mitigation: retry resolution with bounded exponential backoff; if still failing, persist the session with `handle = null` / `pdsUrl = null` and surface a warning — the access token is still usable for `did:plc:...` calls.
+
+- **[`completeLogin` branching complexity]** The DID-mismatch check is a security-critical invariant; making it conditional risks a regression where the login path silently degrades to "no mismatch check." → Mitigation: the flag lives on `PendingAuthState`, which is built by `beginLogin` / `beginSignup` — there's no other path to construct it. Add a test that proves the login path still rejects mismatched `sub`.
+
+- **[Non-bsky auth servers]** We default to `bsky.social` and gate on `prompt_values_supported`. Self-hosted entryways may not advertise `"create"` even if they support it. → Mitigation: accept a `requirePromptCreateSupport: Boolean = true` parameter on `beginSignup` so advanced consumers can bypass the check; default-on keeps the safe path.
+
+- **[Test coverage for a path we can't dry-run end-to-end]** We can't actually create accounts against bsky.social in CI. → Mitigation: rely on `MockEngine` fixtures matching real PAR + token-endpoint responses; verify the wire shape (params, headers, body) byte-for-byte; document that end-to-end verification is manual against the sample app.
+
+## Migration Plan
+
+1. Land the `:oauth` changes behind no flag (this is a new entry point + a binary-breaking refactor; partial rollout doesn't help).
+2. Refresh `:runtime:apiDump` + relevant `*.api` files; commit them in the same PR.
+3. Author `docs/breaking-changes/vN.md` modeled on `v5.md`.
+4. Include `BREAKING CHANGE:` footer in the squashed merge commit so semantic-release bumps the major.
+5. Update sample app in the same PR (same major) to use the new entry point — demonstrates the migration in-tree.
+6. Tag downstream `kikin81/nubecita#nubecita-lq9t.3.5` once the release is on Maven Central.
+
+**Rollback:** revert the PR. No persistent state changes, no migrations.
+
+## Open Questions
+
+- Should the existing `OAuthSession`'s identity fields really become nullable on disk, or should we lazy-resolve and persist only after we have the full identity? Persisting `handle = null` to `EncryptedSharedPreferences` means callers who load a session early may see a half-populated session. Lean: persist eagerly with nulls; document the half-state as expected in the seconds immediately after signup completion.
+- Naming nit: `beginSignup` returns just a `String` (the auth URL) like `beginLogin` does — but should it return a richer object (e.g., a `SignupHandle` with the URL + the pending state ID) for callers that want to observe completion? Lean: keep parity with `beginLogin` for v1; revisit if a real consumer asks.
+- Are there atproto-spec-level requirements we're missing for "anonymous" PAR flows (e.g., must `scope` differ from login scope)? Spec is silent; lean is to use the same scope.

--- a/openspec/changes/add-oauth-signup-flow/proposal.md
+++ b/openspec/changes/add-oauth-signup-flow/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+`AtOAuth.beginLogin(handle)` requires a resolved handle/DID, which doesn't exist for a user who has never created an account. Consuming apps currently work around this by dumping users into `bsky.app`'s web flow, after which users must re-type their newly-created handle back in the app — a discontinuity that loses a substantial fraction of brand-new users. `bsky.social` already advertises `prompt=create` in `prompt_values_supported`, so the server side is ready; the SDK needs a matching entry point.
+
+## What Changes
+
+- Add a new `AtOAuth` entry point that begins an OAuth flow against a **known auth server** (default `bsky.social`) with no handle/DID required, sending OIDC `prompt=create` in the PAR body so the auth server renders its signup UI.
+- Short-circuit `DiscoveryChain` so a known auth-server URL skips `resolveHandle` / `resolveDid` / `resolvePds` / `resolveAuthServer` and goes straight to `fetchAuthServerMetadata`.
+- **BREAKING (binary):** `AuthServerMetadata` (and `OAuthSession`) treat `did`, `handle`, and `pdsUrl` as deferred-resolution fields — populated post-token-exchange for the signup path. Existing login path still resolves them eagerly. Public-API binary surface changes; release will need a `BREAKING CHANGE:` footer to cut a major bump and a `docs/breaking-changes/vN.md` entry.
+- `completeLogin(redirectUri)` learns that the DID-mismatch check at the token-response stage is conditional on whether `pendingState` was opened with a pre-resolved DID. Signup flows accept the token-response `sub` as authoritative and resolve `handle` + `pdsUrl` from the freshly minted account.
+- Sample Android app gains a "Create account" CTA that calls the new entry point, as a reference integration.
+- Reuse the existing `completeLogin(redirectUri)` redirect handler — no new redirect plumbing on the consumer side.
+
+## Capabilities
+
+### New Capabilities
+
+(none — this extends the existing OAuth flow capability rather than introducing a new one)
+
+### Modified Capabilities
+
+- `oauth-flow`: Adds a signup entry point that operates against a known auth server with no handle/DID, injects `prompt=create` into PAR, and defers identity (`did`/`handle`/`pdsUrl`) resolution until after token exchange. Modifies the `sub`-vs-resolved-DID verification requirement to make it conditional on the flow origin (login path keeps strict check; signup path treats the token response as the identity source of truth).
+- `oauth-android-integration`: Sample app exposes a "Create account" CTA wired to the new entry point.
+
+## Impact
+
+- **`:oauth` module**: new public `AtOAuth.beginSignup(authServer: String = "bsky.social")` entry point (or — pending API-shape decision — a more general `beginAnonymousAuth(authServer, prompt)`); changes to `DiscoveryChain` to support short-circuit-by-known-auth-server; nullable `did`/`handle`/`pdsUrl` on `AuthServerMetadata` + `OAuthSession`; `PendingAuthState` gains a flow-origin flag; `completeLogin` branches DID validation on that flag.
+- **Binary-compatibility validator**: `:runtime:apiDump` / `:models:apiDump` and `:oauth` public surface will need a refreshed `.api` file. Per repo memory, semantic-release won't cut a major bump from defaults alone — commit message MUST include a `BREAKING CHANGE:` footer, and `docs/breaking-changes/vN.md` must be added modeled on `v5.md`.
+- **`:samples:android`**: new "Create account" CTA in `MainViewModel` and the login screen; redirect handling unchanged.
+- **Tests**: new `AtOAuthTest` fixtures for the signup path (mocked PAR + token exchange against a hardcoded auth server, token response carrying a brand-new DID).
+- **Docs**: README + KDoc updates noting the new entry point; downstream tracker `kikin81/nubecita#nubecita-lq9t.3.5` unblocked on release.
+- **Out of scope**: handle-picker UI (auth server handles it); custom-PDS signup (defer until real demand); in-app `com.atproto.server.createAccount` direct-XRPC signup (different flow).

--- a/openspec/changes/add-oauth-signup-flow/specs/oauth-android-integration/spec.md
+++ b/openspec/changes/add-oauth-signup-flow/specs/oauth-android-integration/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: Android sample SHALL expose a "Create account" CTA driven by `beginSignup`
+
+The `:samples:android` login screen SHALL render a secondary "Create account" call-to-action below the existing handle-and-sign-in form. Tapping the CTA SHALL call `AtOAuth.beginSignup()` (with the default `bsky.social` auth server), emit the returned authorization URL to the same Custom Tab pipeline the login flow uses, and on successful redirect SHALL land the user on the feed screen as the newly-created account without prompting for a handle.
+
+#### Scenario: User taps "Create account" and lands signed in
+
+- **WHEN** the user opens the login screen and taps "Create account"
+- **THEN** the sample calls `oauth.beginSignup()`, opens a Custom Tab to the authorization server's `/authorize` endpoint, the user completes signup in the browser, the redirect is captured by the existing redirect intent filter, `AtOAuth.completeLogin(redirectUri)` is invoked, and the app transitions to the feed screen with a session for the newly-created DID
+
+#### Scenario: CTA reuses the existing redirect handler
+
+- **WHEN** a developer reads the sample's `MainActivity.kt` and `MainViewModel.kt`
+- **THEN** the redirect intent filter and the `completeLogin` invocation are shared between the login and signup paths — there is no second redirect handler
+
+### Requirement: Sample SHALL surface a typed error if signup is unsupported by the auth server
+
+If `beginSignup` throws `OAuthSignupNotSupportedException` (because the configured auth server does not advertise `prompt=create` in its `prompt_values_supported`), the sample's login screen SHALL render a user-facing error explaining that signup is not available on the configured server, and SHALL leave the login form enabled.
+
+#### Scenario: Unsupported-signup error is shown without breaking login
+
+- **WHEN** the sample is configured against an auth server that does not advertise `prompt=create`
+- **AND** the user taps "Create account"
+- **THEN** the sample displays a "Signup not available on this server" message, and the user can still type a handle and tap "Sign in" successfully

--- a/openspec/changes/add-oauth-signup-flow/specs/oauth-flow/spec.md
+++ b/openspec/changes/add-oauth-signup-flow/specs/oauth-flow/spec.md
@@ -1,0 +1,97 @@
+## ADDED Requirements
+
+### Requirement: OAuth module SHALL expose a signup entry point against a known auth server
+
+The `:oauth` module SHALL expose a public suspending function `AtOAuth.beginSignup(authServer: String = "bsky.social"): String` that begins an OAuth authorization flow against the named auth server **without** requiring a handle or DID, by short-circuiting the discovery chain to fetch only the auth-server metadata and injecting OIDC `prompt=create` into the PAR request body. The function SHALL return an authorization URL suitable for opening in a browser. The redirect MUST be completable via the existing `AtOAuth.completeLogin(redirectUri)` entry point — no new redirect handler is required of the consumer.
+
+#### Scenario: Signup flow begins against bsky.social with no handle
+
+- **WHEN** a consumer calls `AtOAuth.beginSignup()` with a valid client metadata URL
+- **THEN** the module fetches `https://bsky.social/.well-known/oauth-authorization-server`, skips handle/DID/PDS resolution entirely, generates a PKCE code verifier + challenge and a DPoP EC P-256 keypair, pushes a PAR request that includes `prompt=create` and **no** `login_hint`, and returns an authorization URL for `https://bsky.social/oauth/authorize` carrying the resulting `request_uri`
+
+#### Scenario: Signup completes via the existing redirect handler
+
+- **WHEN** the browser redirects back to the app's registered redirect URI with an authorization code after the user finishes signup
+- **AND** the consumer calls `AtOAuth.completeLogin(redirectUri)` with that URI
+- **THEN** the module exchanges the code for tokens, accepts the token-response `sub` as the new account's DID, persists the session, and returns an authenticated session — the consumer never re-prompts for the user's handle
+
+### Requirement: Signup SHALL be gated on the auth server advertising `prompt=create`
+
+Before issuing the PAR request, the module SHALL verify that the auth server's metadata `prompt_values_supported` array contains `"create"`. If the value is absent, the module SHALL throw a typed `OAuthSignupNotSupportedException` carrying the auth server URL and the advertised `prompt_values_supported`. A `requirePromptCreateSupport: Boolean = true` parameter on `beginSignup` SHALL allow advanced consumers to bypass the check for non-conformant entryways.
+
+#### Scenario: Auth server without `prompt=create` is rejected
+
+- **WHEN** a consumer calls `AtOAuth.beginSignup(authServer = "example.entryway.test")`
+- **AND** `example.entryway.test`'s `/.well-known/oauth-authorization-server` does not list `"create"` in `prompt_values_supported`
+- **THEN** the module throws `OAuthSignupNotSupportedException` before issuing PAR
+
+#### Scenario: Bypass flag skips the gate
+
+- **WHEN** a consumer calls `AtOAuth.beginSignup(authServer = "example.entryway.test", requirePromptCreateSupport = false)`
+- **AND** `example.entryway.test`'s metadata does not advertise `"create"`
+- **THEN** the module proceeds with PAR carrying `prompt=create` regardless
+
+### Requirement: DiscoveryChain SHALL support known-auth-server short-circuit
+
+The `DiscoveryChain` SHALL expose a method that, given a known auth-server URL, fetches only the auth-server metadata and returns an `AuthServerMetadata` with `did = null`, `handle = null`, and `pdsUrl = null`. The existing handle-resolving chain SHALL be unchanged and SHALL continue to populate all three identity fields.
+
+#### Scenario: Short-circuit skips identity resolution
+
+- **WHEN** the module invokes `DiscoveryChain.resolveKnownAuthServer("https://bsky.social")`
+- **THEN** the returned `AuthServerMetadata` carries valid `authorizationEndpoint`, `tokenEndpoint`, `parEndpoint`, and `issuer` values, and `did`, `handle`, and `pdsUrl` are all null
+
+### Requirement: Signup token exchange SHALL derive identity from the token response
+
+For sessions opened via `beginSignup`, after a successful token exchange the module SHALL treat the token-response `sub` field as the authoritative DID, resolve the DID's PDS via the existing DID-document → service-endpoint logic, derive the `handle` from the DID document's `alsoKnownAs`, and persist the completed session with all three identity fields populated.
+
+#### Scenario: Identity is hydrated post-signup
+
+- **WHEN** `AtOAuth.completeLogin(redirectUri)` exchanges the code for a signup-flow session
+- **AND** the token response carries `sub = "did:plc:newlymintedid"`
+- **THEN** the module resolves `did:plc:newlymintedid` via the PLC directory, extracts the `#atproto_pds` service endpoint as the PDS URL, extracts the handle from `alsoKnownAs[0]` (`at://<handle>` form), and persists the `OAuthSession` with `did`, `handle`, and `pdsUrl` all populated
+
+#### Scenario: Bounded retry on transient resolution failure
+
+- **WHEN** the freshly-minted DID is not yet resolvable via the PLC directory (HTTP 404 due to propagation delay)
+- **THEN** the module retries resolution with bounded exponential backoff, and on persistent failure persists the session with `handle = null` / `pdsUrl = null` and a logged warning — the access token remains usable for DID-keyed calls
+
+## MODIFIED Requirements
+
+### Requirement: Token response `sub` field SHALL be verified against the resolved DID
+
+For sessions opened via the login flow (where a DID was resolved up-front), the module SHALL verify that the `sub` field in the token response matches the pre-resolved DID. A mismatch indicates the user authorized a different account than expected — the module SHALL reject the session and throw a typed `OAuthAccountMismatchException`. For sessions opened via the signup flow (where no DID exists pre-flight), this check SHALL be skipped and the token-response `sub` SHALL be accepted as authoritative; the signup-flow identity-derivation requirements (above) govern that path instead.
+
+#### Scenario: Mismatched `sub` DID is rejected on the login flow
+
+- **WHEN** `AtOAuth.completeLogin(redirectUri)` exchanges the authorization code for tokens against a session opened by `beginLogin(handle)`
+- **AND** the token response's `sub` field does not match the DID resolved from the user's handle
+- **THEN** the module throws `OAuthAccountMismatchException` and does NOT persist the session
+
+#### Scenario: Signup flow accepts the token-response `sub`
+
+- **WHEN** `AtOAuth.completeLogin(redirectUri)` completes a session opened by `beginSignup(authServer)`
+- **THEN** the module accepts the token-response `sub` as the new account's DID without any prior-DID comparison, and proceeds to identity hydration
+
+### Requirement: OAuthSessionStore SHALL be a pluggable persistence interface
+
+The module SHALL define an `OAuthSessionStore` interface with `load`, `save`, and `clear` methods. The interface SHALL be platform-agnostic (no Android or iOS imports). The Android sample SHALL provide an `EncryptedSharedPreferences`-backed implementation. The stored session SHALL include at minimum: access token, refresh token, DPoP private key (serialized), DPoP public key (serialized), DID, handle, PDS URL, and the authorization server's token endpoint URL. The `did`, `handle`, and `pdsUrl` fields MAY be transiently null in the brief window between a signup-flow token exchange and identity hydration; once hydration completes (or its bounded retry budget exhausts) the session SHALL be re-persisted with whatever values were resolved.
+
+#### Scenario: Session survives app restart
+
+- **WHEN** a user authenticates via OAuth and the app is force-stopped and relaunched
+- **THEN** the module loads the persisted session from `OAuthSessionStore`, reconstructs the `DpopAuthProvider` with the stored DPoP keypair, and the consumer can make authenticated XRPC calls without re-authenticating
+
+#### Scenario: Signup-flow session persists with null identity then hydrates
+
+- **WHEN** a signup-flow session is persisted immediately after token exchange, before identity hydration completes
+- **AND** the consumer reads `OAuthSession` from the store within that window
+- **THEN** the loaded session carries non-null tokens + DPoP keys and possibly-null `did`/`handle`/`pdsUrl`. Once hydration completes the store is updated with the resolved identity fields.
+
+### Requirement: Module SHALL NOT require the consumer to handle JWTs, keys, or nonces
+
+The entire DPoP proof construction, key management, nonce tracking, and JWT signing SHALL be internal to the module. The consumer-facing API SHALL expose only: `beginLogin(handle)`, `beginSignup(authServer)`, `completeLogin(redirectUri)`, `createClient()`, and `logout()`. No JWT types, no `ECPrivateKey`, no nonce strings SHALL appear in the public API surface.
+
+#### Scenario: Consumer integration is fewer than 15 lines
+
+- **WHEN** a developer integrates the OAuth module into a new Android app
+- **THEN** the integration code (excluding imports and boilerplate) is fewer than 15 lines: construct `AtOAuth`, call `beginLogin` or `beginSignup`, handle redirect with `completeLogin`, call `createClient`, use the service classes

--- a/openspec/changes/add-oauth-signup-flow/tasks.md
+++ b/openspec/changes/add-oauth-signup-flow/tasks.md
@@ -1,0 +1,60 @@
+## 1. DiscoveryChain short-circuit
+
+- [x] 1.1 Make `AuthServerMetadata.did`, `.handle`, `.pdsUrl` nullable (`String?`) in `oauth/.../DiscoveryChain.kt`
+- [x] 1.2 Add `DiscoveryChain.resolveKnownAuthServer(authServerUrl: String): AuthServerMetadata` that only calls `fetchAuthServerMetadata`
+- [x] 1.3 Extract the existing DID → DID-doc → PDS → handle-from-`alsoKnownAs` derivation into a reusable `hydrateIdentityFromDid(did)` helper for post-signup use
+- [x] 1.4 Update `DiscoveryChainTest` with fixtures for `resolveKnownAuthServer` (asserts identity fields are null and endpoints are populated)
+
+## 2. AtOAuth signup entry point
+
+- [x] 2.1 Add `FlowOrigin` enum (`Login`, `Signup`) and add `flowOrigin: FlowOrigin` field to `PendingAuthState`
+- [x] 2.2 Add optional `prompt: String? = null` parameter to `parParams()`; append `prompt` when non-null
+- [x] 2.3 Make `loginHint` parameter on `parParams()` and `pushAuthorizationRequest()` nullable; skip `append("login_hint", ...)` when null
+- [x] 2.4 Implement `AtOAuth.beginSignup(authServer: String = "bsky.social", requirePromptCreateSupport: Boolean = true): String`
+- [x] 2.5 In `beginSignup`, gate on `metadata.promptValuesSupported.contains("create")` when `requirePromptCreateSupport`; throw `OAuthSignupNotSupportedException` otherwise
+- [x] 2.6 Persist `promptValuesSupported: List<String>` on `AuthServerMetadata` (parsed from auth-server metadata) so the gate has data to read
+- [x] 2.7 Construct `PendingAuthState` with `flowOrigin = Signup` and store on the instance
+
+## 3. completeLogin branching
+
+- [x] 3.1 Branch `completeLogin` on `pendingState.flowOrigin`: skip `tokenResponse.sub` vs `metadata.did` mismatch check when `Signup`
+- [x] 3.2 In the signup branch, populate the in-progress metadata's `did` from `tokenResponse.sub`
+- [x] 3.3 Call `DiscoveryChain.hydrateIdentityFromDid(did)` to resolve `handle` + `pdsUrl` with bounded exponential backoff (cap retries: 3 attempts, ~100ms / 400ms / 1.2s)
+- [x] 3.4 Persist `OAuthSession` immediately after token exchange (with whatever identity is known), then re-persist after hydration completes
+- [x] 3.5 Make `OAuthSession.did`, `.handle`, `.pdsUrl` nullable to match; ensure all serializers / deserializers tolerate null
+
+## 4. Exceptions and public surface
+
+- [x] 4.1 Add `OAuthSignupNotSupportedException` carrying `authServerUrl: String` and `advertisedPromptValues: List<String>`
+- [x] 4.2 Ensure the only new public-API symbols are `beginSignup`, `OAuthSignupNotSupportedException`, and the now-nullable fields — keep `FlowOrigin` and `hydrateIdentityFromDid` internal
+
+## 5. Tests
+
+- [x] 5.1 Add `AtOAuthTest` case: `beginSignup()` short-circuits discovery (single HTTP call to `bsky.social/.well-known/oauth-authorization-server`) and posts PAR with `prompt=create` and no `login_hint`
+- [x] 5.2 Add `AtOAuthTest` case: `completeLogin` on a signup-flow session accepts a token-response `sub` that has no pre-resolved DID comparison
+- [x] 5.3 Add `AtOAuthTest` case: signup-flow `completeLogin` calls PLC directory for the new DID and populates `handle` + `pdsUrl` (merged into 5.2 — same fixture asserts both)
+- [x] 5.4 Add `AtOAuthTest` case: signup-flow `completeLogin` survives a 404 from PLC, retries, then persists the session with null identity fields when the budget exhausts
+- [x] 5.5 Add `AtOAuthTest` regression: `beginLogin` + mismatched `sub` STILL throws `OAuthAccountMismatchException` (proves the branch isn't disabling the login-path security check)
+- [x] 5.6 Add `AtOAuthTest` case: `beginSignup` against an auth server without `"create"` in `prompt_values_supported` throws `OAuthSignupNotSupportedException`
+- [x] 5.7 Add `AtOAuthTest` case: `beginSignup(requirePromptCreateSupport = false)` bypasses the gate
+
+## 6. Sample Android app
+
+- [x] 6.1 Add a "Create account" button to `LoginScreen.kt` below the existing sign-in form
+- [x] 6.2 Add `MainViewModel.beginSignup()` that calls `oauth.beginSignup()`, mirrors the existing `login()` error handling, and emits the URL to the same Custom Tab flow
+- [x] 6.3 Render `OAuthSignupNotSupportedException` as a user-facing error message; keep the login form enabled (handled by existing error path — `OAuthSignupNotSupportedException.message` is user-readable and surfaces via `LoggedOut(error = …)` exactly like other errors)
+- [x] 6.4 Add `samples/android/README.md` snippet documenting the signup CTA
+
+## 7. Binary-compat + release plumbing
+
+- [x] 7.1 Run `./gradlew :runtime:apiDump :models:apiDump` and any oauth-module equivalent; commit refreshed `*.api` files
+- [x] 7.2 Author `docs/breaking-changes/vN.md` modeled on `v5.md` — N=8 (next major after current v7.0.1)
+- [x] 7.3 Update `oauth/README.md` (if present) and KDoc on `AtOAuth.beginSignup` with a usage example (sample README updated; KDoc added on `beginSignup`)
+- [ ] 7.4 Squash-merge commit message MUST include a `BREAKING CHANGE:` footer so semantic-release cuts a major bump — deferred to the PR merge step
+
+## 8. Wrap-up
+
+- [x] 8.1 `./gradlew spotlessApply` and `./gradlew build` clean
+- [x] 8.2 `:oauth:test` and `:samples:android:testDebugUnitTest` green (verified via full `./gradlew build`)
+- [ ] 8.3 Manual end-to-end against `bsky.social` from the sample app: tap "Create account", complete signup in the browser, confirm app lands on feed screen with the new account — requires running on a real device; not runnable from CI/agent
+- [ ] 8.4 Notify downstream `kikin81/nubecita#nubecita-lq9t.3.5` once the release is on Maven Central — post-release task

--- a/samples/android/README.md
+++ b/samples/android/README.md
@@ -38,6 +38,13 @@ login screen, enter your handle (e.g. `alice.bsky.social`) and tap **Sign In**.
 A Chrome Custom Tab opens Bluesky's authorization page. After you approve,
 the browser redirects back and the feed loads.
 
+If you don't have a Bluesky account yet, tap **Create account on Bluesky**
+instead. The same Chrome Custom Tab opens `bsky.social`'s signup page (via
+OIDC `prompt=create`); after you create the account, the browser redirects
+back and the app lands you on the feed already signed in -- no need to
+re-type your newly-chosen handle. This calls `AtOAuth.beginSignup()` which
+short-circuits the handle/DID discovery chain.
+
 Tap the log-out icon in the top-right to clear the stored session.
 
 ## OAuth flow

--- a/samples/android/src/main/kotlin/io/github/kikin81/atproto/samples/bluesky/MainActivity.kt
+++ b/samples/android/src/main/kotlin/io/github/kikin81/atproto/samples/bluesky/MainActivity.kt
@@ -112,6 +112,7 @@ private fun MainScreen(
                 errorMessage = current.error,
                 busy = current.busy,
                 onLogin = { handle -> viewModel.onEvent(MainEvent.Login(handle)) },
+                onSignup = { viewModel.onEvent(MainEvent.Signup) },
             )
         }
         is MainUiState.LoggedIn -> {

--- a/samples/android/src/main/kotlin/io/github/kikin81/atproto/samples/bluesky/MainUiState.kt
+++ b/samples/android/src/main/kotlin/io/github/kikin81/atproto/samples/bluesky/MainUiState.kt
@@ -17,6 +17,7 @@ sealed interface MainUiState {
 
 sealed interface MainEvent {
     data class Login(val handle: String) : MainEvent
+    data object Signup : MainEvent
     data class CompleteOAuthRedirect(val redirectUri: String) : MainEvent
     data object Logout : MainEvent
 }

--- a/samples/android/src/main/kotlin/io/github/kikin81/atproto/samples/bluesky/MainViewModel.kt
+++ b/samples/android/src/main/kotlin/io/github/kikin81/atproto/samples/bluesky/MainViewModel.kt
@@ -32,7 +32,7 @@ class MainViewModel @Inject constructor(
         viewModelScope.launch {
             val existing = sessionStore.load()
             _uiState.value = if (existing != null) {
-                MainUiState.LoggedIn(existing.handle, existing.did)
+                MainUiState.LoggedIn(existing.handle ?: existing.did.orEmpty(), existing.did)
             } else {
                 MainUiState.LoggedOut()
             }
@@ -42,6 +42,7 @@ class MainViewModel @Inject constructor(
     fun onEvent(event: MainEvent) {
         when (event) {
             is MainEvent.Login -> login(event.handle)
+            MainEvent.Signup -> signup()
             is MainEvent.CompleteOAuthRedirect -> completeLogin(event.redirectUri)
             MainEvent.Logout -> logout()
         }
@@ -64,6 +65,23 @@ class MainViewModel @Inject constructor(
         }
     }
 
+    private fun signup() {
+        viewModelScope.launch {
+            _uiState.value = MainUiState.LoggedOut(busy = true)
+            runCatching { oauth.beginSignup() }
+                .onSuccess { url ->
+                    _uiState.value = MainUiState.LoggedOut(busy = false)
+                    _authUrl.emit(url)
+                }
+                .onFailure { t ->
+                    Log.e(TAG, "beginSignup failed", t)
+                    _uiState.value = MainUiState.LoggedOut(
+                        error = t.message ?: "Signup failed",
+                    )
+                }
+        }
+    }
+
     private fun completeLogin(redirectUri: String) {
         val currentState = _uiState.value
         if (currentState is MainUiState.LoggedOut && currentState.busy) {
@@ -80,7 +98,10 @@ class MainViewModel @Inject constructor(
                     val session = sessionStore.load()
                     if (session != null) {
                         Log.d(TAG, "Session loaded: ${session.handle}")
-                        _uiState.value = MainUiState.LoggedIn(session.handle, session.did)
+                        _uiState.value = MainUiState.LoggedIn(
+                            handle = session.handle ?: session.did.orEmpty(),
+                            did = session.did,
+                        )
                     } else {
                         Log.e(TAG, "Session not found after successful login")
                         _uiState.value = MainUiState.LoggedOut(error = "Session not found after login")

--- a/samples/android/src/main/kotlin/io/github/kikin81/atproto/samples/bluesky/ui/LoginScreen.kt
+++ b/samples/android/src/main/kotlin/io/github/kikin81/atproto/samples/bluesky/ui/LoginScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -29,6 +30,7 @@ fun LoginScreen(
     errorMessage: String? = null,
     busy: Boolean = false,
     onLogin: (String) -> Unit,
+    onSignup: () -> Unit = {},
 ) {
     var handle by remember { mutableStateOf("") }
 
@@ -87,6 +89,21 @@ fun LoginScreen(
         Spacer(Modifier.height(8.dp))
         Text(
             text = "You'll be redirected to your PDS to authenticate via OAuth.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+
+        Spacer(Modifier.height(24.dp))
+        OutlinedButton(
+            onClick = onSignup,
+            enabled = !busy,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text("Create account on Bluesky")
+        }
+        Spacer(Modifier.height(4.dp))
+        Text(
+            text = "Don't have an account? Create one without leaving this app.",
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )


### PR DESCRIPTION
Closes #112.

## Summary
- Adds `AtOAuth.beginSignup(authServer = "bsky.social", requirePromptCreateSupport = true)` — short-circuits the discovery chain to a known auth server and sends OIDC `prompt=create` in the PAR body. After signup, the user lands back in the app already signed in (no handle re-entry).
- `DiscoveryChain` gains `resolveKnownAuthServer` + internal `hydrateIdentityFromDid` (bounded exponential backoff for PLC propagation delays). `completeLogin` branches on a new `FlowOrigin` flag — login path keeps the strict `sub`-vs-resolved-DID check, signup path accepts the token-response `sub` as authoritative.
- Sample Android app gains a "Create account on Bluesky" CTA wired to the new entry point (shares the existing Custom Tab + redirect handler).
- Full OpenSpec change at `openspec/changes/add-oauth-signup-flow/` (proposal, design, deltas to `oauth-flow` + `oauth-android-integration`, tasks).

## ⚠️ BREAKING CHANGE
`AuthServerMetadata` and `OAuthSession` identity fields (`did`, `handle`, `pdsUrl`) become nullable; `AuthServerMetadata` constructor gains `promptValuesSupported` (ninth positional). `AtOAuth.createClient()` throws if a loaded session has null `pdsUrl`. Full migration guide in `docs/breaking-changes/v8.md`. Commit footer included so semantic-release cuts v8.0.0.

## Test plan
- [x] `./gradlew :oauth:test` — 44 pass (added 8: 2 in `DiscoveryChainTest`, 6 in `AtOAuthTest`)
- [x] `./gradlew :samples:android:testDebugUnitTest` — green
- [x] `./gradlew :oauth:apiCheck` — green; refreshed `oauth/api/oauth.api` committed
- [x] `./gradlew build` — full green (374 tasks)
- [x] `./gradlew spotlessApply` — clean
- [ ] **Manual E2E (reviewer/maintainer):** install the sample app on a device, tap "Create account on Bluesky", complete signup against `bsky.social`, confirm the app lands on the feed signed in as the new account without re-typing the handle.

## Notes for reviewers
- Repo memory: binary-breaking changes need explicit `BREAKING CHANGE:` footer to trigger a major bump — included.
- `DiscoveryChainTest` adds a fixture proving `resolveKnownAuthServer` does **exactly one** HTTP call (`/.well-known/oauth-authorization-server`) — verifies the short-circuit is real.
- `AtOAuthTest.beginLoginStillRejectsMismatchedSubAfterSignupBranching` is a regression test guarding the login-path security check from the new conditional.
- Downstream `kikin81/nubecita#nubecita-lq9t.3.5` is blocked on this release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)