### PR TITLE
feat(models): add app.bsky.bookmark.* + app.bsky.draft.* lexicons

### DIFF
--- a/generator/lexicons.json
+++ b/generator/lexicons.json
@@ -10,6 +10,15 @@
     "app.bsky.actor.searchActors",
     "app.bsky.actor.searchActorsTypeahead",
     "app.bsky.actor.status",
+    "app.bsky.bookmark.createBookmark",
+    "app.bsky.bookmark.defs",
+    "app.bsky.bookmark.deleteBookmark",
+    "app.bsky.bookmark.getBookmarks",
+    "app.bsky.draft.createDraft",
+    "app.bsky.draft.defs",
+    "app.bsky.draft.deleteDraft",
+    "app.bsky.draft.getDrafts",
+    "app.bsky.draft.updateDraft",
     "app.bsky.feed.generator",
     "app.bsky.feed.getAuthorFeed",
     "app.bsky.feed.getFeed",
@@ -150,6 +159,42 @@
     "app.bsky.actor.status": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.actor.status",
       "cid": "bafyreifdg4b64wohpwkh5lydc6tckvol2rspnpni6dec6recy2rhvlnz4a"
+    },
+    "app.bsky.bookmark.createBookmark": {
+      "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.bookmark.createBookmark",
+      "cid": "bafyreiegg2yu2jl5kfswirsylpn56ro2pj7lkfsufvrnv7xik7xdw27kfi"
+    },
+    "app.bsky.bookmark.defs": {
+      "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.bookmark.defs",
+      "cid": "bafyreifi3xao6wlbsnrzt36xnrfcvl5pil7jw7owrgqpmppfzy52dpy7e4"
+    },
+    "app.bsky.bookmark.deleteBookmark": {
+      "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.bookmark.deleteBookmark",
+      "cid": "bafyreig6rcgoqayi4fwgx5k5va3cnfsjykvc3fes7rmcfpszdd745hvatu"
+    },
+    "app.bsky.bookmark.getBookmarks": {
+      "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.bookmark.getBookmarks",
+      "cid": "bafyreicnazdriby4i3uu3nelt5ur4o3575ivjuw5pxlfj46tvfmglpny2e"
+    },
+    "app.bsky.draft.createDraft": {
+      "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.draft.createDraft",
+      "cid": "bafyreiac6mvg7bdmdb3dndr3dvtpbn6ifjtv5uoweliw4sk2wpbdcwlfca"
+    },
+    "app.bsky.draft.defs": {
+      "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.draft.defs",
+      "cid": "bafyreihdczcc26i65izy6xwpwjgwhm36kqxa6ouytgwdjrugdn3vp3bb5i"
+    },
+    "app.bsky.draft.deleteDraft": {
+      "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.draft.deleteDraft",
+      "cid": "bafyreicxw6nrrrikakfdaue3x45vfp4w62mncscdkpivpeom2orx2ae3su"
+    },
+    "app.bsky.draft.getDrafts": {
+      "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.draft.getDrafts",
+      "cid": "bafyreiewac2qwebwwtm4mtvk3aobtsyhbqug3hplhftjlbbn6bvuuxyumy"
+    },
+    "app.bsky.draft.updateDraft": {
+      "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.draft.updateDraft",
+      "cid": "bafyreicjy2aatoptybrtogj3nckokmkjpbmelvkej5bkfvxfcs5enu2fhu"
     },
     "app.bsky.embed.defs": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.embed.defs",

--- a/models/api/models.api
+++ b/models/api/models.api
@@ -1762,6 +1762,990 @@ public final class io/github/kikin81/atproto/app/bsky/actor/ViewerState$Companio
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class io/github/kikin81/atproto/app/bsky/bookmark/Bookmark {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/bookmark/Bookmark$Companion;
+	public fun <init> (Lio/github/kikin81/atproto/com/atproto/repo/StrongRef;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/com/atproto/repo/StrongRef;
+	public final fun copy (Lio/github/kikin81/atproto/com/atproto/repo/StrongRef;)Lio/github/kikin81/atproto/app/bsky/bookmark/Bookmark;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/bookmark/Bookmark;Lio/github/kikin81/atproto/com/atproto/repo/StrongRef;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/bookmark/Bookmark;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getSubject ()Lio/github/kikin81/atproto/com/atproto/repo/StrongRef;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/bookmark/Bookmark$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/bookmark/Bookmark$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/bookmark/Bookmark;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/bookmark/Bookmark;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/bookmark/Bookmark$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/bookmark/BookmarkService {
+	public fun <init> (Lio/github/kikin81/atproto/runtime/XrpcClient;)V
+	public final fun createBookmark (Lio/github/kikin81/atproto/app/bsky/bookmark/CreateBookmarkRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun deleteBookmark (Lio/github/kikin81/atproto/app/bsky/bookmark/DeleteBookmarkRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getBookmarks (Lio/github/kikin81/atproto/app/bsky/bookmark/GetBookmarksRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getBookmarks$default (Lio/github/kikin81/atproto/app/bsky/bookmark/BookmarkService;Lio/github/kikin81/atproto/app/bsky/bookmark/GetBookmarksRequest;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/bookmark/BookmarkServiceKt {
+	public static final fun bookmarksFlow (Lio/github/kikin81/atproto/app/bsky/bookmark/BookmarkService;Lio/github/kikin81/atproto/app/bsky/bookmark/GetBookmarksRequest;)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun bookmarksFlow$default (Lio/github/kikin81/atproto/app/bsky/bookmark/BookmarkService;Lio/github/kikin81/atproto/app/bsky/bookmark/GetBookmarksRequest;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun bookmarksPageFlow (Lio/github/kikin81/atproto/app/bsky/bookmark/BookmarkService;Lio/github/kikin81/atproto/app/bsky/bookmark/GetBookmarksRequest;)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun bookmarksPageFlow$default (Lio/github/kikin81/atproto/app/bsky/bookmark/BookmarkService;Lio/github/kikin81/atproto/app/bsky/bookmark/GetBookmarksRequest;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/bookmark/BookmarkView {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/bookmark/BookmarkView$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/bookmark/BookmarkViewItemUnion;Lio/github/kikin81/atproto/com/atproto/repo/StrongRef;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/bookmark/BookmarkViewItemUnion;Lio/github/kikin81/atproto/com/atproto/repo/StrongRef;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-G5DCnlA ()Ljava/lang/String;
+	public final fun component2 ()Lio/github/kikin81/atproto/app/bsky/bookmark/BookmarkViewItemUnion;
+	public final fun component3 ()Lio/github/kikin81/atproto/com/atproto/repo/StrongRef;
+	public final fun copy-SC4vqUM (Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/bookmark/BookmarkViewItemUnion;Lio/github/kikin81/atproto/com/atproto/repo/StrongRef;)Lio/github/kikin81/atproto/app/bsky/bookmark/BookmarkView;
+	public static synthetic fun copy-SC4vqUM$default (Lio/github/kikin81/atproto/app/bsky/bookmark/BookmarkView;Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/bookmark/BookmarkViewItemUnion;Lio/github/kikin81/atproto/com/atproto/repo/StrongRef;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/bookmark/BookmarkView;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCreatedAt-G5DCnlA ()Ljava/lang/String;
+	public final fun getItem ()Lio/github/kikin81/atproto/app/bsky/bookmark/BookmarkViewItemUnion;
+	public final fun getSubject ()Lio/github/kikin81/atproto/com/atproto/repo/StrongRef;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/bookmark/BookmarkView$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/bookmark/BookmarkView$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/bookmark/BookmarkView;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/bookmark/BookmarkView;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/bookmark/BookmarkView$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class io/github/kikin81/atproto/app/bsky/bookmark/BookmarkViewItemUnion : io/github/kikin81/atproto/runtime/OpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/bookmark/BookmarkViewItemUnion$Companion;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/bookmark/BookmarkViewItemUnion$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/bookmark/BookmarkViewItemUnion$Unknown : io/github/kikin81/atproto/app/bsky/bookmark/BookmarkViewItemUnion, io/github/kikin81/atproto/runtime/UnknownOpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/bookmark/BookmarkViewItemUnion$Unknown$Companion;
+	public fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/app/bsky/bookmark/BookmarkViewItemUnion$Unknown;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/bookmark/BookmarkViewItemUnion$Unknown;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/bookmark/BookmarkViewItemUnion$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getRaw ()Lkotlinx/serialization/json/JsonObject;
+	public fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/bookmark/BookmarkViewItemUnion$Unknown$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/bookmark/BookmarkViewItemUnionSerializer : io/github/kikin81/atproto/runtime/OpenUnionSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/bookmark/BookmarkViewItemUnionSerializer;
+	public fun selectKnownDeserializer (Ljava/lang/String;)Lkotlinx/serialization/KSerializer;
+	public fun selectKnownSerializer (Lio/github/kikin81/atproto/app/bsky/bookmark/BookmarkViewItemUnion;)Lkotlinx/serialization/KSerializer;
+	public synthetic fun selectKnownSerializer (Lio/github/kikin81/atproto/runtime/OpenUnionMember;)Lkotlinx/serialization/KSerializer;
+	public fun unknownSerializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/bookmark/BookmarkViewItemUnionUnknownSerializer : io/github/kikin81/atproto/runtime/UnknownMemberSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/bookmark/BookmarkViewItemUnionUnknownSerializer;
+	public fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/app/bsky/bookmark/BookmarkViewItemUnion$Unknown;
+	public synthetic fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/runtime/UnknownOpenUnionMember;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/bookmark/CreateBookmarkRequest {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/bookmark/CreateBookmarkRequest$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-LVDfoeI ()Ljava/lang/String;
+	public final fun component2-GUXd3rc ()Ljava/lang/String;
+	public final fun copy-rJe4bLw (Ljava/lang/String;Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/bookmark/CreateBookmarkRequest;
+	public static synthetic fun copy-rJe4bLw$default (Lio/github/kikin81/atproto/app/bsky/bookmark/CreateBookmarkRequest;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/bookmark/CreateBookmarkRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCid-LVDfoeI ()Ljava/lang/String;
+	public final fun getUri-GUXd3rc ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/bookmark/CreateBookmarkRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/bookmark/CreateBookmarkRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/bookmark/CreateBookmarkRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/bookmark/CreateBookmarkRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/bookmark/CreateBookmarkRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/bookmark/DeleteBookmarkRequest {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/bookmark/DeleteBookmarkRequest$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-GUXd3rc ()Ljava/lang/String;
+	public final fun copy-wvBT1Tk (Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/bookmark/DeleteBookmarkRequest;
+	public static synthetic fun copy-wvBT1Tk$default (Lio/github/kikin81/atproto/app/bsky/bookmark/DeleteBookmarkRequest;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/bookmark/DeleteBookmarkRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUri-GUXd3rc ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/bookmark/DeleteBookmarkRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/bookmark/DeleteBookmarkRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/bookmark/DeleteBookmarkRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/bookmark/DeleteBookmarkRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/bookmark/DeleteBookmarkRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/bookmark/GetBookmarksRequest {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/bookmark/GetBookmarksRequest$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Long;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Long;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/Long;
+	public final fun copy (Ljava/lang/String;Ljava/lang/Long;)Lio/github/kikin81/atproto/app/bsky/bookmark/GetBookmarksRequest;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/bookmark/GetBookmarksRequest;Ljava/lang/String;Ljava/lang/Long;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/bookmark/GetBookmarksRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCursor ()Ljava/lang/String;
+	public final fun getLimit ()Ljava/lang/Long;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/bookmark/GetBookmarksRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/bookmark/GetBookmarksRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/bookmark/GetBookmarksRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/bookmark/GetBookmarksRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/bookmark/GetBookmarksRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/bookmark/GetBookmarksResponse {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/bookmark/GetBookmarksResponse$Companion;
+	public fun <init> (Ljava/util/List;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/util/List;Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/bookmark/GetBookmarksResponse;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/bookmark/GetBookmarksResponse;Ljava/util/List;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/bookmark/GetBookmarksResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBookmarks ()Ljava/util/List;
+	public final fun getCursor ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/bookmark/GetBookmarksResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/bookmark/GetBookmarksResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/bookmark/GetBookmarksResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/bookmark/GetBookmarksResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/bookmark/GetBookmarksResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/draft/CreateDraftRequest {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/draft/CreateDraftRequest$Companion;
+	public fun <init> (Lio/github/kikin81/atproto/app/bsky/draft/Draft;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/app/bsky/draft/Draft;
+	public final fun copy (Lio/github/kikin81/atproto/app/bsky/draft/Draft;)Lio/github/kikin81/atproto/app/bsky/draft/CreateDraftRequest;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/draft/CreateDraftRequest;Lio/github/kikin81/atproto/app/bsky/draft/Draft;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/draft/CreateDraftRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDraft ()Lio/github/kikin81/atproto/app/bsky/draft/Draft;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/draft/CreateDraftRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/draft/CreateDraftRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/draft/CreateDraftRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/draft/CreateDraftRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/draft/CreateDraftRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/draft/CreateDraftResponse {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/draft/CreateDraftResponse$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/draft/CreateDraftResponse;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/draft/CreateDraftResponse;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/draft/CreateDraftResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/draft/CreateDraftResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/draft/CreateDraftResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/draft/CreateDraftResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/draft/CreateDraftResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/draft/CreateDraftResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/draft/DeleteDraftRequest {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/draft/DeleteDraftRequest$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-nr-ICYc ()Ljava/lang/String;
+	public final fun copy-_HIKpcE (Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/draft/DeleteDraftRequest;
+	public static synthetic fun copy-_HIKpcE$default (Lio/github/kikin81/atproto/app/bsky/draft/DeleteDraftRequest;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/draft/DeleteDraftRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getId-nr-ICYc ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/draft/DeleteDraftRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/draft/DeleteDraftRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/draft/DeleteDraftRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/draft/DeleteDraftRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/draft/DeleteDraftRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/draft/Draft {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/draft/Draft$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Ljava/util/List;
+	public final fun component6 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;)Lio/github/kikin81/atproto/app/bsky/draft/Draft;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/draft/Draft;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/draft/Draft;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDeviceId ()Ljava/lang/String;
+	public final fun getDeviceName ()Ljava/lang/String;
+	public final fun getLangs ()Ljava/util/List;
+	public final fun getPostgateEmbeddingRules ()Ljava/util/List;
+	public final fun getPosts ()Ljava/util/List;
+	public final fun getThreadgateAllow ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/draft/Draft$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/draft/Draft$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/draft/Draft;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/draft/Draft;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/draft/Draft$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/draft/DraftEmbedCaption {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedCaption$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2-JI_oZ4A ()Ljava/lang/String;
+	public final fun copy-2jZb1e0 (Ljava/lang/String;Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedCaption;
+	public static synthetic fun copy-2jZb1e0$default (Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedCaption;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedCaption;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getContent ()Ljava/lang/String;
+	public final fun getLang-JI_oZ4A ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/draft/DraftEmbedCaption$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedCaption$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedCaption;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedCaption;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/draft/DraftEmbedCaption$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/draft/DraftEmbedExternal {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedExternal$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-jMNtXP8 ()Ljava/lang/String;
+	public final fun copy-joEfuLA (Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedExternal;
+	public static synthetic fun copy-joEfuLA$default (Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedExternal;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedExternal;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUri-jMNtXP8 ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/draft/DraftEmbedExternal$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedExternal$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedExternal;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedExternal;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/draft/DraftEmbedExternal$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/draft/DraftEmbedImage {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedImage$Companion;
+	public fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedLocalRef;)V
+	public synthetic fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedLocalRef;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedLocalRef;
+	public final fun copy (Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedLocalRef;)Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedImage;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedImage;Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedLocalRef;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedImage;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAlt ()Ljava/lang/String;
+	public final fun getLocalRef ()Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedLocalRef;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/draft/DraftEmbedImage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedImage$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedImage;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedImage;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/draft/DraftEmbedImage$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/draft/DraftEmbedImageInput {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedImageInput$Companion;
+	public fun <init> (Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedLocalRef;)V
+	public synthetic fun <init> (Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedLocalRef;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun component2 ()Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedLocalRef;
+	public final fun copy (Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedLocalRef;)Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedImageInput;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedImageInput;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedLocalRef;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedImageInput;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAlt ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun getLocalRef ()Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedLocalRef;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/draft/DraftEmbedImageInput$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedImageInput$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedImageInput;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedImageInput;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/draft/DraftEmbedImageInput$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/draft/DraftEmbedLocalRef {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedLocalRef$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedLocalRef;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedLocalRef;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedLocalRef;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPath ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/draft/DraftEmbedLocalRef$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedLocalRef$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedLocalRef;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedLocalRef;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/draft/DraftEmbedLocalRef$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/draft/DraftEmbedRecord {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedRecord$Companion;
+	public fun <init> (Lio/github/kikin81/atproto/com/atproto/repo/StrongRef;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/com/atproto/repo/StrongRef;
+	public final fun copy (Lio/github/kikin81/atproto/com/atproto/repo/StrongRef;)Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedRecord;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedRecord;Lio/github/kikin81/atproto/com/atproto/repo/StrongRef;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedRecord;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getRecord ()Lio/github/kikin81/atproto/com/atproto/repo/StrongRef;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/draft/DraftEmbedRecord$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedRecord$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedRecord;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedRecord;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/draft/DraftEmbedRecord$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/draft/DraftEmbedVideo {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedVideo$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedLocalRef;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedLocalRef;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedLocalRef;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedLocalRef;)Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedVideo;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedVideo;Ljava/lang/String;Ljava/util/List;Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedLocalRef;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedVideo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAlt ()Ljava/lang/String;
+	public final fun getCaptions ()Ljava/util/List;
+	public final fun getLocalRef ()Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedLocalRef;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/draft/DraftEmbedVideo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedVideo$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedVideo;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedVideo;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/draft/DraftEmbedVideo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/draft/DraftEmbedVideoInput {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedVideoInput$Companion;
+	public fun <init> (Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedLocalRef;)V
+	public synthetic fun <init> (Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedLocalRef;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun component2 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun component3 ()Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedLocalRef;
+	public final fun copy (Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedLocalRef;)Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedVideoInput;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedVideoInput;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedLocalRef;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedVideoInput;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAlt ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun getCaptions ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun getLocalRef ()Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedLocalRef;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/draft/DraftEmbedVideoInput$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedVideoInput$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedVideoInput;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedVideoInput;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/draft/DraftEmbedVideoInput$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/draft/DraftInput {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/draft/DraftInput$Companion;
+	public fun <init> (Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Ljava/util/List;Lio/github/kikin81/atproto/runtime/AtField;)V
+	public synthetic fun <init> (Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Ljava/util/List;Lio/github/kikin81/atproto/runtime/AtField;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun component2 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun component3 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun component4 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun component5 ()Ljava/util/List;
+	public final fun component6 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun copy (Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Ljava/util/List;Lio/github/kikin81/atproto/runtime/AtField;)Lio/github/kikin81/atproto/app/bsky/draft/DraftInput;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/draft/DraftInput;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Ljava/util/List;Lio/github/kikin81/atproto/runtime/AtField;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/draft/DraftInput;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDeviceId ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun getDeviceName ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun getLangs ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun getPostgateEmbeddingRules ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun getPosts ()Ljava/util/List;
+	public final fun getThreadgateAllow ()Lio/github/kikin81/atproto/runtime/AtField;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/draft/DraftInput$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/draft/DraftInput$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/draft/DraftInput;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/draft/DraftInput;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/draft/DraftInput$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/draft/DraftPost {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/draft/DraftPost$Companion;
+	public fun <init> (Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lio/github/kikin81/atproto/app/bsky/draft/DraftPostLabelsUnion;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lio/github/kikin81/atproto/app/bsky/draft/DraftPostLabelsUnion;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Lio/github/kikin81/atproto/app/bsky/draft/DraftPostLabelsUnion;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun copy (Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lio/github/kikin81/atproto/app/bsky/draft/DraftPostLabelsUnion;Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/draft/DraftPost;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/draft/DraftPost;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lio/github/kikin81/atproto/app/bsky/draft/DraftPostLabelsUnion;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/draft/DraftPost;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEmbedExternals ()Ljava/util/List;
+	public final fun getEmbedImages ()Ljava/util/List;
+	public final fun getEmbedRecords ()Ljava/util/List;
+	public final fun getEmbedVideos ()Ljava/util/List;
+	public final fun getLabels ()Lio/github/kikin81/atproto/app/bsky/draft/DraftPostLabelsUnion;
+	public final fun getText ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/draft/DraftPost$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/draft/DraftPost$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/draft/DraftPost;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/draft/DraftPost;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/draft/DraftPost$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/draft/DraftPostInput {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/draft/DraftPostInput$Companion;
+	public fun <init> (Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;)V
+	public synthetic fun <init> (Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun component2 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun component3 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun component4 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun component5 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun copy (Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/draft/DraftPostInput;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/draft/DraftPostInput;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/draft/DraftPostInput;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEmbedExternals ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun getEmbedImages ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun getEmbedRecords ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun getEmbedVideos ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun getLabels ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun getText ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/draft/DraftPostInput$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/draft/DraftPostInput$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/draft/DraftPostInput;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/draft/DraftPostInput;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/draft/DraftPostInput$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class io/github/kikin81/atproto/app/bsky/draft/DraftPostLabelsUnion : io/github/kikin81/atproto/runtime/OpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/draft/DraftPostLabelsUnion$Companion;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/draft/DraftPostLabelsUnion$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/draft/DraftPostLabelsUnion$Unknown : io/github/kikin81/atproto/app/bsky/draft/DraftPostLabelsUnion, io/github/kikin81/atproto/runtime/UnknownOpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/draft/DraftPostLabelsUnion$Unknown$Companion;
+	public fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/app/bsky/draft/DraftPostLabelsUnion$Unknown;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/draft/DraftPostLabelsUnion$Unknown;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/draft/DraftPostLabelsUnion$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getRaw ()Lkotlinx/serialization/json/JsonObject;
+	public fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/draft/DraftPostLabelsUnion$Unknown$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/draft/DraftPostLabelsUnionSerializer : io/github/kikin81/atproto/runtime/OpenUnionSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/draft/DraftPostLabelsUnionSerializer;
+	public fun selectKnownDeserializer (Ljava/lang/String;)Lkotlinx/serialization/KSerializer;
+	public fun selectKnownSerializer (Lio/github/kikin81/atproto/app/bsky/draft/DraftPostLabelsUnion;)Lkotlinx/serialization/KSerializer;
+	public synthetic fun selectKnownSerializer (Lio/github/kikin81/atproto/runtime/OpenUnionMember;)Lkotlinx/serialization/KSerializer;
+	public fun unknownSerializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/draft/DraftPostLabelsUnionUnknownSerializer : io/github/kikin81/atproto/runtime/UnknownMemberSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/draft/DraftPostLabelsUnionUnknownSerializer;
+	public fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/app/bsky/draft/DraftPostLabelsUnion$Unknown;
+	public synthetic fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/runtime/UnknownOpenUnionMember;
+}
+
+public abstract interface class io/github/kikin81/atproto/app/bsky/draft/DraftPostgateEmbeddingRulesUnion : io/github/kikin81/atproto/runtime/OpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/draft/DraftPostgateEmbeddingRulesUnion$Companion;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/draft/DraftPostgateEmbeddingRulesUnion$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/draft/DraftPostgateEmbeddingRulesUnion$Unknown : io/github/kikin81/atproto/app/bsky/draft/DraftPostgateEmbeddingRulesUnion, io/github/kikin81/atproto/runtime/UnknownOpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/draft/DraftPostgateEmbeddingRulesUnion$Unknown$Companion;
+	public fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/app/bsky/draft/DraftPostgateEmbeddingRulesUnion$Unknown;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/draft/DraftPostgateEmbeddingRulesUnion$Unknown;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/draft/DraftPostgateEmbeddingRulesUnion$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getRaw ()Lkotlinx/serialization/json/JsonObject;
+	public fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/draft/DraftPostgateEmbeddingRulesUnion$Unknown$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/draft/DraftPostgateEmbeddingRulesUnionSerializer : io/github/kikin81/atproto/runtime/OpenUnionSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/draft/DraftPostgateEmbeddingRulesUnionSerializer;
+	public fun selectKnownDeserializer (Ljava/lang/String;)Lkotlinx/serialization/KSerializer;
+	public fun selectKnownSerializer (Lio/github/kikin81/atproto/app/bsky/draft/DraftPostgateEmbeddingRulesUnion;)Lkotlinx/serialization/KSerializer;
+	public synthetic fun selectKnownSerializer (Lio/github/kikin81/atproto/runtime/OpenUnionMember;)Lkotlinx/serialization/KSerializer;
+	public fun unknownSerializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/draft/DraftPostgateEmbeddingRulesUnionUnknownSerializer : io/github/kikin81/atproto/runtime/UnknownMemberSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/draft/DraftPostgateEmbeddingRulesUnionUnknownSerializer;
+	public fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/app/bsky/draft/DraftPostgateEmbeddingRulesUnion$Unknown;
+	public synthetic fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/runtime/UnknownOpenUnionMember;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/draft/DraftService {
+	public fun <init> (Lio/github/kikin81/atproto/runtime/XrpcClient;)V
+	public final fun createDraft (Lio/github/kikin81/atproto/app/bsky/draft/CreateDraftRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun deleteDraft (Lio/github/kikin81/atproto/app/bsky/draft/DeleteDraftRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getDrafts (Lio/github/kikin81/atproto/app/bsky/draft/GetDraftsRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getDrafts$default (Lio/github/kikin81/atproto/app/bsky/draft/DraftService;Lio/github/kikin81/atproto/app/bsky/draft/GetDraftsRequest;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun updateDraft (Lio/github/kikin81/atproto/app/bsky/draft/UpdateDraftRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/draft/DraftServiceKt {
+	public static final fun draftsFlow (Lio/github/kikin81/atproto/app/bsky/draft/DraftService;Lio/github/kikin81/atproto/app/bsky/draft/GetDraftsRequest;)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun draftsFlow$default (Lio/github/kikin81/atproto/app/bsky/draft/DraftService;Lio/github/kikin81/atproto/app/bsky/draft/GetDraftsRequest;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun draftsPageFlow (Lio/github/kikin81/atproto/app/bsky/draft/DraftService;Lio/github/kikin81/atproto/app/bsky/draft/GetDraftsRequest;)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun draftsPageFlow$default (Lio/github/kikin81/atproto/app/bsky/draft/DraftService;Lio/github/kikin81/atproto/app/bsky/draft/GetDraftsRequest;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+}
+
+public abstract interface class io/github/kikin81/atproto/app/bsky/draft/DraftThreadgateAllowUnion : io/github/kikin81/atproto/runtime/OpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/draft/DraftThreadgateAllowUnion$Companion;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/draft/DraftThreadgateAllowUnion$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/draft/DraftThreadgateAllowUnion$Unknown : io/github/kikin81/atproto/app/bsky/draft/DraftThreadgateAllowUnion, io/github/kikin81/atproto/runtime/UnknownOpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/draft/DraftThreadgateAllowUnion$Unknown$Companion;
+	public fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/app/bsky/draft/DraftThreadgateAllowUnion$Unknown;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/draft/DraftThreadgateAllowUnion$Unknown;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/draft/DraftThreadgateAllowUnion$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getRaw ()Lkotlinx/serialization/json/JsonObject;
+	public fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/draft/DraftThreadgateAllowUnion$Unknown$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/draft/DraftThreadgateAllowUnionSerializer : io/github/kikin81/atproto/runtime/OpenUnionSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/draft/DraftThreadgateAllowUnionSerializer;
+	public fun selectKnownDeserializer (Ljava/lang/String;)Lkotlinx/serialization/KSerializer;
+	public fun selectKnownSerializer (Lio/github/kikin81/atproto/app/bsky/draft/DraftThreadgateAllowUnion;)Lkotlinx/serialization/KSerializer;
+	public synthetic fun selectKnownSerializer (Lio/github/kikin81/atproto/runtime/OpenUnionMember;)Lkotlinx/serialization/KSerializer;
+	public fun unknownSerializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/draft/DraftThreadgateAllowUnionUnknownSerializer : io/github/kikin81/atproto/runtime/UnknownMemberSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/draft/DraftThreadgateAllowUnionUnknownSerializer;
+	public fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/app/bsky/draft/DraftThreadgateAllowUnion$Unknown;
+	public synthetic fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/runtime/UnknownOpenUnionMember;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/draft/DraftView {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/draft/DraftView$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/draft/Draft;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-DnBUIck ()Ljava/lang/String;
+	public final fun component2 ()Lio/github/kikin81/atproto/app/bsky/draft/Draft;
+	public final fun component3-nr-ICYc ()Ljava/lang/String;
+	public final fun component4-DnBUIck ()Ljava/lang/String;
+	public final fun copy-Ps_zquw (Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/draft/Draft;Ljava/lang/String;Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/draft/DraftView;
+	public static synthetic fun copy-Ps_zquw$default (Lio/github/kikin81/atproto/app/bsky/draft/DraftView;Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/draft/Draft;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/draft/DraftView;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCreatedAt-DnBUIck ()Ljava/lang/String;
+	public final fun getDraft ()Lio/github/kikin81/atproto/app/bsky/draft/Draft;
+	public final fun getId-nr-ICYc ()Ljava/lang/String;
+	public final fun getUpdatedAt-DnBUIck ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/draft/DraftView$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/draft/DraftView$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/draft/DraftView;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/draft/DraftView;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/draft/DraftView$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/draft/DraftWithId {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/draft/DraftWithId$Companion;
+	public synthetic fun <init> (Lio/github/kikin81/atproto/app/bsky/draft/Draft;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/app/bsky/draft/Draft;
+	public final fun component2-nr-ICYc ()Ljava/lang/String;
+	public final fun copy-Yp3DCYM (Lio/github/kikin81/atproto/app/bsky/draft/Draft;Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/draft/DraftWithId;
+	public static synthetic fun copy-Yp3DCYM$default (Lio/github/kikin81/atproto/app/bsky/draft/DraftWithId;Lio/github/kikin81/atproto/app/bsky/draft/Draft;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/draft/DraftWithId;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDraft ()Lio/github/kikin81/atproto/app/bsky/draft/Draft;
+	public final fun getId-nr-ICYc ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/draft/DraftWithId$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/draft/DraftWithId$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/draft/DraftWithId;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/draft/DraftWithId;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/draft/DraftWithId$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/draft/GetDraftsRequest {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/draft/GetDraftsRequest$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Long;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Long;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/Long;
+	public final fun copy (Ljava/lang/String;Ljava/lang/Long;)Lio/github/kikin81/atproto/app/bsky/draft/GetDraftsRequest;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/draft/GetDraftsRequest;Ljava/lang/String;Ljava/lang/Long;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/draft/GetDraftsRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCursor ()Ljava/lang/String;
+	public final fun getLimit ()Ljava/lang/Long;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/draft/GetDraftsRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/draft/GetDraftsRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/draft/GetDraftsRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/draft/GetDraftsRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/draft/GetDraftsRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/draft/GetDraftsResponse {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/draft/GetDraftsResponse$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;)Lio/github/kikin81/atproto/app/bsky/draft/GetDraftsResponse;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/draft/GetDraftsResponse;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/draft/GetDraftsResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCursor ()Ljava/lang/String;
+	public final fun getDrafts ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/draft/GetDraftsResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/draft/GetDraftsResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/draft/GetDraftsResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/draft/GetDraftsResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/draft/GetDraftsResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/draft/UpdateDraftRequest {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/draft/UpdateDraftRequest$Companion;
+	public fun <init> (Lio/github/kikin81/atproto/app/bsky/draft/DraftWithId;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/app/bsky/draft/DraftWithId;
+	public final fun copy (Lio/github/kikin81/atproto/app/bsky/draft/DraftWithId;)Lio/github/kikin81/atproto/app/bsky/draft/UpdateDraftRequest;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/draft/UpdateDraftRequest;Lio/github/kikin81/atproto/app/bsky/draft/DraftWithId;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/draft/UpdateDraftRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDraft ()Lio/github/kikin81/atproto/app/bsky/draft/DraftWithId;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/draft/UpdateDraftRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/draft/UpdateDraftRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/draft/UpdateDraftRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/draft/UpdateDraftRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/draft/UpdateDraftRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
 public final class io/github/kikin81/atproto/app/bsky/embed/AspectRatio {
 	public static final field Companion Lio/github/kikin81/atproto/app/bsky/embed/AspectRatio$Companion;
 	public fun <init> (JJ)V
@@ -2575,7 +3559,7 @@ public final class io/github/kikin81/atproto/app/bsky/feed/BlockedAuthor$Compani
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class io/github/kikin81/atproto/app/bsky/feed/BlockedPost : io/github/kikin81/atproto/app/bsky/feed/GetPostThreadResponseThreadUnion, io/github/kikin81/atproto/app/bsky/feed/ReplyRefParentUnion, io/github/kikin81/atproto/app/bsky/feed/ReplyRefRootUnion, io/github/kikin81/atproto/app/bsky/feed/ThreadViewPostParentUnion, io/github/kikin81/atproto/app/bsky/feed/ThreadViewPostRepliesUnion {
+public final class io/github/kikin81/atproto/app/bsky/feed/BlockedPost : io/github/kikin81/atproto/app/bsky/bookmark/BookmarkViewItemUnion, io/github/kikin81/atproto/app/bsky/feed/GetPostThreadResponseThreadUnion, io/github/kikin81/atproto/app/bsky/feed/ReplyRefParentUnion, io/github/kikin81/atproto/app/bsky/feed/ReplyRefRootUnion, io/github/kikin81/atproto/app/bsky/feed/ThreadViewPostParentUnion, io/github/kikin81/atproto/app/bsky/feed/ThreadViewPostRepliesUnion {
 	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/BlockedPost$Companion;
 	public synthetic fun <init> (Lio/github/kikin81/atproto/app/bsky/feed/BlockedAuthor;ZLjava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lio/github/kikin81/atproto/app/bsky/feed/BlockedAuthor;
@@ -3517,7 +4501,7 @@ public final class io/github/kikin81/atproto/app/bsky/feed/Like$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class io/github/kikin81/atproto/app/bsky/feed/NotFoundPost : io/github/kikin81/atproto/app/bsky/feed/GetPostThreadResponseThreadUnion, io/github/kikin81/atproto/app/bsky/feed/ReplyRefParentUnion, io/github/kikin81/atproto/app/bsky/feed/ReplyRefRootUnion, io/github/kikin81/atproto/app/bsky/feed/ThreadViewPostParentUnion, io/github/kikin81/atproto/app/bsky/feed/ThreadViewPostRepliesUnion {
+public final class io/github/kikin81/atproto/app/bsky/feed/NotFoundPost : io/github/kikin81/atproto/app/bsky/bookmark/BookmarkViewItemUnion, io/github/kikin81/atproto/app/bsky/feed/GetPostThreadResponseThreadUnion, io/github/kikin81/atproto/app/bsky/feed/ReplyRefParentUnion, io/github/kikin81/atproto/app/bsky/feed/ReplyRefRootUnion, io/github/kikin81/atproto/app/bsky/feed/ThreadViewPostParentUnion, io/github/kikin81/atproto/app/bsky/feed/ThreadViewPostRepliesUnion {
 	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/NotFoundPost$Companion;
 	public synthetic fun <init> (ZLjava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Z
@@ -3759,7 +4743,7 @@ public final class io/github/kikin81/atproto/app/bsky/feed/PostTextSlice$Compani
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class io/github/kikin81/atproto/app/bsky/feed/PostView : io/github/kikin81/atproto/app/bsky/feed/ReplyRefParentUnion, io/github/kikin81/atproto/app/bsky/feed/ReplyRefRootUnion {
+public final class io/github/kikin81/atproto/app/bsky/feed/PostView : io/github/kikin81/atproto/app/bsky/bookmark/BookmarkViewItemUnion, io/github/kikin81/atproto/app/bsky/feed/ReplyRefParentUnion, io/github/kikin81/atproto/app/bsky/feed/ReplyRefRootUnion {
 	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/PostView$Companion;
 	public synthetic fun <init> (Lio/github/kikin81/atproto/app/bsky/actor/ProfileViewBasic;Ljava/lang/Long;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Lio/github/kikin81/atproto/app/bsky/feed/PostViewEmbedUnion;Ljava/lang/String;Ljava/util/List;Ljava/lang/Long;Ljava/lang/Long;Lkotlinx/serialization/json/JsonObject;Ljava/lang/Long;Ljava/lang/Long;Lio/github/kikin81/atproto/app/bsky/feed/ThreadgateView;Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/feed/ViewerState;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun <init> (Lio/github/kikin81/atproto/app/bsky/actor/ProfileViewBasic;Ljava/lang/Long;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Lio/github/kikin81/atproto/app/bsky/feed/PostViewEmbedUnion;Ljava/lang/String;Ljava/util/List;Ljava/lang/Long;Ljava/lang/Long;Lkotlinx/serialization/json/JsonObject;Ljava/lang/Long;Ljava/lang/Long;Lio/github/kikin81/atproto/app/bsky/feed/ThreadgateView;Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/feed/ViewerState;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -3889,7 +4873,7 @@ public final class io/github/kikin81/atproto/app/bsky/feed/Postgate$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class io/github/kikin81/atproto/app/bsky/feed/PostgateDisableRule : io/github/kikin81/atproto/app/bsky/actor/PostInteractionSettingsPrefPostgateEmbeddingRulesUnion, io/github/kikin81/atproto/app/bsky/feed/PostgateEmbeddingRulesUnion {
+public final class io/github/kikin81/atproto/app/bsky/feed/PostgateDisableRule : io/github/kikin81/atproto/app/bsky/actor/PostInteractionSettingsPrefPostgateEmbeddingRulesUnion, io/github/kikin81/atproto/app/bsky/draft/DraftPostgateEmbeddingRulesUnion, io/github/kikin81/atproto/app/bsky/feed/PostgateEmbeddingRulesUnion {
 	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/PostgateDisableRule$Companion;
 	public fun <init> ()V
 }
@@ -4564,7 +5548,7 @@ public final class io/github/kikin81/atproto/app/bsky/feed/ThreadgateAllowUnionU
 	public synthetic fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/runtime/UnknownOpenUnionMember;
 }
 
-public final class io/github/kikin81/atproto/app/bsky/feed/ThreadgateFollowerRule : io/github/kikin81/atproto/app/bsky/actor/PostInteractionSettingsPrefThreadgateAllowRulesUnion, io/github/kikin81/atproto/app/bsky/feed/ThreadgateAllowUnion {
+public final class io/github/kikin81/atproto/app/bsky/feed/ThreadgateFollowerRule : io/github/kikin81/atproto/app/bsky/actor/PostInteractionSettingsPrefThreadgateAllowRulesUnion, io/github/kikin81/atproto/app/bsky/draft/DraftThreadgateAllowUnion, io/github/kikin81/atproto/app/bsky/feed/ThreadgateAllowUnion {
 	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/ThreadgateFollowerRule$Companion;
 	public fun <init> ()V
 }
@@ -4584,7 +5568,7 @@ public final class io/github/kikin81/atproto/app/bsky/feed/ThreadgateFollowerRul
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class io/github/kikin81/atproto/app/bsky/feed/ThreadgateFollowingRule : io/github/kikin81/atproto/app/bsky/actor/PostInteractionSettingsPrefThreadgateAllowRulesUnion, io/github/kikin81/atproto/app/bsky/feed/ThreadgateAllowUnion {
+public final class io/github/kikin81/atproto/app/bsky/feed/ThreadgateFollowingRule : io/github/kikin81/atproto/app/bsky/actor/PostInteractionSettingsPrefThreadgateAllowRulesUnion, io/github/kikin81/atproto/app/bsky/draft/DraftThreadgateAllowUnion, io/github/kikin81/atproto/app/bsky/feed/ThreadgateAllowUnion {
 	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/ThreadgateFollowingRule$Companion;
 	public fun <init> ()V
 }
@@ -4604,7 +5588,7 @@ public final class io/github/kikin81/atproto/app/bsky/feed/ThreadgateFollowingRu
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class io/github/kikin81/atproto/app/bsky/feed/ThreadgateListRule : io/github/kikin81/atproto/app/bsky/actor/PostInteractionSettingsPrefThreadgateAllowRulesUnion, io/github/kikin81/atproto/app/bsky/feed/ThreadgateAllowUnion {
+public final class io/github/kikin81/atproto/app/bsky/feed/ThreadgateListRule : io/github/kikin81/atproto/app/bsky/actor/PostInteractionSettingsPrefThreadgateAllowRulesUnion, io/github/kikin81/atproto/app/bsky/draft/DraftThreadgateAllowUnion, io/github/kikin81/atproto/app/bsky/feed/ThreadgateAllowUnion {
 	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/ThreadgateListRule$Companion;
 	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1-GUXd3rc ()Ljava/lang/String;
@@ -4631,7 +5615,7 @@ public final class io/github/kikin81/atproto/app/bsky/feed/ThreadgateListRule$Co
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class io/github/kikin81/atproto/app/bsky/feed/ThreadgateMentionRule : io/github/kikin81/atproto/app/bsky/actor/PostInteractionSettingsPrefThreadgateAllowRulesUnion, io/github/kikin81/atproto/app/bsky/feed/ThreadgateAllowUnion {
+public final class io/github/kikin81/atproto/app/bsky/feed/ThreadgateMentionRule : io/github/kikin81/atproto/app/bsky/actor/PostInteractionSettingsPrefThreadgateAllowRulesUnion, io/github/kikin81/atproto/app/bsky/draft/DraftThreadgateAllowUnion, io/github/kikin81/atproto/app/bsky/feed/ThreadgateAllowUnion {
 	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/ThreadgateMentionRule$Companion;
 	public fun <init> ()V
 }
@@ -12115,7 +13099,7 @@ public final class io/github/kikin81/atproto/com/atproto/label/SelfLabel$Compani
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class io/github/kikin81/atproto/com/atproto/label/SelfLabels : io/github/kikin81/atproto/app/bsky/actor/ProfileLabelsUnion, io/github/kikin81/atproto/app/bsky/feed/GeneratorLabelsUnion, io/github/kikin81/atproto/app/bsky/feed/PostLabelsUnion, io/github/kikin81/atproto/app/bsky/graph/ListLabelsUnion, io/github/kikin81/atproto/app/bsky/labeler/ServiceLabelsUnion {
+public final class io/github/kikin81/atproto/com/atproto/label/SelfLabels : io/github/kikin81/atproto/app/bsky/actor/ProfileLabelsUnion, io/github/kikin81/atproto/app/bsky/draft/DraftPostLabelsUnion, io/github/kikin81/atproto/app/bsky/feed/GeneratorLabelsUnion, io/github/kikin81/atproto/app/bsky/feed/PostLabelsUnion, io/github/kikin81/atproto/app/bsky/graph/ListLabelsUnion, io/github/kikin81/atproto/app/bsky/labeler/ServiceLabelsUnion {
 	public static final field Companion Lio/github/kikin81/atproto/com/atproto/label/SelfLabels$Companion;
 	public fun <init> (Ljava/util/List;)V
 	public final fun component1 ()Ljava/util/List;

--- a/models/build.gradle.kts
+++ b/models/build.gradle.kts
@@ -38,6 +38,8 @@ kotlin {
         }
         commonTest.dependencies {
             implementation(kotlin("test"))
+            implementation(libs.ktor.client.mock)
+            implementation(libs.kotlinx.coroutines.test)
         }
     }
 }

--- a/models/src/commonTest/kotlin/io/github/kikin81/atproto/app/bsky/bookmark/BookmarkServiceTest.kt
+++ b/models/src/commonTest/kotlin/io/github/kikin81/atproto/app/bsky/bookmark/BookmarkServiceTest.kt
@@ -1,0 +1,50 @@
+package io.github.kikin81.atproto.app.bsky.bookmark
+
+import io.github.kikin81.atproto.runtime.XrpcClient
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.utils.io.ByteReadChannel
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class BookmarkServiceTest {
+
+    @Test
+    fun getBookmarksHitsCorrectXrpcPathWithPaginatedQueryParams() = runTest {
+        var capturedUrl: String? = null
+        var capturedMethod: HttpMethod? = null
+        val client = HttpClient(
+            MockEngine { request ->
+                capturedUrl = request.url.toString()
+                capturedMethod = request.method
+                respond(
+                    ByteReadChannel("""{"cursor":"next","bookmarks":[]}"""),
+                    HttpStatusCode.OK,
+                    headersOf(HttpHeaders.ContentType, "application/json"),
+                )
+            },
+        )
+        val xrpc = XrpcClient(baseUrl = "https://pds.test", httpClient = client)
+
+        val response = BookmarkService(xrpc).getBookmarks(
+            GetBookmarksRequest(limit = 25, cursor = "abc"),
+        )
+
+        assertEquals(HttpMethod.Get, capturedMethod)
+        val url = capturedUrl
+        assertNotNull(url)
+        assertContains(url, "/xrpc/app.bsky.bookmark.getBookmarks")
+        assertContains(url, "limit=25")
+        assertContains(url, "cursor=abc")
+        assertEquals("next", response.cursor)
+        assertEquals(emptyList(), response.bookmarks)
+    }
+}

--- a/models/src/commonTest/kotlin/io/github/kikin81/atproto/app/bsky/bookmark/BookmarkServiceTest.kt
+++ b/models/src/commonTest/kotlin/io/github/kikin81/atproto/app/bsky/bookmark/BookmarkServiceTest.kt
@@ -1,15 +1,9 @@
 package io.github.kikin81.atproto.app.bsky.bookmark
 
-import io.github.kikin81.atproto.runtime.XrpcClient
-import io.ktor.client.HttpClient
-import io.ktor.client.engine.mock.MockEngine
-import io.ktor.client.engine.mock.respond
-import io.ktor.http.HttpHeaders
+import io.github.kikin81.atproto.test.MockXrpcFixture
 import io.ktor.http.HttpMethod
-import io.ktor.http.HttpStatusCode
-import io.ktor.http.headersOf
-import io.ktor.utils.io.ByteReadChannel
 import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
@@ -17,29 +11,23 @@ import kotlin.test.assertNotNull
 
 class BookmarkServiceTest {
 
+    private lateinit var fixture: MockXrpcFixture
+
+    @BeforeTest
+    fun setup() {
+        fixture = MockXrpcFixture()
+    }
+
     @Test
     fun getBookmarksHitsCorrectXrpcPathWithPaginatedQueryParams() = runTest {
-        var capturedUrl: String? = null
-        var capturedMethod: HttpMethod? = null
-        val client = HttpClient(
-            MockEngine { request ->
-                capturedUrl = request.url.toString()
-                capturedMethod = request.method
-                respond(
-                    ByteReadChannel("""{"cursor":"next","bookmarks":[]}"""),
-                    HttpStatusCode.OK,
-                    headersOf(HttpHeaders.ContentType, "application/json"),
-                )
-            },
-        )
-        val xrpc = XrpcClient(baseUrl = "https://pds.test", httpClient = client)
+        fixture.respondWith("""{"cursor":"next","bookmarks":[]}""")
 
-        val response = BookmarkService(xrpc).getBookmarks(
+        val response = BookmarkService(fixture.client).getBookmarks(
             GetBookmarksRequest(limit = 25, cursor = "abc"),
         )
 
-        assertEquals(HttpMethod.Get, capturedMethod)
-        val url = capturedUrl
+        assertEquals(HttpMethod.Get, fixture.capturedMethod)
+        val url = fixture.capturedUrl
         assertNotNull(url)
         assertContains(url, "/xrpc/app.bsky.bookmark.getBookmarks")
         assertContains(url, "limit=25")

--- a/models/src/commonTest/kotlin/io/github/kikin81/atproto/app/bsky/draft/DraftServiceTest.kt
+++ b/models/src/commonTest/kotlin/io/github/kikin81/atproto/app/bsky/draft/DraftServiceTest.kt
@@ -1,16 +1,9 @@
 package io.github.kikin81.atproto.app.bsky.draft
 
-import io.github.kikin81.atproto.runtime.XrpcClient
-import io.ktor.client.HttpClient
-import io.ktor.client.engine.mock.MockEngine
-import io.ktor.client.engine.mock.respond
-import io.ktor.http.HttpHeaders
+import io.github.kikin81.atproto.test.MockXrpcFixture
 import io.ktor.http.HttpMethod
-import io.ktor.http.HttpStatusCode
-import io.ktor.http.content.OutgoingContent
-import io.ktor.http.headersOf
-import io.ktor.utils.io.ByteReadChannel
 import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
@@ -18,29 +11,18 @@ import kotlin.test.assertNotNull
 
 class DraftServiceTest {
 
+    private lateinit var fixture: MockXrpcFixture
+
+    @BeforeTest
+    fun setup() {
+        fixture = MockXrpcFixture()
+    }
+
     @Test
     fun createDraftPostsJsonEncodedInputToCorrectXrpcPath() = runTest {
-        var capturedUrl: String? = null
-        var capturedMethod: HttpMethod? = null
-        var capturedBody: String? = null
-        val client = HttpClient(
-            MockEngine { request ->
-                capturedUrl = request.url.toString()
-                capturedMethod = request.method
-                val body = request.body
-                if (body is OutgoingContent.ByteArrayContent) {
-                    capturedBody = body.bytes().decodeToString()
-                }
-                respond(
-                    ByteReadChannel("""{"id":"draft-123"}"""),
-                    HttpStatusCode.OK,
-                    headersOf(HttpHeaders.ContentType, "application/json"),
-                )
-            },
-        )
-        val xrpc = XrpcClient(baseUrl = "https://pds.test", httpClient = client)
+        fixture.respondWith("""{"id":"draft-123"}""")
 
-        val response = DraftService(xrpc).createDraft(
+        val response = DraftService(fixture.client).createDraft(
             CreateDraftRequest(
                 draft = Draft(
                     posts = listOf(DraftPost(text = "hello from a draft")),
@@ -48,12 +30,16 @@ class DraftServiceTest {
             ),
         )
 
-        assertEquals(HttpMethod.Post, capturedMethod)
-        val url = capturedUrl
+        assertEquals(HttpMethod.Post, fixture.capturedMethod)
+        val url = fixture.capturedUrl
         assertNotNull(url)
         assertContains(url, "/xrpc/app.bsky.draft.createDraft")
 
-        val body = capturedBody
+        val contentType = fixture.capturedContentType
+        assertNotNull(contentType)
+        assertContains(contentType, "application/json")
+
+        val body = fixture.capturedBody
         assertNotNull(body)
         assertContains(body, "\"draft\"")
         assertContains(body, "hello from a draft")

--- a/models/src/commonTest/kotlin/io/github/kikin81/atproto/app/bsky/draft/DraftServiceTest.kt
+++ b/models/src/commonTest/kotlin/io/github/kikin81/atproto/app/bsky/draft/DraftServiceTest.kt
@@ -1,0 +1,63 @@
+package io.github.kikin81.atproto.app.bsky.draft
+
+import io.github.kikin81.atproto.runtime.XrpcClient
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.content.OutgoingContent
+import io.ktor.http.headersOf
+import io.ktor.utils.io.ByteReadChannel
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class DraftServiceTest {
+
+    @Test
+    fun createDraftPostsJsonEncodedInputToCorrectXrpcPath() = runTest {
+        var capturedUrl: String? = null
+        var capturedMethod: HttpMethod? = null
+        var capturedBody: String? = null
+        val client = HttpClient(
+            MockEngine { request ->
+                capturedUrl = request.url.toString()
+                capturedMethod = request.method
+                val body = request.body
+                if (body is OutgoingContent.ByteArrayContent) {
+                    capturedBody = body.bytes().decodeToString()
+                }
+                respond(
+                    ByteReadChannel("""{"id":"draft-123"}"""),
+                    HttpStatusCode.OK,
+                    headersOf(HttpHeaders.ContentType, "application/json"),
+                )
+            },
+        )
+        val xrpc = XrpcClient(baseUrl = "https://pds.test", httpClient = client)
+
+        val response = DraftService(xrpc).createDraft(
+            CreateDraftRequest(
+                draft = Draft(
+                    posts = listOf(DraftPost(text = "hello from a draft")),
+                ),
+            ),
+        )
+
+        assertEquals(HttpMethod.Post, capturedMethod)
+        val url = capturedUrl
+        assertNotNull(url)
+        assertContains(url, "/xrpc/app.bsky.draft.createDraft")
+
+        val body = capturedBody
+        assertNotNull(body)
+        assertContains(body, "\"draft\"")
+        assertContains(body, "hello from a draft")
+
+        assertEquals("draft-123", response.id)
+    }
+}

--- a/models/src/commonTest/kotlin/io/github/kikin81/atproto/test/MockXrpcFixture.kt
+++ b/models/src/commonTest/kotlin/io/github/kikin81/atproto/test/MockXrpcFixture.kt
@@ -1,0 +1,67 @@
+package io.github.kikin81.atproto.test
+
+import io.github.kikin81.atproto.runtime.XrpcClient
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.content.OutgoingContent
+import io.ktor.http.headersOf
+import io.ktor.utils.io.ByteReadChannel
+
+/**
+ * Lightweight test fixture for generated XRPC service tests.
+ *
+ * Sets up a Ktor [MockEngine]-backed [XrpcClient] that captures the most
+ * recent outgoing request (URL, method, content-type, body) and serves
+ * the most recently configured canned response. Designed for `@BeforeTest`
+ * construction; per-test response is configured via [respondWith] before
+ * invoking the service under test.
+ *
+ * Ktor's `TextContent` (used by JSON-body procedures) extends
+ * `OutgoingContent.ByteArrayContent`, so the body capture covers both JSON
+ * procedures and raw-bytes uploads with a single branch.
+ */
+class MockXrpcFixture(baseUrl: String = "https://pds.test") {
+    private var nextResponseJson: String = "{}"
+    private var nextStatus: HttpStatusCode = HttpStatusCode.OK
+
+    var capturedUrl: String? = null
+        private set
+    var capturedMethod: HttpMethod? = null
+        private set
+    var capturedContentType: String? = null
+        private set
+    var capturedBody: String? = null
+        private set
+
+    val client: XrpcClient = XrpcClient(
+        baseUrl = baseUrl,
+        httpClient = HttpClient(
+            MockEngine { request ->
+                capturedUrl = request.url.toString()
+                capturedMethod = request.method
+                val body = request.body
+                if (body is OutgoingContent.ByteArrayContent) {
+                    capturedBody = body.bytes().decodeToString()
+                    // Content-Type rides on the OutgoingContent (Ktor's request
+                    // builder applies `contentType(...)` to the body, not to the
+                    // top-level request headers).
+                    capturedContentType = body.contentType?.toString()
+                }
+                respond(
+                    ByteReadChannel(nextResponseJson),
+                    nextStatus,
+                    headersOf(HttpHeaders.ContentType, "application/json"),
+                )
+            },
+        ),
+    )
+
+    fun respondWith(json: String, status: HttpStatusCode = HttpStatusCode.OK) {
+        nextResponseJson = json
+        nextStatus = status
+    }
+}

--- a/openspec/changes/add-bookmark-and-draft-lexicons/.openspec.yaml
+++ b/openspec/changes/add-bookmark-and-draft-lexicons/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-20

--- a/openspec/changes/add-bookmark-and-draft-lexicons/design.md
+++ b/openspec/changes/add-bookmark-and-draft-lexicons/design.md
@@ -77,7 +77,7 @@ The same pattern was used for prior namespace additions (e.g. `chat.bsky.*`); th
 ## Migration Plan
 
 1. Append 9 NSIDs to `generator/lexicons.json`.
-2. `cd generator && npx lex install --ci` — pins CIDs. If a single NSID fails, fall back to Decision 5's workaround.
+2. `cd generator && npx lex install` — pins CIDs for the newly added NSIDs. **Note:** the first run must omit `--ci` since `--ci` verifies an already-pinned manifest and errors out when new entries lack CIDs. After the new NSIDs are pinned and committed, subsequent CI verifications can use `npx lex install --ci`. If a single NSID fails on the initial install, fall back to Decision 5's workaround.
 3. `./gradlew :generator:generateModels` — emits new sources into `models/build/generated/source/lexicon/`.
 4. `./gradlew :models:apiDump` — refresh the public API surface file.
 5. Write 2 MockEngine smoke tests in `:models`.

--- a/openspec/changes/add-bookmark-and-draft-lexicons/design.md
+++ b/openspec/changes/add-bookmark-and-draft-lexicons/design.md
@@ -1,0 +1,94 @@
+## Context
+
+The SDK's generated surface is governed by `generator/lexicons.json` — a curated manifest of NSIDs the codegen pipeline emits Kotlin for. Each manifest entry carries a CID pinned at install time so codegen is reproducible. Adding new namespaces is purely a manifest exercise; the generator's behaviour (parsing, IR, naming, emission) is unchanged.
+
+Two upstream lexicon namespaces are not yet in the manifest:
+- `lexicons/app/bsky/bookmark/` (3 endpoints + 1 defs file) — saved-posts feature
+- `lexicons/app/bsky/draft/` (4 endpoints + 1 defs file) — server-side draft posts
+
+Both are first-class user features in the AT Protocol and a known target for nubecita's next launch slice.
+
+The same pattern was used for prior namespace additions (e.g. `chat.bsky.*`); this change is mechanically identical, with the small twist that one of those installs once tripped over the upstream Atmosphere lex-resolver (`chat.bsky.convo.getConvoMembers` proof-of-existence failure), which is now a documented workflow risk.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Ship `BookmarkService` and `DraftService` as part of `:models` so nubecita can compile against typed clients today.
+- Cover the wire shape with at least one query + one procedure MockEngine smoke test, beyond what `GoldenFileTest` already proves.
+- Keep this release a minor bump (v8.1.0) — no source-level or binary-level breakage of existing consumer code.
+- Make the manifest addition idempotent: re-running `lex install` should produce the same `lexicons.json` (same CIDs) as long as upstream doesn't republish.
+
+**Non-Goals:**
+- Sample Android UI for either feature (deferred to a separate change).
+- Helper extensions on the generated services (e.g. paginated `Flow<BookmarkView>` wrappers).
+- Offline-first behaviour for drafts (downstream consumer concern — DataStore/Room cache wrapping the service, not an SDK abstraction).
+- Any runtime change to `:runtime` or `:oauth`.
+
+## Decisions
+
+### Decision 1: Single combined change, not two separate ones
+
+**Chosen:** One OpenSpec change, one PR, one release.
+
+**Rationale:** The two namespaces are mechanically identical to integrate — same workflow, same generator path, same test pattern. Bundling halves the review + release overhead. The two are independent enough that a problem in one (e.g. an upstream schema not yet resolvable) can be partially mitigated by shipping only the working half via the documented Atmosphere workaround.
+
+**Alternative considered:** Two sequential changes (bookmark first, draft second). Rejected — extra ceremony for zero added value.
+
+### Decision 2: Spec delta under `lexicon-codegen` rather than a new capability
+
+**Chosen:** Add two `## ADDED Requirements` entries to `lexicon-codegen/spec.md`, one per namespace, each with a scenario asserting the generated service is callable.
+
+**Rationale:** `lexicon-codegen` is the capability that owns "what the SDK exposes from upstream lexicons." Creating a brand-new capability for two namespaces would fragment the canonical spec for no benefit. The added requirements document the user-facing shape of the new clients without changing codegen behaviour.
+
+**Alternative considered:** Create a new `bookmark-draft-support` capability. Rejected — tiny, doesn't compose with anything, future namespace adds would fragment further.
+
+### Decision 3: MockEngine smoke tests in `:models`, not `:samples:android`
+
+**Chosen:** Add `BookmarkServiceTest` and `DraftServiceTest` (or pick one combined file) under `models/src/test/kotlin/...` that exercise the generated XRPC clients through a `MockEngine`-backed `XrpcClient`.
+
+**Rationale:** The tests prove generator output works correctly at the wire-shape level — independent of any Android plumbing. They live next to the generated code they cover and run in `:models:test`.
+
+**Alternative considered:** Reuse the existing `:samples:android` test setup. Rejected — slower, drags in Android-platform deps, and the test is about the model layer, not the app.
+
+### Decision 4: Minor version bump (v8.1.0), no breaking-changes doc
+
+**Chosen:** Refresh `:models:apiDump`, commit, and rely on semantic-release's default minor behaviour (no `BREAKING CHANGE:` footer, no `feat!:` prefix).
+
+**Rationale:** All API surface changes are additive — new public classes and accessors. The `kotlinx-binary-compatibility-validator` will see additions but no incompatible signature changes. Per the existing release pipeline, additive `feat:` commits produce a minor bump.
+
+**Alternative considered:** Bundle bookmark/draft with the next breaking change to amortize the v9 cost. Rejected — would block this release indefinitely for a hypothetical future breakage; better to ship minor today.
+
+### Decision 5: Document the Atmosphere lex-resolver workaround in the tasks file
+
+**Chosen:** Add an explicit task that says: if `npx lex install --ci` fails for any of the 9 new NSIDs, install everything else first, pin those CIDs, then add the failing NSID(s) separately.
+
+**Rationale:** Repo memory captured this exact failure mode for `chat.bsky.convo.getConvoMembers` previously. Putting the workaround in the tasks file means an implementer (human or agent) won't waste an hour rediscovering it.
+
+## Risks / Trade-offs
+
+- **[Upstream Atmosphere lex-resolver flake]** A single broken NSID in the batch aborts the whole install, leaving `lexicons.json` unmodified. → Mitigation: Decision 5 above. Documented in tasks.md.
+
+- **[Server-side endpoints not yet deployed on bsky.social]** Consumers calling the generated clients before the production AppView/PDS rolls these out will see `XrpcError` at runtime. → Mitigation: a sentence in the release notes warning of this; nothing structural the SDK can do. Lexicons being in `bluesky-social/atproto@main` is the canonical "client-side ready" signal in this ecosystem.
+
+- **[Generated KDoc may surface upstream schema descriptions verbatim]** If upstream descriptions reference Bluesky-specific UX (e.g. "as displayed in the iOS sheet"), the KDoc inherits that wording. → Acceptable: matches existing chat.bsky.* / com.atproto.* behaviour. Not worth a sanitization pass.
+
+- **[Pagination shape for getBookmarks]** Returns `{ cursor, bookmarks: [bookmarkView] }`. The existing `pagination` capability already handles cursor-bearing responses generically — the bookmark client should "just work" with whatever pagination helpers consumers reach for. → No work needed; tests assert the response decodes.
+
+## Migration Plan
+
+1. Append 9 NSIDs to `generator/lexicons.json`.
+2. `cd generator && npx lex install --ci` — pins CIDs. If a single NSID fails, fall back to Decision 5's workaround.
+3. `./gradlew :generator:generateModels` — emits new sources into `models/build/generated/source/lexicon/`.
+4. `./gradlew :models:apiDump` — refresh the public API surface file.
+5. Write 2 MockEngine smoke tests in `:models`.
+6. `./gradlew :generator:test --tests '*GoldenFileTest*'` — regenerate goldens if codegen produced new output for shared paths (run with `GOLDEN_UPDATE=1` if needed).
+7. `./gradlew spotlessApply build` — clean.
+8. Update spec delta under `openspec/changes/add-bookmark-and-draft-lexicons/specs/lexicon-codegen/spec.md`.
+9. PR + merge + semantic-release cuts v8.1.0.
+
+**Rollback:** Pure revert. No persistent state. Downstream consumers stay on v8.0.0.
+
+## Open Questions
+
+- Should we backfill a generic Kotlin extension that pages `BookmarkService.getBookmarks` into a `Flow<BookmarkView>` for ergonomic consumption? Lean **no for v8.1.0** — premature; let nubecita ask for it after they wire it up. The existing `pagination` capability gives them the primitives.
+- Are there any upstream Lexicon validation quirks specific to `app.bsky.draft.defs#draft` (e.g. nested unions, optional embed types) that might trip the generator? Lean **find out empirically during step 3 of the migration plan**; if so, file a separate generator-bug ticket and surface via openspec.

--- a/openspec/changes/add-bookmark-and-draft-lexicons/proposal.md
+++ b/openspec/changes/add-bookmark-and-draft-lexicons/proposal.md
@@ -14,7 +14,7 @@ The downstream `kikin81/nubecita` client wants two next-up retention features us
   - `app.bsky.draft.deleteDraft`
   - `app.bsky.draft.getDrafts`
   - `app.bsky.draft.updateDraft`
-- Run `npx lex install --ci` to fetch the JSON schemas from upstream and pin CIDs.
+- Run `npx lex install` to fetch the JSON schemas from upstream and pin CIDs. The first run must omit `--ci` because that flag verifies an already-pinned manifest; once new NSIDs are pinned, subsequent CI builds can use `npx lex install --ci` for verification.
 - Regenerate via `:generator:generateModels` — emits `BookmarkService`, `DraftService`, and the `BookmarkView` / `Draft` model types under the existing `io.github.kikin81.atproto.app.bsky.{bookmark,draft}` packages.
 - Refresh `:models:apiDump` — additive only (new public classes + accessors).
 - Add 2 MockEngine smoke tests in `:models` proving wire-shape: one query (`BookmarkService.getBookmarks`) and one procedure (`DraftService.createDraft`).

--- a/openspec/changes/add-bookmark-and-draft-lexicons/proposal.md
+++ b/openspec/changes/add-bookmark-and-draft-lexicons/proposal.md
@@ -1,0 +1,42 @@
+## Why
+
+The downstream `kikin81/nubecita` client wants two next-up retention features users have come to expect from Bluesky clients: **bookmarks** (saving posts for later) and **drafts** (composing posts across devices/sessions). Both are first-class server-supported features in `bluesky-social/atproto@main` (lexicon schemas live under `lexicons/app/bsky/bookmark/` and `lexicons/app/bsky/draft/`), but the SDK doesn't yet generate clients for them — they're not in `generator/lexicons.json`. Adding the NSIDs lets nubecita build a bookmarks list and persistent-drafts UX immediately, with no runtime work in this SDK.
+
+## What Changes
+
+- Append 9 NSIDs to `generator/lexicons.json`:
+  - `app.bsky.bookmark.defs` (shared types — `bookmarkView`)
+  - `app.bsky.bookmark.createBookmark`
+  - `app.bsky.bookmark.deleteBookmark`
+  - `app.bsky.bookmark.getBookmarks`
+  - `app.bsky.draft.defs` (shared types — `draft`)
+  - `app.bsky.draft.createDraft`
+  - `app.bsky.draft.deleteDraft`
+  - `app.bsky.draft.getDrafts`
+  - `app.bsky.draft.updateDraft`
+- Run `npx lex install --ci` to fetch the JSON schemas from upstream and pin CIDs.
+- Regenerate via `:generator:generateModels` — emits `BookmarkService`, `DraftService`, and the `BookmarkView` / `Draft` model types under the existing `io.github.kikin81.atproto.app.bsky.{bookmark,draft}` packages.
+- Refresh `:models:apiDump` — additive only (new public classes + accessors).
+- Add 2 MockEngine smoke tests in `:models` proving wire-shape: one query (`BookmarkService.getBookmarks`) and one procedure (`DraftService.createDraft`).
+- Release as a **minor bump** (v8.0.0 → v8.1.0). Purely additive — no `BREAKING CHANGE:` footer, no breaking-changes doc.
+
+## Capabilities
+
+### New Capabilities
+
+(none — extends the existing `lexicon-codegen` capability with two added scope requirements)
+
+### Modified Capabilities
+
+- `lexicon-codegen`: Adds requirements stating that the generated SDK ships `BookmarkService` (with `getBookmarks` / `createBookmark` / `deleteBookmark`) and `DraftService` (with `getDrafts` / `createDraft` / `deleteDraft` / `updateDraft`) bound to their respective `app.bsky.bookmark.*` and `app.bsky.draft.*` lexicon NSIDs. No change to how codegen *works* — these are pure scope additions verifiable through the existing emission pipeline.
+
+## Impact
+
+- **`:generator`**: 9 manifest entries added to `lexicons.json` + corresponding CIDs after `lex install`. No code changes.
+- **`:models`**: 2 new auto-generated service classes + their data models (`BookmarkView`, `Draft`, paginated `getBookmarks` response, etc.). Public API surface grows additively.
+- **Tests**: 2 new MockEngine smoke tests in `:models` (query + procedure) to catch wire-shape regressions beyond what GoldenFileTest covers.
+- **Binary compatibility**: `:models:apiCheck` will require a refreshed `.api` file. Strictly additive — minor version bump, not major.
+- **Release notes**: One sentence noting that bookmark/draft client models ship in v8.1.0 and that server-side production deployment of these endpoints on `bsky.social` may still be rolling out; runtime XRPC calls may surface `XrpcError` until the server side is live.
+- **Downstream consumer guidance** (for nubecita): the `DraftService` exposes a remote-record API; offline-first behaviour should be implemented at the consumer layer (DataStore/Room cache wrapping the service) so users can compose drafts without network. Out of scope for this SDK.
+- **Risk: Atmosphere lex-resolver**: Per repo memory, a single broken NSID can abort the whole `npx lex install` batch (chat.bsky.convo.getConvoMembers precedent). Mitigation: install everything else first, add the broken one separately. Documented in implementation tasks.
+- **Out of scope**: sample Android UI for either feature; helper extensions on the generated services (presumptive ergonomics); offline-first wrappers (downstream concern).

--- a/openspec/changes/add-bookmark-and-draft-lexicons/specs/lexicon-codegen/spec.md
+++ b/openspec/changes/add-bookmark-and-draft-lexicons/specs/lexicon-codegen/spec.md
@@ -1,0 +1,34 @@
+## ADDED Requirements
+
+### Requirement: Generated SDK SHALL include `app.bsky.bookmark.*` clients
+
+The system SHALL include `app.bsky.bookmark.defs`, `app.bsky.bookmark.createBookmark`, `app.bsky.bookmark.deleteBookmark`, and `app.bsky.bookmark.getBookmarks` in the manifest at `generator/lexicons.json` and emit a `BookmarkService` Kotlin class in package `io.github.kikin81.atproto.app.bsky.bookmark` exposing the three endpoints as suspending functions, plus a `BookmarkView` data class for the `bookmarkView` ref in `app.bsky.bookmark.defs`.
+
+#### Scenario: Generated BookmarkService exposes the three endpoints
+
+- **WHEN** a consumer constructs `BookmarkService(xrpcClient)` after building `:models`
+- **THEN** the class exposes `suspend fun getBookmarks(request: GetBookmarksRequest = GetBookmarksRequest()): GetBookmarksResponse`, `suspend fun createBookmark(request: CreateBookmarkRequest): Unit`, and `suspend fun deleteBookmark(request: DeleteBookmarkRequest): Unit`
+- **AND** `GetBookmarksResponse.bookmarks` is typed `List<BookmarkView>` with an optional `cursor: String?`
+
+#### Scenario: getBookmarks hits the correct XRPC path with paginated query params
+
+- **WHEN** a consumer calls `BookmarkService(xrpcClient).getBookmarks(GetBookmarksRequest(limit = 25, cursor = "abc"))` against a `MockEngine`-backed `XrpcClient`
+- **THEN** the outgoing HTTP request is `GET .../xrpc/app.bsky.bookmark.getBookmarks` with `limit=25` and `cursor=abc` in the query string
+- **AND** a JSON response of `{"cursor":"next","bookmarks":[]}` decodes into a typed `GetBookmarksResponse`
+
+### Requirement: Generated SDK SHALL include `app.bsky.draft.*` clients
+
+The system SHALL include `app.bsky.draft.defs`, `app.bsky.draft.createDraft`, `app.bsky.draft.deleteDraft`, `app.bsky.draft.getDrafts`, and `app.bsky.draft.updateDraft` in the manifest at `generator/lexicons.json` and emit a `DraftService` Kotlin class in package `io.github.kikin81.atproto.app.bsky.draft` exposing the four endpoints as suspending functions, plus a `Draft` data class for the `draft` ref in `app.bsky.draft.defs`.
+
+#### Scenario: Generated DraftService exposes the four endpoints
+
+- **WHEN** a consumer constructs `DraftService(xrpcClient)` after building `:models`
+- **THEN** the class exposes `suspend fun getDrafts(request: GetDraftsRequest = GetDraftsRequest()): GetDraftsResponse`, `suspend fun createDraft(request: CreateDraftRequest): CreateDraftResponse`, `suspend fun updateDraft(request: UpdateDraftRequest): Unit`, and `suspend fun deleteDraft(request: DeleteDraftRequest): Unit`
+- **AND** `CreateDraftResponse.id` is typed `String`
+
+#### Scenario: createDraft posts the JSON-encoded input to the correct XRPC path
+
+- **WHEN** a consumer calls `DraftService(xrpcClient).createDraft(CreateDraftRequest(draft = Draft(posts = listOf(DraftPost(text = "hello")))))` against a `MockEngine`-backed `XrpcClient`
+- **THEN** the outgoing HTTP request is `POST .../xrpc/app.bsky.draft.createDraft` with `Content-Type: application/json`
+- **AND** the request body contains a JSON object with a `draft` property whose `posts[0].text` is `"hello"`
+- **AND** a JSON response of `{"id":"draft-123"}` decodes into a typed `CreateDraftResponse` with `id = "draft-123"`

--- a/openspec/changes/add-bookmark-and-draft-lexicons/tasks.md
+++ b/openspec/changes/add-bookmark-and-draft-lexicons/tasks.md
@@ -1,0 +1,47 @@
+## 1. Manifest additions
+
+- [x] 1.1 Append 4 bookmark NSIDs to `generator/lexicons.json`
+- [x] 1.2 Append 5 draft NSIDs to `generator/lexicons.json`
+- [x] 1.3 Confirm alphabetical ordering — bookmark/draft slot between `app.bsky.actor.*` and `app.bsky.feed.*`
+
+## 2. Lexicon install + pin CIDs
+
+- [x] 2.1 Run `cd generator && npx lex install` (without `--ci`, which requires pre-pinned CIDs). All 9 NSIDs resolved cleanly — no Atmosphere lex-resolver issues this time
+- [x] 2.2 Verified all 9 NSIDs are in both `lexicons[]` and `resolutions{}` of the manifest; total resolutions went from 130 → 139
+- [x] 2.3 Manifest change is included with the rest of the change; standalone commit not separated (low risk, no transitive surprises)
+
+## 3. Regenerate models
+
+- [x] 3.1 `./gradlew :generator:generateModels` succeeded — `BookmarkService.kt`, `DraftService.kt`, and their data classes are emitted under the expected packages
+- [x] 3.2 Spot-checked services: `getBookmarks` is GET, `createBookmark`/`deleteBookmark`/`createDraft`/`updateDraft`/`deleteDraft` are POST, correct NSIDs in `client.query`/`client.procedure` calls, KDoc copied from upstream lexicon descriptions
+- [x] 3.3 Spot-checked data classes — naming convention is `*Request`/`*Response` (not `*Input`/`*Output`); `Draft.posts` is `List<DraftPost>` required, optional fields use `T? = null`. Two generator warnings about union fields (`threadgateAllow`, `labels`) falling back to `JsonObject` — known limitation, raw JSON still accessible; noted in PR
+
+## 4. Golden file regression check
+
+- [x] 4.1 `./gradlew :generator:test --tests '*GoldenFileTest*'` passes — generator output is consistent with golden fixtures
+- [x] 4.2 No golden updates needed
+
+## 5. MockEngine smoke tests
+
+- [x] 5.1 Added `models/src/commonTest/kotlin/io/github/kikin81/atproto/app/bsky/bookmark/BookmarkServiceTest.kt` — asserts GET method, URL contains `/xrpc/app.bsky.bookmark.getBookmarks` + `limit=25&cursor=abc`, decodes typed response
+- [x] 5.2 Added `models/src/commonTest/kotlin/io/github/kikin81/atproto/app/bsky/draft/DraftServiceTest.kt` — asserts POST method, URL, JSON body containing `"draft"` + nested post text, decodes typed `CreateDraftResponse`
+- [x] 5.3 Set up `commonTest` source set in `models/build.gradle.kts` (added `ktor.client.mock` + `kotlinx.coroutines.test` to commonTest deps — first test infrastructure for this module). Verified via `:models:jvmTest` — 2 tests pass
+
+## 6. Binary-compat dump
+
+- [x] 6.1 `./gradlew :models:apiDump` refreshed `models/api/models.api` (~1000 lines diff — includes stale drift since last dump on 2026-05-14 + bookmark/draft additions)
+- [x] 6.2 Confirmed bookmark/draft additions are strictly additive new classes; older changes (PostView etc.) are pre-existing drift from prior generator changes not captured in apiCheck-blocking incompatibility
+- [x] 6.3 `./gradlew :models:apiCheck` green
+
+## 7. Spec sync + cleanup
+
+- [x] 7.1 No breaking changes doc — minor bump
+- [x] 7.2 Commit prefix `feat(models):` for minor bump via semantic-release
+- [x] 7.3 PR body includes server-side deployment status note
+
+## 8. Wrap-up
+
+- [x] 8.1 `./gradlew spotlessApply` and `./gradlew build` clean
+- [x] 8.2 All module tests green via full `./gradlew build` (383 tasks, including the 2 new BookmarkServiceTest/DraftServiceTest cases)
+- [ ] 8.3 Push branch, open PR, address review comments, merge
+- [ ] 8.4 Once v8.1.0 is on Maven Central: notify nubecita to upgrade


### PR DESCRIPTION
Adds bookmark and draft retention features to the SDK via codegen — `BookmarkService` and `DraftService` ready for downstream consumption by `kikin81/nubecita` and other AT Protocol clients. Pure codegen change, no runtime modifications.

## Summary
- **9 new NSIDs in `generator/lexicons.json`**: 4 bookmark (`createBookmark`, `defs`, `deleteBookmark`, `getBookmarks`) + 5 draft (`createDraft`, `defs`, `deleteDraft`, `getDrafts`, `updateDraft`). All resolved cleanly via `npx lex install` — no Atmosphere lex-resolver issues.
- **Generated services**: `io.github.kikin81.atproto.app.bsky.bookmark.BookmarkService` (3 endpoints) and `io.github.kikin81.atproto.app.bsky.draft.DraftService` (4 endpoints), plus their request/response/view data classes.
- **First-time `:models` test infrastructure**: set up `commonTest` source set with `ktor.client.mock` + `kotlinx.coroutines.test` deps. Two MockEngine smoke tests verify wire shape (one query, one procedure). Pays forward for future generated-service tests.
- **`models/api/models.api` refreshed**: ~1000-line diff. The majority is pre-existing drift since the last dump on 2026-05-14 — `apiCheck` was passing before and is passing now; no incompatibilities. Bookmark/draft additions are net-new classes.
- **Minor bump**: v8.0.0 → v8.1.0. No `BREAKING CHANGE:` footer.

## Known limitation
Two union fields in `DraftPost` (`threadgateAllow`, `labels`) fall back to `JsonObject` because the generator's `EmissionPlan` doesn't compute a union site for them. The data is still accessible as raw JSON; refining this requires a generator fix that's out of scope for this PR. Worth a separate beads issue.

## Server-side rollout note
`bsky.social` may not have these endpoints deployed in production yet; the lexicon schemas live in `bluesky-social/atproto@main` (the standard signal of "client-side ready"). Consumers calling these against a server that hasn't deployed will see `XrpcError` at runtime — nothing structural the SDK can fix.

## OpenSpec change
`openspec/changes/add-bookmark-and-draft-lexicons/` — proposal, design, delta on `lexicon-codegen` (+2 ADDED requirements, 4 scenarios), and tasks file with full breakdown.

## Test plan
- [x] `npx lex install` resolves all 9 NSIDs to CIDs
- [x] `./gradlew :generator:generateModels` emits services + types
- [x] `./gradlew :generator:test --tests '*GoldenFileTest*'` — green (no regression)
- [x] `./gradlew :models:apiDump` refreshed; `:models:apiCheck` green
- [x] `./gradlew :models:jvmTest` — 2 new tests pass (BookmarkServiceTest, DraftServiceTest)
- [x] `./gradlew build` — full green (383 tasks)
- [x] `./gradlew spotlessApply` — clean
- [ ] **Manual:** downstream nubecita can import `BookmarkService` / `DraftService` from `io.github.kikin81.atproto:models:8.1.0` after release

🤖 Generated with [Claude Code](https://claude.com/claude-code)