### PR TITLE
feat(generator): per-method proxy override on generated services

### DIFF
--- a/docs/breaking-changes/v9.md
+++ b/docs/breaking-changes/v9.md
@@ -1,0 +1,193 @@
+# Breaking changes — v9.0.0
+
+## Summary
+
+Every generated XRPC service method in `io.github.kikin81.atproto:models`
+gains a new optional `proxy: String? = null` final parameter. This is the
+per-call escape hatch for setting the `atproto-proxy` HTTP header when
+the proxy target is consumer-chosen (i.e. not a Bluesky-managed appview
+that `ProxyMapping` can hardcode).
+
+The motivating use case is push-notification registration:
+`app.bsky.notification.{registerPush, unregisterPush}` route to a push
+gateway whose DID is operator-chosen (Bluesky's first-party client uses
+`did:web:api.bsky.app#bsky_notif`; self-hosted operators run their own
+gateway, e.g. `did:web:push.nubecita.app#bsky_notif`). Until v9 there
+was no way to forward an `atproto-proxy` header through the generated
+`NotificationService` wrapper — consumers had to drop to raw
+`XrpcClient.procedure(...)`. Now:
+
+```kotlin
+notificationService.registerPush(
+    request = RegisterPushRequest(serviceDid = Did("did:web:push.nubecita.app"), …),
+    proxy = "did:web:push.nubecita.app#bsky_notif",
+)
+```
+
+For services that already had a constructor-level `proxy` default (today:
+`chat.bsky.convo.ConvoService`), defaults preserve the existing wire
+behavior — no consumer change required. Consumers who want to point
+those services at a self-hosted appview can now do so per-call as a
+bonus.
+
+This is binary-breaking even though every existing call site compiles
+unchanged: adding a parameter to a public API tracked by
+`kotlinx-binary-compatibility-validator` shifts the JVM method
+descriptor, so the major version is required. There is no source-level
+break — Kotlin callers see no change unless they explicitly pass `proxy`.
+
+## What changed
+
+### Generated `*Service` methods — new trailing `proxy` parameter
+
+Every `suspend fun` on every generated service in `:models` gains
+`proxy: String? = null` as its last parameter, regardless of input
+shape (query, JSON procedure, params-only procedure, no-input
+procedure, or raw-bytes procedure).
+
+Forwarding semantics inside the generated body:
+
+- Services **with** a constructor-level `proxy` property (today: only
+  `ConvoService`): the emitted forwarding expression is
+  `proxy = proxy ?: this.proxy`. When the caller passes `null` (the
+  default), the constructor-level default wins. When the caller passes
+  a value, the override wins for that single call.
+- Services **without** a constructor-level `proxy` property (everyone
+  else): the emitted forwarding expression is `proxy = proxy`. When
+  the caller passes `null` (the default), no `atproto-proxy` header is
+  sent — identical to v8 behavior. When the caller passes a value, it
+  is sent as-is.
+
+### Before / after — `NotificationService` (newly unblocked)
+
+```kotlin
+// before (v8) — no escape hatch, bypass the wrapper
+xrpcClient.procedure(
+    nsid = "app.bsky.notification.registerPush",
+    params = NoXrpcParams,
+    paramsSerializer = NoXrpcParams.serializer(),
+    input = RegisterPushRequest(serviceDid = Did(gatewayDid), token = fcmToken, …),
+    inputSerializer = RegisterPushRequest.serializer(),
+    responseSerializer = UnitResponseSerializer,
+    proxy = "$gatewayDid#bsky_notif",
+)
+
+// after (v9) — typed wrapper carries the override
+NotificationService(xrpcClient).registerPush(
+    request = RegisterPushRequest(serviceDid = Did(gatewayDid), token = fcmToken, …),
+    proxy = "$gatewayDid#bsky_notif",
+)
+```
+
+### Before / after — `ConvoService` (no consumer change required)
+
+```kotlin
+// before (v8) — constructor default sends did:web:api.bsky.chat#bsky_chat
+ConvoService(xrpcClient).listConvos(ListConvosRequest())
+
+// after (v9) — identical wire behavior, identical source
+ConvoService(xrpcClient).listConvos(ListConvosRequest())
+
+// (new in v9) per-call override for self-hosted chat appviews
+ConvoService(xrpcClient).listConvos(
+    ListConvosRequest(),
+    proxy = "did:web:custom.chat#bsky_chat",
+)
+```
+
+The constructor `proxy: String? = "did:web:api.bsky.chat#bsky_chat"`
+parameter is unchanged.
+
+### Unchanged
+
+- `ProxyMapping` — still the source of truth for constructor-level
+  proxy defaults.
+- `ServiceGenerator.resolveProxyForPackage` — still enforces "one
+  proxy per service package" at codegen time.
+- `XrpcClient.{query, procedure}` — already accepted `proxy: String?`
+  on every overload; no `:runtime` change.
+- No `*Request` / `*Response` data classes change shape.
+
+## How to migrate
+
+### 1. Bump the dependency
+
+```kotlin
+// before
+implementation("io.github.kikin81.atproto:models:8.x.x")
+
+// after
+implementation("io.github.kikin81.atproto:models:9.0.0")
+```
+
+### 2. If you were bypassing the generated wrapper to send `atproto-proxy`
+
+Replace the raw `XrpcClient.procedure(...)` / `XrpcClient.query(...)`
+call with the typed service method, passing your gateway DID as the
+new `proxy` argument. The motivating example is push registration:
+
+```kotlin
+// before — direct XrpcClient call, lost wrapper ergonomics
+override suspend fun register(did: String, fcmToken: String) = runCatching {
+    xrpcClient.procedure(
+        nsid = "app.bsky.notification.registerPush",
+        params = NoXrpcParams,
+        paramsSerializer = NoXrpcParams.serializer(),
+        input = RegisterPushRequest(serviceDid = Did(gatewayDid), token = fcmToken, …),
+        inputSerializer = RegisterPushRequest.serializer(),
+        responseSerializer = UnitResponseSerializer,
+        proxy = "$gatewayDid#bsky_notif",
+    )
+}
+
+// after — typed wrapper carries the override
+override suspend fun register(did: String, fcmToken: String) = runCatching {
+    NotificationService(xrpcClient).registerPush(
+        request = RegisterPushRequest(serviceDid = Did(gatewayDid), token = fcmToken, …),
+        proxy = "$gatewayDid#bsky_notif",
+    )
+}
+```
+
+The same shape applies to `unregisterPush` and to any other call that
+needs a consumer-chosen proxy.
+
+### 3. If you only use chat services with the default appview
+
+No changes required. The constructor default
+`did:web:api.bsky.chat#bsky_chat` continues to win when you don't
+pass `proxy` — wire-identical to v8.
+
+### 4. Everyone else
+
+No changes required. The new `proxy` parameter defaults to `null` and
+the generated body forwards `null`, so no `atproto-proxy` header is
+sent for services that didn't previously send one.
+
+## Why this is a major bump
+
+Per the kotlinx-binary-compatibility-validator (gating this repo at
+`:models:apiCheck`):
+
+- Every generated `*Service.<method>(...)` JVM signature changed:
+  an extra `Ljava/lang/String;` parameter slot was added before the
+  `Continuation`. The corresponding `$default` bridge functions added
+  the same parameter, plus the kotlinx-emitted default-value mask.
+- KotlinPoet emits default-value bridges so Kotlin callers see no
+  source-level break — `notificationService.registerPush(request)`
+  still compiles. JVM bytecode consumers (and any non-Kotlin
+  consumer recompiling against the new artifact) see the new
+  signature.
+
+Per repo discipline (see `v5.md`, `v6.md`, `v7.md`, `v8.md`) and the
+project's binary-compat memory, adding any parameter to a public API —
+even one with a default — is binary-breaking even when
+source-compatible, and requires a `BREAKING CHANGE:` footer on the
+merge commit so semantic-release cuts a major version.
+
+## References
+
+- GitHub issue: [#117](https://github.com/kikin81/atproto-kotlin/issues/117)
+- Motivating consumer PR (push registration bypass that v9 obviates):
+  [nubecita#301](https://github.com/kikin81/nubecita/pull/301)
+- Push gateway implementation: [DracoBlue/atproto-push-gateway](https://github.com/DracoBlue/atproto-push-gateway)

--- a/generator/src/main/kotlin/io/github/kikin81/atproto/generator/emit/ServiceGenerator.kt
+++ b/generator/src/main/kotlin/io/github/kikin81/atproto/generator/emit/ServiceGenerator.kt
@@ -199,6 +199,7 @@ public class ServiceGenerator(
                 param.defaultValue("%T()", requestCn)
             }
             fn.addParameter(param.build())
+            fn.addParameter(proxyOverrideParam())
             fn.addCode(
                 buildCall(
                     kind = "query",
@@ -213,6 +214,7 @@ public class ServiceGenerator(
             )
         } else {
             // No params: use NoXrpcParams as a sentinel to satisfy XrpcClient.query's signature.
+            fn.addParameter(proxyOverrideParam())
             fn.addCode(
                 buildCall(
                     kind = "query",
@@ -260,6 +262,7 @@ public class ServiceGenerator(
                         param.defaultValue("%T()", requestCn)
                     }
                     fn.addParameter(param.build())
+                    fn.addParameter(proxyOverrideParam())
                     fn.addCode(
                         buildCall(
                             kind = "procedure",
@@ -275,6 +278,7 @@ public class ServiceGenerator(
                 } else {
                     // Edge: classifier said Json (encoding is application/json or
                     // schema present) but no schema/Request — fall back to no-body.
+                    fn.addParameter(proxyOverrideParam())
                     fn.addCode(noInputCall(defKey, responseSerializer, emitProxy))
                 }
             }
@@ -286,6 +290,7 @@ public class ServiceGenerator(
                         param.defaultValue("%T()", requestCn)
                     }
                     fn.addParameter(param.build())
+                    fn.addParameter(proxyOverrideParam())
                     fn.addCode(
                         buildCall(
                             kind = "procedure",
@@ -299,6 +304,7 @@ public class ServiceGenerator(
                         ),
                     )
                 } else {
+                    fn.addParameter(proxyOverrideParam())
                     fn.addCode(noInputCall(defKey, responseSerializer, emitProxy))
                 }
             }
@@ -309,6 +315,7 @@ public class ServiceGenerator(
                     contentTypeParam.defaultValue(contentTypeDefaultExpr(it))
                 }
                 fn.addParameter(contentTypeParam.build())
+                fn.addParameter(proxyOverrideParam())
                 fn.addCode(
                     buildRawBytesCall(
                         nsid = defKey.nsid.raw,
@@ -317,7 +324,10 @@ public class ServiceGenerator(
                     ),
                 )
             }
-            is ProcedureInputShape.None -> fn.addCode(noInputCall(defKey, responseSerializer, emitProxy))
+            is ProcedureInputShape.None -> {
+                fn.addParameter(proxyOverrideParam())
+                fn.addCode(noInputCall(defKey, responseSerializer, emitProxy))
+            }
             is ProcedureInputShape.UnsupportedRawBytesWithParams -> throw VerificationFailure(
                 "Unsupported procedure shape: lexicon '${shape.lexiconId}' declares input.encoding " +
                     "'${shape.encoding}' (raw bytes) AND def.parameters (URL params). The SDK does not " +
@@ -361,7 +371,7 @@ public class ServiceGenerator(
         emitProxy: Boolean,
     ): CodeBlock {
         val rsExpr = responseSerializerExpr ?: CodeBlock.of("%T", UNIT_RESPONSE_SERIALIZER)
-        val proxyLine = if (emitProxy) "    proxy = proxy,\n" else ""
+        val proxyLine = if (emitProxy) "    proxy = proxy ?: this.proxy,\n" else "    proxy = proxy,\n"
         return CodeBlock.of(
             "return client.procedure(\n" +
                 "    nsid = %S,\n" +
@@ -378,6 +388,10 @@ public class ServiceGenerator(
             rsExpr,
         )
     }
+
+    private fun proxyOverrideParam(): ParameterSpec = ParameterSpec.builder("proxy", STRING_NULLABLE)
+        .defaultValue("null")
+        .build()
 
     private fun responseSerializerExpr(fqName: FqName): CodeBlock {
         val cn = ClassName(fqName.pkg, fqName.simpleName)
@@ -416,6 +430,8 @@ public class ServiceGenerator(
             }
             append("    responseSerializer = %L,\n")
             if (emitProxy) {
+                append("    proxy = proxy ?: this.proxy,\n")
+            } else {
                 append("    proxy = proxy,\n")
             }
             append(")\n")

--- a/generator/src/test/kotlin/io/github/kikin81/atproto/generator/emit/ServiceGeneratorProxyEmissionTest.kt
+++ b/generator/src/test/kotlin/io/github/kikin81/atproto/generator/emit/ServiceGeneratorProxyEmissionTest.kt
@@ -1,0 +1,286 @@
+package io.github.kikin81.atproto.generator.emit
+
+import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.TypeSpec
+import io.github.kikin81.atproto.generator.naming.NamingMatrix
+import io.github.kikin81.atproto.generator.parser.LexiconParser
+import io.github.kikin81.atproto.generator.resolved.ContextTagger
+import io.github.kikin81.atproto.generator.resolved.RefResolver
+import io.github.kikin81.atproto.generator.resolved.SymbolTable
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Verifies that `ServiceGenerator` emits a per-call `proxy: String? = null`
+ * parameter on every generated query/procedure method (regardless of input
+ * shape), and forwards it correctly:
+ *
+ * - Services with a constructor `proxy` property (services whose NSIDs hit
+ *   a `ProxyMapping` entry — `chat.bsky.*` today): forwarding expression
+ *   `proxy = proxy ?: this.proxy`. Method-level override wins when non-null;
+ *   constructor default wins when null.
+ * - Services without a constructor `proxy` property (everyone else):
+ *   forwarding expression `proxy = proxy`. Null when caller omits, no
+ *   `atproto-proxy` header.
+ *
+ * Uses a synthetic inline lexicon corpus covering every input shape:
+ * query, JSON procedure, params-only procedure, no-input procedure, and
+ * raw-bytes procedure — for both a proxied and an unproxied namespace.
+ *
+ * Byte-for-byte regression is covered by [io.github.kikin81.atproto.generator.golden.GoldenFileTest].
+ */
+class ServiceGeneratorProxyEmissionTest {
+
+    private val parser = LexiconParser()
+
+    private val proxiedLexicons = listOf(
+        // chat query
+        """
+        {
+          "lexicon": 1,
+          "id": "chat.bsky.fake.listFake",
+          "defs": {
+            "main": {
+              "type": "query",
+              "parameters": {
+                "type": "params",
+                "properties": { "limit": { "type": "integer" } }
+              },
+              "output": {
+                "encoding": "application/json",
+                "schema": {
+                  "type": "object",
+                  "required": ["items"],
+                  "properties": { "items": { "type": "array", "items": { "type": "string" } } }
+                }
+              }
+            }
+          }
+        }
+        """,
+        // chat JSON procedure
+        """
+        {
+          "lexicon": 1,
+          "id": "chat.bsky.fake.doFake",
+          "defs": {
+            "main": {
+              "type": "procedure",
+              "input": {
+                "encoding": "application/json",
+                "schema": {
+                  "type": "object",
+                  "required": ["payload"],
+                  "properties": { "payload": { "type": "string" } }
+                }
+              },
+              "output": {
+                "encoding": "application/json",
+                "schema": {
+                  "type": "object",
+                  "required": ["ok"],
+                  "properties": { "ok": { "type": "boolean" } }
+                }
+              }
+            }
+          }
+        }
+        """,
+    )
+
+    private val unproxiedLexicons = listOf(
+        // non-chat query
+        """
+        {
+          "lexicon": 1,
+          "id": "app.bsky.fake.getFake",
+          "defs": {
+            "main": {
+              "type": "query",
+              "parameters": {
+                "type": "params",
+                "properties": { "id": { "type": "string" } }
+              },
+              "output": {
+                "encoding": "application/json",
+                "schema": {
+                  "type": "object",
+                  "required": ["value"],
+                  "properties": { "value": { "type": "string" } }
+                }
+              }
+            }
+          }
+        }
+        """,
+        // non-chat JSON procedure
+        """
+        {
+          "lexicon": 1,
+          "id": "app.bsky.fake.putFake",
+          "defs": {
+            "main": {
+              "type": "procedure",
+              "input": {
+                "encoding": "application/json",
+                "schema": {
+                  "type": "object",
+                  "required": ["value"],
+                  "properties": { "value": { "type": "string" } }
+                }
+              }
+            }
+          }
+        }
+        """,
+        // non-chat params-only procedure (no input body, only URL params)
+        """
+        {
+          "lexicon": 1,
+          "id": "app.bsky.fake.searchFake",
+          "defs": {
+            "main": {
+              "type": "procedure",
+              "parameters": {
+                "type": "params",
+                "properties": { "q": { "type": "string" } }
+              },
+              "output": {
+                "encoding": "application/json",
+                "schema": {
+                  "type": "object",
+                  "required": ["hits"],
+                  "properties": { "hits": { "type": "integer" } }
+                }
+              }
+            }
+          }
+        }
+        """,
+        // non-chat no-input procedure (has output schema so a Response class is
+        // emitted and the method is not silently filtered out of ServiceGenerator.emitAll)
+        """
+        {
+          "lexicon": 1,
+          "id": "app.bsky.fake.pingFake",
+          "defs": {
+            "main": {
+              "type": "procedure",
+              "output": {
+                "encoding": "application/json",
+                "schema": {
+                  "type": "object",
+                  "required": ["pong"],
+                  "properties": { "pong": { "type": "boolean" } }
+                }
+              }
+            }
+          }
+        }
+        """,
+        // non-chat raw-bytes procedure
+        """
+        {
+          "lexicon": 1,
+          "id": "app.bsky.fake.uploadFake",
+          "defs": {
+            "main": {
+              "type": "procedure",
+              "input": { "encoding": "image/png" },
+              "output": {
+                "encoding": "application/json",
+                "schema": {
+                  "type": "object",
+                  "required": ["blob"],
+                  "properties": { "blob": { "type": "blob" } }
+                }
+              }
+            }
+          }
+        }
+        """,
+    )
+
+    private fun emissionsFor(jsonLexicons: List<String>): List<ServiceGenerator.ServiceEmission> {
+        val docs = jsonLexicons.map { parser.parse(it.trimIndent()) }
+        val symbols = SymbolTable.build(docs)
+        RefResolver(symbols).validate()
+        val contexts = ContextTagger(symbols).tag()
+        val plan = EmissionPlan.build(symbols, NamingMatrix(), contexts)
+        return ServiceGenerator(plan, symbols).emitAll()
+    }
+
+    private fun TypeSpec.functions(): List<FunSpec> = funSpecs
+
+    @Test
+    fun proxied_service_appends_proxy_param_and_forwards_with_fallback() {
+        val emissions = emissionsFor(proxiedLexicons)
+        val service = emissions.singleOrNull { it.fqName.simpleName == "FakeService" }
+        assertNotNull(service, "expected exactly one FakeService emission in: ${emissions.map { it.fqName }}")
+
+        val funs = service.typeSpec.functions()
+        assertTrue(funs.size >= 2, "expected at least 2 methods on proxied FakeService, got: ${funs.map { it.name }}")
+
+        for (fn in funs) {
+            val last = fn.parameters.lastOrNull()
+            assertNotNull(last, "method ${fn.name} has no parameters")
+            assertEquals("proxy", last.name, "method ${fn.name} last param is not 'proxy'")
+            assertEquals("kotlin.String?", last.type.toString(), "method ${fn.name} 'proxy' param has wrong type: ${last.type}")
+            assertEquals("null", last.defaultValue?.toString(), "method ${fn.name} 'proxy' default is not 'null': ${last.defaultValue}")
+
+            val body = fn.body.toString()
+            assertTrue(
+                body.contains("proxy = proxy ?: this.proxy"),
+                "method ${fn.name} body missing 'proxy = proxy ?: this.proxy':\n$body",
+            )
+        }
+    }
+
+    @Test
+    fun unproxied_service_appends_proxy_param_and_forwards_plain() {
+        val emissions = emissionsFor(unproxiedLexicons)
+        val service = emissions.singleOrNull { it.fqName.simpleName == "FakeService" }
+        assertNotNull(service, "expected exactly one FakeService emission in: ${emissions.map { it.fqName }}")
+
+        val funs = service.typeSpec.functions()
+        assertTrue(funs.size >= 5, "expected at least 5 methods on unproxied FakeService, got: ${funs.map { it.name }}")
+
+        for (fn in funs) {
+            val last = fn.parameters.lastOrNull()
+            assertNotNull(last, "method ${fn.name} has no parameters")
+            assertEquals("proxy", last.name, "method ${fn.name} last param is not 'proxy'")
+            assertEquals("kotlin.String?", last.type.toString(), "method ${fn.name} 'proxy' param has wrong type: ${last.type}")
+            assertEquals("null", last.defaultValue?.toString(), "method ${fn.name} 'proxy' default is not 'null': ${last.defaultValue}")
+
+            val body = fn.body.toString()
+            assertTrue(
+                body.contains("proxy = proxy"),
+                "method ${fn.name} body missing 'proxy = proxy':\n$body",
+            )
+            assertTrue(
+                !body.contains("this.proxy"),
+                "method ${fn.name} body should NOT contain 'this.proxy' on an unproxied service:\n$body",
+            )
+        }
+    }
+
+    @Test
+    fun raw_bytes_procedure_also_appends_proxy_param() {
+        val emissions = emissionsFor(unproxiedLexicons)
+        val service = emissions.single { it.fqName.simpleName == "FakeService" }
+        val uploadFn = service.typeSpec.functions().single { it.name == "uploadFake" }
+
+        // raw-bytes shape: parameters are (input, inputContentType, proxy)
+        assertEquals(3, uploadFn.parameters.size, "raw-bytes method should have 3 params, got: ${uploadFn.parameters.map { it.name }}")
+        assertEquals("input", uploadFn.parameters[0].name)
+        assertEquals("inputContentType", uploadFn.parameters[1].name)
+        assertEquals("proxy", uploadFn.parameters[2].name)
+        assertEquals("null", uploadFn.parameters[2].defaultValue?.toString())
+
+        val body = uploadFn.body.toString()
+        assertTrue(body.contains("proxy = proxy"), "raw-bytes body missing 'proxy = proxy':\n$body")
+        assertTrue(!body.contains("this.proxy"), "raw-bytes body on unproxied service should not contain 'this.proxy':\n$body")
+    }
+}

--- a/generator/src/test/resources/golden/kotlin/io/github/kikin81/atproto/chat/bsky/convo/ConvoService.kt
+++ b/generator/src/test/resources/golden/kotlin/io/github/kikin81/atproto/chat/bsky/convo/ConvoService.kt
@@ -14,12 +14,12 @@ public class ConvoService(
   /**
    * List conversations.
    */
-  public suspend fun listConvos(request: ListConvosRequest = ListConvosRequest()): ListConvosResponse = client.query(
+  public suspend fun listConvos(request: ListConvosRequest = ListConvosRequest(), proxy: String? = null): ListConvosResponse = client.query(
       nsid = "chat.bsky.convo.listConvos",
       params = request,
       paramsSerializer = ListConvosRequest.serializer(),
       responseSerializer = ListConvosResponse.serializer(),
-      proxy = proxy,
+      proxy = proxy ?: this.proxy,
   )
 }
 

--- a/generator/src/test/resources/golden/kotlin/io/github/kikin81/atproto/example/ExampleService.kt
+++ b/generator/src/test/resources/golden/kotlin/io/github/kikin81/atproto/example/ExampleService.kt
@@ -4,6 +4,7 @@ import io.github.kikin81.atproto.runtime.NoXrpcParams
 import io.github.kikin81.atproto.runtime.XrpcClient
 import io.ktor.http.ContentType
 import kotlin.ByteArray
+import kotlin.String
 
 public class ExampleService(
   private val client: XrpcClient,
@@ -11,36 +12,47 @@ public class ExampleService(
   /**
    * Round-trips a Shared value through a procedure.
    */
-  public suspend fun sendShared(request: SendSharedRequest): SendSharedResponse = client.procedure(
+  public suspend fun sendShared(request: SendSharedRequest, proxy: String? = null): SendSharedResponse = client.procedure(
       nsid = "example.sendShared",
       params = NoXrpcParams,
       paramsSerializer = NoXrpcParams.serializer(),
       input = request,
       inputSerializer = SendSharedRequest.serializer(),
       responseSerializer = SendSharedResponse.serializer(),
+      proxy = proxy,
   )
 
   /**
    * Upload a PNG avatar.
    */
-  public suspend fun uploadAvatar(input: ByteArray, inputContentType: ContentType = ContentType.Image.PNG): UploadAvatarResponse = client.procedure(
+  public suspend fun uploadAvatar(
+    input: ByteArray,
+    inputContentType: ContentType = ContentType.Image.PNG,
+    proxy: String? = null,
+  ): UploadAvatarResponse = client.procedure(
       nsid = "example.uploadAvatar",
       params = NoXrpcParams,
       paramsSerializer = NoXrpcParams.serializer(),
       input = input,
       inputContentType = inputContentType,
       responseSerializer = UploadAvatarResponse.serializer(),
+      proxy = proxy,
   )
 
   /**
    * Upload a blob and receive its CID reference.
    */
-  public suspend fun uploadBlob(input: ByteArray, inputContentType: ContentType): UploadBlobResponse = client.procedure(
+  public suspend fun uploadBlob(
+    input: ByteArray,
+    inputContentType: ContentType,
+    proxy: String? = null,
+  ): UploadBlobResponse = client.procedure(
       nsid = "example.uploadBlob",
       params = NoXrpcParams,
       paramsSerializer = NoXrpcParams.serializer(),
       input = input,
       inputContentType = inputContentType,
       responseSerializer = UploadBlobResponse.serializer(),
+      proxy = proxy,
   )
 }

--- a/generator/src/test/resources/golden/kotlin/io/github/kikin81/atproto/example/feed/FeedService.kt
+++ b/generator/src/test/resources/golden/kotlin/io/github/kikin81/atproto/example/feed/FeedService.kt
@@ -4,6 +4,7 @@ import io.github.kikin81.atproto.example.StrongRef
 import io.github.kikin81.atproto.runtime.XrpcClient
 import io.github.kikin81.atproto.runtime.paginate
 import io.github.kikin81.atproto.runtime.paginatePages
+import kotlin.String
 import kotlin.collections.List
 import kotlinx.coroutines.flow.Flow
 
@@ -13,11 +14,12 @@ public class FeedService(
   /**
    * Get a paginated timeline.
    */
-  public suspend fun getTimeline(request: GetTimelineRequest = GetTimelineRequest()): GetTimelineResponse = client.query(
+  public suspend fun getTimeline(request: GetTimelineRequest = GetTimelineRequest(), proxy: String? = null): GetTimelineResponse = client.query(
       nsid = "example.feed.getTimeline",
       params = request,
       paramsSerializer = GetTimelineRequest.serializer(),
       responseSerializer = GetTimelineResponse.serializer(),
+      proxy = proxy,
   )
 }
 

--- a/models/api/models.api
+++ b/models/api/models.api
@@ -1,16 +1,19 @@
 public final class io/github/kikin81/atproto/app/bsky/actor/ActorService {
 	public fun <init> (Lio/github/kikin81/atproto/runtime/XrpcClient;)V
-	public final fun getPreferences (Lio/github/kikin81/atproto/app/bsky/actor/GetPreferencesRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun getPreferences$default (Lio/github/kikin81/atproto/app/bsky/actor/ActorService;Lio/github/kikin81/atproto/app/bsky/actor/GetPreferencesRequest;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun getProfile (Lio/github/kikin81/atproto/app/bsky/actor/GetProfileRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getProfiles (Lio/github/kikin81/atproto/app/bsky/actor/GetProfilesRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getSuggestions (Lio/github/kikin81/atproto/app/bsky/actor/GetSuggestionsRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun getSuggestions$default (Lio/github/kikin81/atproto/app/bsky/actor/ActorService;Lio/github/kikin81/atproto/app/bsky/actor/GetSuggestionsRequest;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun putPreferences (Lio/github/kikin81/atproto/app/bsky/actor/PutPreferencesRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun searchActors (Lio/github/kikin81/atproto/app/bsky/actor/SearchActorsRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun searchActors$default (Lio/github/kikin81/atproto/app/bsky/actor/ActorService;Lio/github/kikin81/atproto/app/bsky/actor/SearchActorsRequest;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun searchActorsTypeahead (Lio/github/kikin81/atproto/app/bsky/actor/SearchActorsTypeaheadRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun searchActorsTypeahead$default (Lio/github/kikin81/atproto/app/bsky/actor/ActorService;Lio/github/kikin81/atproto/app/bsky/actor/SearchActorsTypeaheadRequest;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getPreferences (Lio/github/kikin81/atproto/app/bsky/actor/GetPreferencesRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getPreferences$default (Lio/github/kikin81/atproto/app/bsky/actor/ActorService;Lio/github/kikin81/atproto/app/bsky/actor/GetPreferencesRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getProfile (Lio/github/kikin81/atproto/app/bsky/actor/GetProfileRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getProfile$default (Lio/github/kikin81/atproto/app/bsky/actor/ActorService;Lio/github/kikin81/atproto/app/bsky/actor/GetProfileRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getProfiles (Lio/github/kikin81/atproto/app/bsky/actor/GetProfilesRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getProfiles$default (Lio/github/kikin81/atproto/app/bsky/actor/ActorService;Lio/github/kikin81/atproto/app/bsky/actor/GetProfilesRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getSuggestions (Lio/github/kikin81/atproto/app/bsky/actor/GetSuggestionsRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getSuggestions$default (Lio/github/kikin81/atproto/app/bsky/actor/ActorService;Lio/github/kikin81/atproto/app/bsky/actor/GetSuggestionsRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun putPreferences (Lio/github/kikin81/atproto/app/bsky/actor/PutPreferencesRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun putPreferences$default (Lio/github/kikin81/atproto/app/bsky/actor/ActorService;Lio/github/kikin81/atproto/app/bsky/actor/PutPreferencesRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun searchActors (Lio/github/kikin81/atproto/app/bsky/actor/SearchActorsRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun searchActors$default (Lio/github/kikin81/atproto/app/bsky/actor/ActorService;Lio/github/kikin81/atproto/app/bsky/actor/SearchActorsRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun searchActorsTypeahead (Lio/github/kikin81/atproto/app/bsky/actor/SearchActorsTypeaheadRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun searchActorsTypeahead$default (Lio/github/kikin81/atproto/app/bsky/actor/ActorService;Lio/github/kikin81/atproto/app/bsky/actor/SearchActorsTypeaheadRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class io/github/kikin81/atproto/app/bsky/actor/ActorServiceKt {
@@ -1791,10 +1794,12 @@ public final class io/github/kikin81/atproto/app/bsky/bookmark/Bookmark$Companio
 
 public final class io/github/kikin81/atproto/app/bsky/bookmark/BookmarkService {
 	public fun <init> (Lio/github/kikin81/atproto/runtime/XrpcClient;)V
-	public final fun createBookmark (Lio/github/kikin81/atproto/app/bsky/bookmark/CreateBookmarkRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun deleteBookmark (Lio/github/kikin81/atproto/app/bsky/bookmark/DeleteBookmarkRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getBookmarks (Lio/github/kikin81/atproto/app/bsky/bookmark/GetBookmarksRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun getBookmarks$default (Lio/github/kikin81/atproto/app/bsky/bookmark/BookmarkService;Lio/github/kikin81/atproto/app/bsky/bookmark/GetBookmarksRequest;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun createBookmark (Lio/github/kikin81/atproto/app/bsky/bookmark/CreateBookmarkRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun createBookmark$default (Lio/github/kikin81/atproto/app/bsky/bookmark/BookmarkService;Lio/github/kikin81/atproto/app/bsky/bookmark/CreateBookmarkRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun deleteBookmark (Lio/github/kikin81/atproto/app/bsky/bookmark/DeleteBookmarkRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun deleteBookmark$default (Lio/github/kikin81/atproto/app/bsky/bookmark/BookmarkService;Lio/github/kikin81/atproto/app/bsky/bookmark/DeleteBookmarkRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getBookmarks (Lio/github/kikin81/atproto/app/bsky/bookmark/GetBookmarksRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getBookmarks$default (Lio/github/kikin81/atproto/app/bsky/bookmark/BookmarkService;Lio/github/kikin81/atproto/app/bsky/bookmark/GetBookmarksRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class io/github/kikin81/atproto/app/bsky/bookmark/BookmarkServiceKt {
@@ -2542,11 +2547,14 @@ public final class io/github/kikin81/atproto/app/bsky/draft/DraftPostgateEmbeddi
 
 public final class io/github/kikin81/atproto/app/bsky/draft/DraftService {
 	public fun <init> (Lio/github/kikin81/atproto/runtime/XrpcClient;)V
-	public final fun createDraft (Lio/github/kikin81/atproto/app/bsky/draft/CreateDraftRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun deleteDraft (Lio/github/kikin81/atproto/app/bsky/draft/DeleteDraftRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getDrafts (Lio/github/kikin81/atproto/app/bsky/draft/GetDraftsRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun getDrafts$default (Lio/github/kikin81/atproto/app/bsky/draft/DraftService;Lio/github/kikin81/atproto/app/bsky/draft/GetDraftsRequest;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun updateDraft (Lio/github/kikin81/atproto/app/bsky/draft/UpdateDraftRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun createDraft (Lio/github/kikin81/atproto/app/bsky/draft/CreateDraftRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun createDraft$default (Lio/github/kikin81/atproto/app/bsky/draft/DraftService;Lio/github/kikin81/atproto/app/bsky/draft/CreateDraftRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun deleteDraft (Lio/github/kikin81/atproto/app/bsky/draft/DeleteDraftRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun deleteDraft$default (Lio/github/kikin81/atproto/app/bsky/draft/DraftService;Lio/github/kikin81/atproto/app/bsky/draft/DeleteDraftRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getDrafts (Lio/github/kikin81/atproto/app/bsky/draft/GetDraftsRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getDrafts$default (Lio/github/kikin81/atproto/app/bsky/draft/DraftService;Lio/github/kikin81/atproto/app/bsky/draft/GetDraftsRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun updateDraft (Lio/github/kikin81/atproto/app/bsky/draft/UpdateDraftRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun updateDraft$default (Lio/github/kikin81/atproto/app/bsky/draft/DraftService;Lio/github/kikin81/atproto/app/bsky/draft/UpdateDraftRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class io/github/kikin81/atproto/app/bsky/draft/DraftServiceKt {
@@ -3592,16 +3600,24 @@ public final class io/github/kikin81/atproto/app/bsky/feed/BlockedPost$Companion
 
 public final class io/github/kikin81/atproto/app/bsky/feed/FeedService {
 	public fun <init> (Lio/github/kikin81/atproto/runtime/XrpcClient;)V
-	public final fun getAuthorFeed (Lio/github/kikin81/atproto/app/bsky/feed/GetAuthorFeedRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getFeed (Lio/github/kikin81/atproto/app/bsky/feed/GetFeedRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getFeedGenerator (Lio/github/kikin81/atproto/app/bsky/feed/GetFeedGeneratorRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getLikes (Lio/github/kikin81/atproto/app/bsky/feed/GetLikesRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getPostThread (Lio/github/kikin81/atproto/app/bsky/feed/GetPostThreadRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getPosts (Lio/github/kikin81/atproto/app/bsky/feed/GetPostsRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getRepostedBy (Lio/github/kikin81/atproto/app/bsky/feed/GetRepostedByRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getTimeline (Lio/github/kikin81/atproto/app/bsky/feed/GetTimelineRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun getTimeline$default (Lio/github/kikin81/atproto/app/bsky/feed/FeedService;Lio/github/kikin81/atproto/app/bsky/feed/GetTimelineRequest;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun searchPosts (Lio/github/kikin81/atproto/app/bsky/feed/SearchPostsRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getAuthorFeed (Lio/github/kikin81/atproto/app/bsky/feed/GetAuthorFeedRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getAuthorFeed$default (Lio/github/kikin81/atproto/app/bsky/feed/FeedService;Lio/github/kikin81/atproto/app/bsky/feed/GetAuthorFeedRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getFeed (Lio/github/kikin81/atproto/app/bsky/feed/GetFeedRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getFeed$default (Lio/github/kikin81/atproto/app/bsky/feed/FeedService;Lio/github/kikin81/atproto/app/bsky/feed/GetFeedRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getFeedGenerator (Lio/github/kikin81/atproto/app/bsky/feed/GetFeedGeneratorRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getFeedGenerator$default (Lio/github/kikin81/atproto/app/bsky/feed/FeedService;Lio/github/kikin81/atproto/app/bsky/feed/GetFeedGeneratorRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getLikes (Lio/github/kikin81/atproto/app/bsky/feed/GetLikesRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getLikes$default (Lio/github/kikin81/atproto/app/bsky/feed/FeedService;Lio/github/kikin81/atproto/app/bsky/feed/GetLikesRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getPostThread (Lio/github/kikin81/atproto/app/bsky/feed/GetPostThreadRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getPostThread$default (Lio/github/kikin81/atproto/app/bsky/feed/FeedService;Lio/github/kikin81/atproto/app/bsky/feed/GetPostThreadRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getPosts (Lio/github/kikin81/atproto/app/bsky/feed/GetPostsRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getPosts$default (Lio/github/kikin81/atproto/app/bsky/feed/FeedService;Lio/github/kikin81/atproto/app/bsky/feed/GetPostsRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getRepostedBy (Lio/github/kikin81/atproto/app/bsky/feed/GetRepostedByRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getRepostedBy$default (Lio/github/kikin81/atproto/app/bsky/feed/FeedService;Lio/github/kikin81/atproto/app/bsky/feed/GetRepostedByRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getTimeline (Lio/github/kikin81/atproto/app/bsky/feed/GetTimelineRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getTimeline$default (Lio/github/kikin81/atproto/app/bsky/feed/FeedService;Lio/github/kikin81/atproto/app/bsky/feed/GetTimelineRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun searchPosts (Lio/github/kikin81/atproto/app/bsky/feed/SearchPostsRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun searchPosts$default (Lio/github/kikin81/atproto/app/bsky/feed/FeedService;Lio/github/kikin81/atproto/app/bsky/feed/SearchPostsRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class io/github/kikin81/atproto/app/bsky/feed/FeedServiceKt {
@@ -6853,33 +6869,52 @@ public final class io/github/kikin81/atproto/app/bsky/graph/GetSuggestedFollowsB
 
 public final class io/github/kikin81/atproto/app/bsky/graph/GraphService {
 	public fun <init> (Lio/github/kikin81/atproto/runtime/XrpcClient;)V
-	public final fun getActorStarterPacks (Lio/github/kikin81/atproto/app/bsky/graph/GetActorStarterPacksRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getBlocks (Lio/github/kikin81/atproto/app/bsky/graph/GetBlocksRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun getBlocks$default (Lio/github/kikin81/atproto/app/bsky/graph/GraphService;Lio/github/kikin81/atproto/app/bsky/graph/GetBlocksRequest;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun getFollowers (Lio/github/kikin81/atproto/app/bsky/graph/GetFollowersRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getFollows (Lio/github/kikin81/atproto/app/bsky/graph/GetFollowsRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getKnownFollowers (Lio/github/kikin81/atproto/app/bsky/graph/GetKnownFollowersRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getList (Lio/github/kikin81/atproto/app/bsky/graph/GetListRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getListBlocks (Lio/github/kikin81/atproto/app/bsky/graph/GetListBlocksRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun getListBlocks$default (Lio/github/kikin81/atproto/app/bsky/graph/GraphService;Lio/github/kikin81/atproto/app/bsky/graph/GetListBlocksRequest;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun getListMutes (Lio/github/kikin81/atproto/app/bsky/graph/GetListMutesRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun getListMutes$default (Lio/github/kikin81/atproto/app/bsky/graph/GraphService;Lio/github/kikin81/atproto/app/bsky/graph/GetListMutesRequest;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun getLists (Lio/github/kikin81/atproto/app/bsky/graph/GetListsRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getListsWithMembership (Lio/github/kikin81/atproto/app/bsky/graph/GetListsWithMembershipRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getMutes (Lio/github/kikin81/atproto/app/bsky/graph/GetMutesRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun getMutes$default (Lio/github/kikin81/atproto/app/bsky/graph/GraphService;Lio/github/kikin81/atproto/app/bsky/graph/GetMutesRequest;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun getRelationships (Lio/github/kikin81/atproto/app/bsky/graph/GetRelationshipsRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getStarterPack (Lio/github/kikin81/atproto/app/bsky/graph/GetStarterPackRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getStarterPacks (Lio/github/kikin81/atproto/app/bsky/graph/GetStarterPacksRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getStarterPacksWithMembership (Lio/github/kikin81/atproto/app/bsky/graph/GetStarterPacksWithMembershipRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getSuggestedFollowsByActor (Lio/github/kikin81/atproto/app/bsky/graph/GetSuggestedFollowsByActorRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun muteActor (Lio/github/kikin81/atproto/app/bsky/graph/MuteActorRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun muteActorList (Lio/github/kikin81/atproto/app/bsky/graph/MuteActorListRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun muteThread (Lio/github/kikin81/atproto/app/bsky/graph/MuteThreadRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun searchStarterPacks (Lio/github/kikin81/atproto/app/bsky/graph/SearchStarterPacksRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun unmuteActor (Lio/github/kikin81/atproto/app/bsky/graph/UnmuteActorRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun unmuteActorList (Lio/github/kikin81/atproto/app/bsky/graph/UnmuteActorListRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun unmuteThread (Lio/github/kikin81/atproto/app/bsky/graph/UnmuteThreadRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getActorStarterPacks (Lio/github/kikin81/atproto/app/bsky/graph/GetActorStarterPacksRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getActorStarterPacks$default (Lio/github/kikin81/atproto/app/bsky/graph/GraphService;Lio/github/kikin81/atproto/app/bsky/graph/GetActorStarterPacksRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getBlocks (Lio/github/kikin81/atproto/app/bsky/graph/GetBlocksRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getBlocks$default (Lio/github/kikin81/atproto/app/bsky/graph/GraphService;Lio/github/kikin81/atproto/app/bsky/graph/GetBlocksRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getFollowers (Lio/github/kikin81/atproto/app/bsky/graph/GetFollowersRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getFollowers$default (Lio/github/kikin81/atproto/app/bsky/graph/GraphService;Lio/github/kikin81/atproto/app/bsky/graph/GetFollowersRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getFollows (Lio/github/kikin81/atproto/app/bsky/graph/GetFollowsRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getFollows$default (Lio/github/kikin81/atproto/app/bsky/graph/GraphService;Lio/github/kikin81/atproto/app/bsky/graph/GetFollowsRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getKnownFollowers (Lio/github/kikin81/atproto/app/bsky/graph/GetKnownFollowersRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getKnownFollowers$default (Lio/github/kikin81/atproto/app/bsky/graph/GraphService;Lio/github/kikin81/atproto/app/bsky/graph/GetKnownFollowersRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getList (Lio/github/kikin81/atproto/app/bsky/graph/GetListRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getList$default (Lio/github/kikin81/atproto/app/bsky/graph/GraphService;Lio/github/kikin81/atproto/app/bsky/graph/GetListRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getListBlocks (Lio/github/kikin81/atproto/app/bsky/graph/GetListBlocksRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getListBlocks$default (Lio/github/kikin81/atproto/app/bsky/graph/GraphService;Lio/github/kikin81/atproto/app/bsky/graph/GetListBlocksRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getListMutes (Lio/github/kikin81/atproto/app/bsky/graph/GetListMutesRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getListMutes$default (Lio/github/kikin81/atproto/app/bsky/graph/GraphService;Lio/github/kikin81/atproto/app/bsky/graph/GetListMutesRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getLists (Lio/github/kikin81/atproto/app/bsky/graph/GetListsRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getLists$default (Lio/github/kikin81/atproto/app/bsky/graph/GraphService;Lio/github/kikin81/atproto/app/bsky/graph/GetListsRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getListsWithMembership (Lio/github/kikin81/atproto/app/bsky/graph/GetListsWithMembershipRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getListsWithMembership$default (Lio/github/kikin81/atproto/app/bsky/graph/GraphService;Lio/github/kikin81/atproto/app/bsky/graph/GetListsWithMembershipRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getMutes (Lio/github/kikin81/atproto/app/bsky/graph/GetMutesRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getMutes$default (Lio/github/kikin81/atproto/app/bsky/graph/GraphService;Lio/github/kikin81/atproto/app/bsky/graph/GetMutesRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getRelationships (Lio/github/kikin81/atproto/app/bsky/graph/GetRelationshipsRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getRelationships$default (Lio/github/kikin81/atproto/app/bsky/graph/GraphService;Lio/github/kikin81/atproto/app/bsky/graph/GetRelationshipsRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getStarterPack (Lio/github/kikin81/atproto/app/bsky/graph/GetStarterPackRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getStarterPack$default (Lio/github/kikin81/atproto/app/bsky/graph/GraphService;Lio/github/kikin81/atproto/app/bsky/graph/GetStarterPackRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getStarterPacks (Lio/github/kikin81/atproto/app/bsky/graph/GetStarterPacksRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getStarterPacks$default (Lio/github/kikin81/atproto/app/bsky/graph/GraphService;Lio/github/kikin81/atproto/app/bsky/graph/GetStarterPacksRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getStarterPacksWithMembership (Lio/github/kikin81/atproto/app/bsky/graph/GetStarterPacksWithMembershipRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getStarterPacksWithMembership$default (Lio/github/kikin81/atproto/app/bsky/graph/GraphService;Lio/github/kikin81/atproto/app/bsky/graph/GetStarterPacksWithMembershipRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getSuggestedFollowsByActor (Lio/github/kikin81/atproto/app/bsky/graph/GetSuggestedFollowsByActorRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getSuggestedFollowsByActor$default (Lio/github/kikin81/atproto/app/bsky/graph/GraphService;Lio/github/kikin81/atproto/app/bsky/graph/GetSuggestedFollowsByActorRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun muteActor (Lio/github/kikin81/atproto/app/bsky/graph/MuteActorRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun muteActor$default (Lio/github/kikin81/atproto/app/bsky/graph/GraphService;Lio/github/kikin81/atproto/app/bsky/graph/MuteActorRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun muteActorList (Lio/github/kikin81/atproto/app/bsky/graph/MuteActorListRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun muteActorList$default (Lio/github/kikin81/atproto/app/bsky/graph/GraphService;Lio/github/kikin81/atproto/app/bsky/graph/MuteActorListRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun muteThread (Lio/github/kikin81/atproto/app/bsky/graph/MuteThreadRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun muteThread$default (Lio/github/kikin81/atproto/app/bsky/graph/GraphService;Lio/github/kikin81/atproto/app/bsky/graph/MuteThreadRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun searchStarterPacks (Lio/github/kikin81/atproto/app/bsky/graph/SearchStarterPacksRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun searchStarterPacks$default (Lio/github/kikin81/atproto/app/bsky/graph/GraphService;Lio/github/kikin81/atproto/app/bsky/graph/SearchStarterPacksRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun unmuteActor (Lio/github/kikin81/atproto/app/bsky/graph/UnmuteActorRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun unmuteActor$default (Lio/github/kikin81/atproto/app/bsky/graph/GraphService;Lio/github/kikin81/atproto/app/bsky/graph/UnmuteActorRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun unmuteActorList (Lio/github/kikin81/atproto/app/bsky/graph/UnmuteActorListRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun unmuteActorList$default (Lio/github/kikin81/atproto/app/bsky/graph/GraphService;Lio/github/kikin81/atproto/app/bsky/graph/UnmuteActorListRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun unmuteThread (Lio/github/kikin81/atproto/app/bsky/graph/UnmuteThreadRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun unmuteThread$default (Lio/github/kikin81/atproto/app/bsky/graph/GraphService;Lio/github/kikin81/atproto/app/bsky/graph/UnmuteThreadRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class io/github/kikin81/atproto/app/bsky/graph/GraphServiceKt {
@@ -7854,7 +7889,8 @@ public final class io/github/kikin81/atproto/app/bsky/labeler/LabelerPoliciesInp
 
 public final class io/github/kikin81/atproto/app/bsky/labeler/LabelerService {
 	public fun <init> (Lio/github/kikin81/atproto/runtime/XrpcClient;)V
-	public final fun getServices (Lio/github/kikin81/atproto/app/bsky/labeler/GetServicesRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getServices (Lio/github/kikin81/atproto/app/bsky/labeler/GetServicesRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getServices$default (Lio/github/kikin81/atproto/app/bsky/labeler/LabelerService;Lio/github/kikin81/atproto/app/bsky/labeler/GetServicesRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class io/github/kikin81/atproto/app/bsky/labeler/LabelerView : io/github/kikin81/atproto/app/bsky/embed/RecordViewRecordUnion, io/github/kikin81/atproto/app/bsky/labeler/GetServicesResponseViewsUnion {
@@ -8448,21 +8484,26 @@ public final class io/github/kikin81/atproto/app/bsky/notification/ListNotificat
 
 public final class io/github/kikin81/atproto/app/bsky/notification/NotificationService {
 	public fun <init> (Lio/github/kikin81/atproto/runtime/XrpcClient;)V
-	public final fun getPreferences (Lio/github/kikin81/atproto/app/bsky/notification/GetPreferencesRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun getPreferences$default (Lio/github/kikin81/atproto/app/bsky/notification/NotificationService;Lio/github/kikin81/atproto/app/bsky/notification/GetPreferencesRequest;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun getUnreadCount (Lio/github/kikin81/atproto/app/bsky/notification/GetUnreadCountRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun getUnreadCount$default (Lio/github/kikin81/atproto/app/bsky/notification/NotificationService;Lio/github/kikin81/atproto/app/bsky/notification/GetUnreadCountRequest;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun listActivitySubscriptions (Lio/github/kikin81/atproto/app/bsky/notification/ListActivitySubscriptionsRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun listActivitySubscriptions$default (Lio/github/kikin81/atproto/app/bsky/notification/NotificationService;Lio/github/kikin81/atproto/app/bsky/notification/ListActivitySubscriptionsRequest;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun listNotifications (Lio/github/kikin81/atproto/app/bsky/notification/ListNotificationsRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun listNotifications$default (Lio/github/kikin81/atproto/app/bsky/notification/NotificationService;Lio/github/kikin81/atproto/app/bsky/notification/ListNotificationsRequest;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun putActivitySubscription (Lio/github/kikin81/atproto/app/bsky/notification/PutActivitySubscriptionRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun putPreferences (Lio/github/kikin81/atproto/app/bsky/notification/PutPreferencesRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun putPreferencesV2 (Lio/github/kikin81/atproto/app/bsky/notification/PutPreferencesV2Request;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun putPreferencesV2$default (Lio/github/kikin81/atproto/app/bsky/notification/NotificationService;Lio/github/kikin81/atproto/app/bsky/notification/PutPreferencesV2Request;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun registerPush (Lio/github/kikin81/atproto/app/bsky/notification/RegisterPushRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun unregisterPush (Lio/github/kikin81/atproto/app/bsky/notification/UnregisterPushRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun updateSeen (Lio/github/kikin81/atproto/app/bsky/notification/UpdateSeenRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getPreferences (Lio/github/kikin81/atproto/app/bsky/notification/GetPreferencesRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getPreferences$default (Lio/github/kikin81/atproto/app/bsky/notification/NotificationService;Lio/github/kikin81/atproto/app/bsky/notification/GetPreferencesRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getUnreadCount (Lio/github/kikin81/atproto/app/bsky/notification/GetUnreadCountRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getUnreadCount$default (Lio/github/kikin81/atproto/app/bsky/notification/NotificationService;Lio/github/kikin81/atproto/app/bsky/notification/GetUnreadCountRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun listActivitySubscriptions (Lio/github/kikin81/atproto/app/bsky/notification/ListActivitySubscriptionsRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun listActivitySubscriptions$default (Lio/github/kikin81/atproto/app/bsky/notification/NotificationService;Lio/github/kikin81/atproto/app/bsky/notification/ListActivitySubscriptionsRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun listNotifications (Lio/github/kikin81/atproto/app/bsky/notification/ListNotificationsRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun listNotifications$default (Lio/github/kikin81/atproto/app/bsky/notification/NotificationService;Lio/github/kikin81/atproto/app/bsky/notification/ListNotificationsRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun putActivitySubscription (Lio/github/kikin81/atproto/app/bsky/notification/PutActivitySubscriptionRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun putActivitySubscription$default (Lio/github/kikin81/atproto/app/bsky/notification/NotificationService;Lio/github/kikin81/atproto/app/bsky/notification/PutActivitySubscriptionRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun putPreferences (Lio/github/kikin81/atproto/app/bsky/notification/PutPreferencesRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun putPreferences$default (Lio/github/kikin81/atproto/app/bsky/notification/NotificationService;Lio/github/kikin81/atproto/app/bsky/notification/PutPreferencesRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun putPreferencesV2 (Lio/github/kikin81/atproto/app/bsky/notification/PutPreferencesV2Request;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun putPreferencesV2$default (Lio/github/kikin81/atproto/app/bsky/notification/NotificationService;Lio/github/kikin81/atproto/app/bsky/notification/PutPreferencesV2Request;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun registerPush (Lio/github/kikin81/atproto/app/bsky/notification/RegisterPushRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun registerPush$default (Lio/github/kikin81/atproto/app/bsky/notification/NotificationService;Lio/github/kikin81/atproto/app/bsky/notification/RegisterPushRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun unregisterPush (Lio/github/kikin81/atproto/app/bsky/notification/UnregisterPushRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun unregisterPush$default (Lio/github/kikin81/atproto/app/bsky/notification/NotificationService;Lio/github/kikin81/atproto/app/bsky/notification/UnregisterPushRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun updateSeen (Lio/github/kikin81/atproto/app/bsky/notification/UpdateSeenRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun updateSeen$default (Lio/github/kikin81/atproto/app/bsky/notification/NotificationService;Lio/github/kikin81/atproto/app/bsky/notification/UpdateSeenRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class io/github/kikin81/atproto/app/bsky/notification/NotificationServiceKt {
@@ -9331,30 +9372,46 @@ public final class io/github/kikin81/atproto/chat/bsky/convo/AddReactionResponse
 public final class io/github/kikin81/atproto/chat/bsky/convo/ConvoService {
 	public fun <init> (Lio/github/kikin81/atproto/runtime/XrpcClient;Ljava/lang/String;)V
 	public synthetic fun <init> (Lio/github/kikin81/atproto/runtime/XrpcClient;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun acceptConvo (Lio/github/kikin81/atproto/chat/bsky/convo/AcceptConvoRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun addReaction (Lio/github/kikin81/atproto/chat/bsky/convo/AddReactionRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun deleteMessageForSelf (Lio/github/kikin81/atproto/chat/bsky/convo/DeleteMessageForSelfRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getConvo (Lio/github/kikin81/atproto/chat/bsky/convo/GetConvoRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getConvoAvailability (Lio/github/kikin81/atproto/chat/bsky/convo/GetConvoAvailabilityRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getConvoForMembers (Lio/github/kikin81/atproto/chat/bsky/convo/GetConvoForMembersRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getLog (Lio/github/kikin81/atproto/chat/bsky/convo/GetLogRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun getLog$default (Lio/github/kikin81/atproto/chat/bsky/convo/ConvoService;Lio/github/kikin81/atproto/chat/bsky/convo/GetLogRequest;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun getMessages (Lio/github/kikin81/atproto/chat/bsky/convo/GetMessagesRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun leaveConvo (Lio/github/kikin81/atproto/chat/bsky/convo/LeaveConvoRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun listConvoRequests (Lio/github/kikin81/atproto/chat/bsky/convo/ListConvoRequestsRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun listConvoRequests$default (Lio/github/kikin81/atproto/chat/bsky/convo/ConvoService;Lio/github/kikin81/atproto/chat/bsky/convo/ListConvoRequestsRequest;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun listConvos (Lio/github/kikin81/atproto/chat/bsky/convo/ListConvosRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun listConvos$default (Lio/github/kikin81/atproto/chat/bsky/convo/ConvoService;Lio/github/kikin81/atproto/chat/bsky/convo/ListConvosRequest;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun lockConvo (Lio/github/kikin81/atproto/chat/bsky/convo/LockConvoRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun muteConvo (Lio/github/kikin81/atproto/chat/bsky/convo/MuteConvoRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun removeReaction (Lio/github/kikin81/atproto/chat/bsky/convo/RemoveReactionRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun sendMessage (Lio/github/kikin81/atproto/chat/bsky/convo/SendMessageRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun sendMessageBatch (Lio/github/kikin81/atproto/chat/bsky/convo/SendMessageBatchRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun unlockConvo (Lio/github/kikin81/atproto/chat/bsky/convo/UnlockConvoRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun unmuteConvo (Lio/github/kikin81/atproto/chat/bsky/convo/UnmuteConvoRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun updateAllRead (Lio/github/kikin81/atproto/chat/bsky/convo/UpdateAllReadRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun updateAllRead$default (Lio/github/kikin81/atproto/chat/bsky/convo/ConvoService;Lio/github/kikin81/atproto/chat/bsky/convo/UpdateAllReadRequest;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun updateRead (Lio/github/kikin81/atproto/chat/bsky/convo/UpdateReadRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun acceptConvo (Lio/github/kikin81/atproto/chat/bsky/convo/AcceptConvoRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun acceptConvo$default (Lio/github/kikin81/atproto/chat/bsky/convo/ConvoService;Lio/github/kikin81/atproto/chat/bsky/convo/AcceptConvoRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun addReaction (Lio/github/kikin81/atproto/chat/bsky/convo/AddReactionRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun addReaction$default (Lio/github/kikin81/atproto/chat/bsky/convo/ConvoService;Lio/github/kikin81/atproto/chat/bsky/convo/AddReactionRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun deleteMessageForSelf (Lio/github/kikin81/atproto/chat/bsky/convo/DeleteMessageForSelfRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun deleteMessageForSelf$default (Lio/github/kikin81/atproto/chat/bsky/convo/ConvoService;Lio/github/kikin81/atproto/chat/bsky/convo/DeleteMessageForSelfRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getConvo (Lio/github/kikin81/atproto/chat/bsky/convo/GetConvoRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getConvo$default (Lio/github/kikin81/atproto/chat/bsky/convo/ConvoService;Lio/github/kikin81/atproto/chat/bsky/convo/GetConvoRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getConvoAvailability (Lio/github/kikin81/atproto/chat/bsky/convo/GetConvoAvailabilityRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getConvoAvailability$default (Lio/github/kikin81/atproto/chat/bsky/convo/ConvoService;Lio/github/kikin81/atproto/chat/bsky/convo/GetConvoAvailabilityRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getConvoForMembers (Lio/github/kikin81/atproto/chat/bsky/convo/GetConvoForMembersRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getConvoForMembers$default (Lio/github/kikin81/atproto/chat/bsky/convo/ConvoService;Lio/github/kikin81/atproto/chat/bsky/convo/GetConvoForMembersRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getLog (Lio/github/kikin81/atproto/chat/bsky/convo/GetLogRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getLog$default (Lio/github/kikin81/atproto/chat/bsky/convo/ConvoService;Lio/github/kikin81/atproto/chat/bsky/convo/GetLogRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getMessages (Lio/github/kikin81/atproto/chat/bsky/convo/GetMessagesRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getMessages$default (Lio/github/kikin81/atproto/chat/bsky/convo/ConvoService;Lio/github/kikin81/atproto/chat/bsky/convo/GetMessagesRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun leaveConvo (Lio/github/kikin81/atproto/chat/bsky/convo/LeaveConvoRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun leaveConvo$default (Lio/github/kikin81/atproto/chat/bsky/convo/ConvoService;Lio/github/kikin81/atproto/chat/bsky/convo/LeaveConvoRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun listConvoRequests (Lio/github/kikin81/atproto/chat/bsky/convo/ListConvoRequestsRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun listConvoRequests$default (Lio/github/kikin81/atproto/chat/bsky/convo/ConvoService;Lio/github/kikin81/atproto/chat/bsky/convo/ListConvoRequestsRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun listConvos (Lio/github/kikin81/atproto/chat/bsky/convo/ListConvosRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun listConvos$default (Lio/github/kikin81/atproto/chat/bsky/convo/ConvoService;Lio/github/kikin81/atproto/chat/bsky/convo/ListConvosRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun lockConvo (Lio/github/kikin81/atproto/chat/bsky/convo/LockConvoRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun lockConvo$default (Lio/github/kikin81/atproto/chat/bsky/convo/ConvoService;Lio/github/kikin81/atproto/chat/bsky/convo/LockConvoRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun muteConvo (Lio/github/kikin81/atproto/chat/bsky/convo/MuteConvoRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun muteConvo$default (Lio/github/kikin81/atproto/chat/bsky/convo/ConvoService;Lio/github/kikin81/atproto/chat/bsky/convo/MuteConvoRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun removeReaction (Lio/github/kikin81/atproto/chat/bsky/convo/RemoveReactionRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun removeReaction$default (Lio/github/kikin81/atproto/chat/bsky/convo/ConvoService;Lio/github/kikin81/atproto/chat/bsky/convo/RemoveReactionRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun sendMessage (Lio/github/kikin81/atproto/chat/bsky/convo/SendMessageRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun sendMessage$default (Lio/github/kikin81/atproto/chat/bsky/convo/ConvoService;Lio/github/kikin81/atproto/chat/bsky/convo/SendMessageRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun sendMessageBatch (Lio/github/kikin81/atproto/chat/bsky/convo/SendMessageBatchRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun sendMessageBatch$default (Lio/github/kikin81/atproto/chat/bsky/convo/ConvoService;Lio/github/kikin81/atproto/chat/bsky/convo/SendMessageBatchRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun unlockConvo (Lio/github/kikin81/atproto/chat/bsky/convo/UnlockConvoRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun unlockConvo$default (Lio/github/kikin81/atproto/chat/bsky/convo/ConvoService;Lio/github/kikin81/atproto/chat/bsky/convo/UnlockConvoRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun unmuteConvo (Lio/github/kikin81/atproto/chat/bsky/convo/UnmuteConvoRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun unmuteConvo$default (Lio/github/kikin81/atproto/chat/bsky/convo/ConvoService;Lio/github/kikin81/atproto/chat/bsky/convo/UnmuteConvoRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun updateAllRead (Lio/github/kikin81/atproto/chat/bsky/convo/UpdateAllReadRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun updateAllRead$default (Lio/github/kikin81/atproto/chat/bsky/convo/ConvoService;Lio/github/kikin81/atproto/chat/bsky/convo/UpdateAllReadRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun updateRead (Lio/github/kikin81/atproto/chat/bsky/convo/UpdateReadRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun updateRead$default (Lio/github/kikin81/atproto/chat/bsky/convo/ConvoService;Lio/github/kikin81/atproto/chat/bsky/convo/UpdateReadRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class io/github/kikin81/atproto/chat/bsky/convo/ConvoServiceKt {
@@ -12762,8 +12819,10 @@ public final class io/github/kikin81/atproto/com/atproto/admin/ThreatSignature$C
 
 public final class io/github/kikin81/atproto/com/atproto/identity/IdentityService {
 	public fun <init> (Lio/github/kikin81/atproto/runtime/XrpcClient;)V
-	public final fun resolveHandle (Lio/github/kikin81/atproto/com/atproto/identity/ResolveHandleRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun updateHandle (Lio/github/kikin81/atproto/com/atproto/identity/UpdateHandleRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun resolveHandle (Lio/github/kikin81/atproto/com/atproto/identity/ResolveHandleRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun resolveHandle$default (Lio/github/kikin81/atproto/com/atproto/identity/IdentityService;Lio/github/kikin81/atproto/com/atproto/identity/ResolveHandleRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun updateHandle (Lio/github/kikin81/atproto/com/atproto/identity/UpdateHandleRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun updateHandle$default (Lio/github/kikin81/atproto/com/atproto/identity/IdentityService;Lio/github/kikin81/atproto/com/atproto/identity/UpdateHandleRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class io/github/kikin81/atproto/com/atproto/identity/ResolveHandleRequest {
@@ -12893,7 +12952,8 @@ public final class io/github/kikin81/atproto/com/atproto/label/Label$Companion {
 
 public final class io/github/kikin81/atproto/com/atproto/label/LabelService {
 	public fun <init> (Lio/github/kikin81/atproto/runtime/XrpcClient;)V
-	public final fun queryLabels (Lio/github/kikin81/atproto/com/atproto/label/QueryLabelsRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun queryLabels (Lio/github/kikin81/atproto/com/atproto/label/QueryLabelsRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun queryLabels$default (Lio/github/kikin81/atproto/com/atproto/label/LabelService;Lio/github/kikin81/atproto/com/atproto/label/QueryLabelsRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class io/github/kikin81/atproto/com/atproto/label/LabelServiceKt {
@@ -13310,7 +13370,8 @@ public final class io/github/kikin81/atproto/com/atproto/moderation/CreateReport
 
 public final class io/github/kikin81/atproto/com/atproto/moderation/ModerationService {
 	public fun <init> (Lio/github/kikin81/atproto/runtime/XrpcClient;)V
-	public final fun createReport (Lio/github/kikin81/atproto/com/atproto/moderation/CreateReportRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun createReport (Lio/github/kikin81/atproto/com/atproto/moderation/CreateReportRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun createReport$default (Lio/github/kikin81/atproto/com/atproto/moderation/ModerationService;Lio/github/kikin81/atproto/com/atproto/moderation/CreateReportRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class io/github/kikin81/atproto/com/atproto/repo/ApplyWritesCreate : io/github/kikin81/atproto/com/atproto/repo/ApplyWritesRequestWritesUnion {
@@ -14101,14 +14162,22 @@ public final class io/github/kikin81/atproto/com/atproto/repo/PutRecordResponse$
 
 public final class io/github/kikin81/atproto/com/atproto/repo/RepoService {
 	public fun <init> (Lio/github/kikin81/atproto/runtime/XrpcClient;)V
-	public final fun applyWrites (Lio/github/kikin81/atproto/com/atproto/repo/ApplyWritesRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun createRecord (Lio/github/kikin81/atproto/com/atproto/repo/CreateRecordRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun deleteRecord (Lio/github/kikin81/atproto/com/atproto/repo/DeleteRecordRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun describeRepo (Lio/github/kikin81/atproto/com/atproto/repo/DescribeRepoRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getRecord (Lio/github/kikin81/atproto/com/atproto/repo/GetRecordRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun listRecords (Lio/github/kikin81/atproto/com/atproto/repo/ListRecordsRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun putRecord (Lio/github/kikin81/atproto/com/atproto/repo/PutRecordRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun uploadBlob ([BLio/ktor/http/ContentType;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun applyWrites (Lio/github/kikin81/atproto/com/atproto/repo/ApplyWritesRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun applyWrites$default (Lio/github/kikin81/atproto/com/atproto/repo/RepoService;Lio/github/kikin81/atproto/com/atproto/repo/ApplyWritesRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun createRecord (Lio/github/kikin81/atproto/com/atproto/repo/CreateRecordRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun createRecord$default (Lio/github/kikin81/atproto/com/atproto/repo/RepoService;Lio/github/kikin81/atproto/com/atproto/repo/CreateRecordRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun deleteRecord (Lio/github/kikin81/atproto/com/atproto/repo/DeleteRecordRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun deleteRecord$default (Lio/github/kikin81/atproto/com/atproto/repo/RepoService;Lio/github/kikin81/atproto/com/atproto/repo/DeleteRecordRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun describeRepo (Lio/github/kikin81/atproto/com/atproto/repo/DescribeRepoRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun describeRepo$default (Lio/github/kikin81/atproto/com/atproto/repo/RepoService;Lio/github/kikin81/atproto/com/atproto/repo/DescribeRepoRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getRecord (Lio/github/kikin81/atproto/com/atproto/repo/GetRecordRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getRecord$default (Lio/github/kikin81/atproto/com/atproto/repo/RepoService;Lio/github/kikin81/atproto/com/atproto/repo/GetRecordRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun listRecords (Lio/github/kikin81/atproto/com/atproto/repo/ListRecordsRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun listRecords$default (Lio/github/kikin81/atproto/com/atproto/repo/RepoService;Lio/github/kikin81/atproto/com/atproto/repo/ListRecordsRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun putRecord (Lio/github/kikin81/atproto/com/atproto/repo/PutRecordRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun putRecord$default (Lio/github/kikin81/atproto/com/atproto/repo/RepoService;Lio/github/kikin81/atproto/com/atproto/repo/PutRecordRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun uploadBlob ([BLio/ktor/http/ContentType;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun uploadBlob$default (Lio/github/kikin81/atproto/com/atproto/repo/RepoService;[BLio/ktor/http/ContentType;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class io/github/kikin81/atproto/com/atproto/repo/RepoServiceKt {
@@ -14587,11 +14656,16 @@ public final class io/github/kikin81/atproto/com/atproto/server/RefreshSessionRe
 
 public final class io/github/kikin81/atproto/com/atproto/server/ServerService {
 	public fun <init> (Lio/github/kikin81/atproto/runtime/XrpcClient;)V
-	public final fun createAccount (Lio/github/kikin81/atproto/com/atproto/server/CreateAccountRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun createSession (Lio/github/kikin81/atproto/com/atproto/server/CreateSessionRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun describeServer (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getSession (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun refreshSession (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun createAccount (Lio/github/kikin81/atproto/com/atproto/server/CreateAccountRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun createAccount$default (Lio/github/kikin81/atproto/com/atproto/server/ServerService;Lio/github/kikin81/atproto/com/atproto/server/CreateAccountRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun createSession (Lio/github/kikin81/atproto/com/atproto/server/CreateSessionRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun createSession$default (Lio/github/kikin81/atproto/com/atproto/server/ServerService;Lio/github/kikin81/atproto/com/atproto/server/CreateSessionRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun describeServer (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun describeServer$default (Lio/github/kikin81/atproto/com/atproto/server/ServerService;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getSession (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getSession$default (Lio/github/kikin81/atproto/com/atproto/server/ServerService;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun refreshSession (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun refreshSession$default (Lio/github/kikin81/atproto/com/atproto/server/ServerService;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class io/github/kikin81/atproto/com/atproto/sync/GetLatestCommitRequest {
@@ -14682,7 +14756,9 @@ public final class io/github/kikin81/atproto/com/atproto/sync/GetRepoRequest$Com
 
 public final class io/github/kikin81/atproto/com/atproto/sync/SyncService {
 	public fun <init> (Lio/github/kikin81/atproto/runtime/XrpcClient;)V
-	public final fun getLatestCommit (Lio/github/kikin81/atproto/com/atproto/sync/GetLatestCommitRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getRepo (Lio/github/kikin81/atproto/com/atproto/sync/GetRepoRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getLatestCommit (Lio/github/kikin81/atproto/com/atproto/sync/GetLatestCommitRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getLatestCommit$default (Lio/github/kikin81/atproto/com/atproto/sync/SyncService;Lio/github/kikin81/atproto/com/atproto/sync/GetLatestCommitRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getRepo (Lio/github/kikin81/atproto/com/atproto/sync/GetRepoRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getRepo$default (Lio/github/kikin81/atproto/com/atproto/sync/SyncService;Lio/github/kikin81/atproto/com/atproto/sync/GetRepoRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 

--- a/openspec/changes/add-per-method-proxy-override/.openspec.yaml
+++ b/openspec/changes/add-per-method-proxy-override/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-25

--- a/openspec/changes/add-per-method-proxy-override/design.md
+++ b/openspec/changes/add-per-method-proxy-override/design.md
@@ -48,7 +48,7 @@ For services without a constructor `proxy`, the expression collapses to just `pr
 
 ### Decision 3: Cut v9.0.0; no compatibility shim
 
-Adding any parameter to a public API tracked by `kotlinx-binary-compatibility-validator` is binary-breaking even with a default value — captured in bd memory `adding-any-parameter-to-a-public-api-xrpcclient`, learned from prior breaking releases. The validator runs as `:models:apiCheck` in CI; the only way to satisfy it is to refresh `models/api/models.api` and accept the major bump.
+Adding any parameter to a public API tracked by `kotlinx-binary-compatibility-validator` is binary-breaking even with a default value. The validator runs as `:models:apiCheck` in CI (gating every release) and refuses to pass against the previous `models/api/models.api` dump once any signature shifts. The only way to satisfy it is to refresh the dump and accept the major bump. Prior breaking releases — see `docs/breaking-changes/v5.md`, `v6.md`, `v7.md`, `v8.md` — followed the same pattern.
 
 There is no source-level break: existing call sites like `notificationService.registerPush(request)` compile unchanged. Only Kotlin consumers who recompile against v9 see new behavior available (the parameter); Java consumers shouldn't exist (this is a KMP library, but `:models` publishes a JVM artifact too — the new parameter is still source-compatible from Java via the default-value bridge KotlinPoet emits).
 
@@ -59,7 +59,7 @@ Alternatives rejected:
 
 ### Decision 4: Test surface — full plan→emit, not isolated unit
 
-The existing `ServiceGeneratorResolveProxyTest` tests the pure function `resolveProxyForPackage` in isolation — it's not appropriate for asserting emitted Kotlin syntax. The new test runs a small synthetic lexicon corpus (one `chat.bsky.*` NSID, one `app.bsky.*` NSID, both with at least one query and one procedure) through `LexiconParser → RefResolver → ContextTagger → NamingMatrix → VerificationPass → EmissionPlan → ServiceGenerator`, then asserts against the emitted `TypeSpec`:
+The existing `ServiceGeneratorResolveProxyTest` tests the pure function `resolveProxyForPackage` in isolation — it's not appropriate for asserting emitted Kotlin syntax. The new test runs a small synthetic lexicon corpus (one `chat.bsky.*` NSID, one `app.bsky.*` NSID, both with at least one query and one procedure) through the same stages that `CodeGenerator` invokes for service emission — `LexiconParser → SymbolTable.build → RefResolver.validate → ContextTagger → EmissionPlan.build → ServiceGenerator.emitAll` — and asserts against the emitted `TypeSpec`. (`VerificationPass`, which `CodeGenerator` runs after `ServiceGenerator.emitAll` to catch naming collisions across the full corpus, is intentionally omitted: the synthetic corpus is too small to trip a collision, and the test's invariants are about per-method parameter and body shape, not naming.):
 
 - Every `FunSpec` in the service `TypeSpec` ends with a `ParameterSpec` named `proxy` of type `String?` with default `null`.
 - The method body `CodeBlock` for the proxied service contains `proxy = proxy ?: this.proxy`; the unproxied service contains `proxy = proxy`.

--- a/openspec/changes/add-per-method-proxy-override/design.md
+++ b/openspec/changes/add-per-method-proxy-override/design.md
@@ -1,0 +1,101 @@
+## Context
+
+`ServiceGenerator` emits one Kotlin `*Service` class per emission package, grouping every `QueryDef` / `ProcedureDef` whose Request/Response classes land in that package. For service packages whose NSIDs hit a `ProxyMapping` entry (today: only `chat.bsky.*` → `did:web:api.bsky.chat#bsky_chat`), the generator emits a constructor parameter `proxy: String? = "<hardcoded-did>"` and forwards `proxy = proxy` on every call. For all other packages, no proxy is emitted and the generated body calls `client.{query, procedure}(...)` without a `proxy` argument (`XrpcClient` defaults it to `null`, so no `atproto-proxy` header is sent).
+
+`XrpcClient.{query, procedure}` already accept `proxy: String? = null` on every overload, including the raw-bytes overload added in the [raw-bytes-procedures change](../archive/2026-05-04-raw-bytes-procedures/proposal.md). The wire-level plumbing exists end-to-end; only the generator wrapper hides it.
+
+The blocked use case: `app.bsky.notification.{registerPush, unregisterPush}` per the wire contract requires `atproto-proxy: <gateway-did>#bsky_notif`. The gateway DID is operator-chosen — Bluesky's official client uses `did:web:api.bsky.app#bsky_notif`, self-hosted operators use whatever they've stood up (e.g. `did:web:push.nubecita.app#bsky_notif` for the `nubecita` consumer running [DracoBlue/atproto-push-gateway](https://github.com/DracoBlue/atproto-push-gateway)). `ProxyMapping` cannot legitimately hardcode a gateway choice that varies per consumer.
+
+The current bypass: `nubecita` PR [#301](https://github.com/kikin81/nubecita/pull/301) calls `XrpcClient.procedure(...)` directly, duplicating the NSID string, both serializer references, and the response-serializer wiring. The bypass works but loses the entire reason the generated wrapper exists.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Every generated `*Service.<method>(...)` accepts an optional per-call `proxy: String? = null` override.
+- For services with a constructor-level `proxy` (today: `ConvoService`), the override falls back to the constructor default when null — existing call sites compile unchanged with identical wire behavior.
+- For services without a constructor-level `proxy` (everyone else), the override is the only way to send an `atproto-proxy` header. When null, the call is wire-identical to today.
+- The change is mechanical and applies uniformly: no per-NSID allowlist, no opt-in.
+- Cut a clean v9.0.0 with a `docs/breaking-changes/v9.md` page and a refreshed `models/api/models.api`.
+
+**Non-Goals:**
+- Adding a `NoBodyResponseSerializer` runtime marker (mentioned as "out of scope" on issue #117 — friendlier than `UnitResponseSerializer` for procedures with no `output.schema`). File separately if motivated.
+- Reading proxy hints from lexicon JSON metadata (no upstream lexicon carries routing metadata today; `ProxyMapping` stays the source of truth for constructor-level defaults).
+- Adding chat-gateway override support to `ConvoService` consumers. The per-method `proxy` parameter gives them this for free, but the docs and breaking-changes page don't actively promote it — `chat.bsky.*` consumers should keep using the constructor default.
+- Touching `XrpcClient` or any other `:runtime` surface. The runtime already supports `proxy` per-call.
+- Touching `ProxyMapping`, `resolveProxyForPackage`, or constructor-property emission. The constructor-level proxy stays exactly as today.
+
+## Decisions
+
+### Decision 1: Per-method parameter on every method, not just proxied services
+
+Emit `proxy: String? = null` on **every** generated query/procedure method, regardless of whether the service has a `ProxyMapping` hit. The alternative — emit the parameter only on services without a constructor proxy, or only on the specific NSIDs that "need" it — would require either (a) a per-NSID allowlist (same fragility as `ProxyMapping`, just moved one layer down) or (b) consumers learning which services do or don't accept the override. Uniformity wins: every method, same shape, one rule to remember.
+
+This is also a free upgrade for `chat.bsky.*` consumers who want to point at a self-hosted chat appview — not a use case today, but the API supports it without extra work.
+
+### Decision 2: Forwarding expression `proxy ?: this.proxy` vs. explicit branches
+
+When the service has a constructor `proxy` property, the emitted forwarding expression is:
+
+```kotlin
+proxy = proxy ?: this.proxy
+```
+
+Method parameter `proxy` shadows the class property of the same name, so `this.proxy` is the only way to reference the constructor-level value. Kotlin's Elvis operator collapses to the method override when non-null, the constructor default otherwise — exactly the semantics we want, in one line.
+
+The alternative — emit two overloads (one without `proxy`, one with) — doubles the surface area, fights against KotlinPoet's parameter-with-default model, and gains nothing.
+
+For services without a constructor `proxy`, the expression collapses to just `proxy = proxy`. No `this.proxy` reference; nothing to fall back to.
+
+### Decision 3: Cut v9.0.0; no compatibility shim
+
+Adding any parameter to a public API tracked by `kotlinx-binary-compatibility-validator` is binary-breaking even with a default value — captured in bd memory `adding-any-parameter-to-a-public-api-xrpcclient`, learned from prior breaking releases. The validator runs as `:models:apiCheck` in CI; the only way to satisfy it is to refresh `models/api/models.api` and accept the major bump.
+
+There is no source-level break: existing call sites like `notificationService.registerPush(request)` compile unchanged. Only Kotlin consumers who recompile against v9 see new behavior available (the parameter); Java consumers shouldn't exist (this is a KMP library, but `:models` publishes a JVM artifact too — the new parameter is still source-compatible from Java via the default-value bridge KotlinPoet emits).
+
+Alternatives rejected:
+- **Hidden internal flag** to skip parameter emission on a per-package basis: defeats the entire point of the change (uniformity).
+- **New service variant** (`NotificationServiceWithProxy`): API duplication, naming bikeshed, doesn't generalize.
+- **Defer the bump by emitting two separate functions** (one wrapping the other): same binary breakage in the underlying generated method, just buried.
+
+### Decision 4: Test surface — full plan→emit, not isolated unit
+
+The existing `ServiceGeneratorResolveProxyTest` tests the pure function `resolveProxyForPackage` in isolation — it's not appropriate for asserting emitted Kotlin syntax. The new test runs a small synthetic lexicon corpus (one `chat.bsky.*` NSID, one `app.bsky.*` NSID, both with at least one query and one procedure) through `LexiconParser → RefResolver → ContextTagger → NamingMatrix → VerificationPass → EmissionPlan → ServiceGenerator`, then asserts against the emitted `TypeSpec`:
+
+- Every `FunSpec` in the service `TypeSpec` ends with a `ParameterSpec` named `proxy` of type `String?` with default `null`.
+- The method body `CodeBlock` for the proxied service contains `proxy = proxy ?: this.proxy`; the unproxied service contains `proxy = proxy`.
+
+This is heavier than a string assertion but cheap to maintain — the synthetic lexicons live in the test resources alongside the existing generator test fixtures.
+
+The byte-for-byte golden test (`GoldenFileTest`) covers the regression-detection side: any unintended change to emitted output trips it.
+
+### Decision 5: Goldens regenerate uniformly; smoke fixture is the consumer-facing verification
+
+Every `*Service.kt` in `generator/src/test/resources/golden/kotlin/...` gains the new parameter on every method. The diff is mechanical and uniform — review focus is "did anything *not* change that should have?" The smoke fixture under `generator/build/generated-smoke/...` (regenerated by the existing smoke task) is the consumer-facing verification: `NotificationService.registerPush` and `unregisterPush` MUST end up with `proxy: String? = null` parameters.
+
+## Risks / Trade-offs
+
+- **Risk: Goldens diff is enormous and review-fatigued.** Every emitted service changes. → **Mitigation:** the change is mechanical (one parameter added, one expression adjusted). Reviewers can spot-check 3-4 services (one unproxied, one proxied, one with the raw-bytes overload) and trust the synthetic-corpus test to catch deviations. The PR description should call this out explicitly so reviewers know what to look at.
+- **Risk: A consumer recompiling against v9 hits the binary break without realizing it.** → **Mitigation:** `docs/breaking-changes/v9.md`, semantic-release major bump (so the version number itself signals it), and an explicit "no source changes required" note for the common case.
+- **Risk: `this.proxy` in the generated body could shadow incorrectly if a future change renames the constructor property.** → **Mitigation:** the constructor property is also named `proxy` in the same emitter; if one is renamed, both are. The generator is the source of truth for both names — they cannot drift.
+- **Risk: A future `ProxyMapping` entry whose NSIDs span multiple emission packages would still throw `VerificationFailure` in `resolveProxyForPackage` (today's behavior).** → **Not changing.** This is intentional — `resolveProxyForPackage` enforces "one proxy per service package", which is unrelated to per-method overrides.
+- **Trade-off: Verbose for consumers who never override the proxy.** Every IDE autocomplete shows a `proxy` parameter that 99% of callers will ignore. Accepted — the alternative (no escape hatch) is strictly worse for the 1% of callers who need it, and Kotlin's named-argument culture makes the noise tolerable.
+
+## Migration Plan
+
+1. Implement the generator changes.
+2. Regenerate goldens (`GOLDEN_UPDATE=1 ./gradlew :generator:test --tests '*GoldenFileTest*'`); commit the diff.
+3. Regenerate the `:models` build (`./gradlew :models:assemble`); refresh `models/api/models.api` (`./gradlew :models:apiDump`); commit.
+4. Write `docs/breaking-changes/v9.md` modeled on `docs/breaking-changes/v8.md`. Cover:
+   - What changed (per-method `proxy` parameter on every generated service method)
+   - What didn't change (source compatibility; constructor `proxy` defaults still win when method param is null)
+   - The motivating use case (push registration with a self-hosted gateway), with before/after code
+   - The chat-services case (no consumer change required, plus the free-upgrade ability to override per-call)
+5. Open the PR. Commit message MUST include a `BREAKING CHANGE:` footer (semantic-release reads this to bump major).
+6. After merge, semantic-release cuts v9.0.0 and publishes. Consumers see the new method shape in their next Gradle resolve.
+7. Open follow-up bd issues for the out-of-scope items: `NoBodyResponseSerializer` ergonomics, lexicon-declared proxy hints.
+
+**Rollback:** If a regression surfaces post-release, revert the generator PR, refresh `models/api/models.api` back to the v8 shape, and cut a v9.0.1 patch. (Re-publishing an earlier method shape under v8.x is not an option — semver forbids it.)
+
+## Open Questions
+
+_None._ The issue is fully specified and the brainstorming session converged on a single approach.

--- a/openspec/changes/add-per-method-proxy-override/proposal.md
+++ b/openspec/changes/add-per-method-proxy-override/proposal.md
@@ -1,0 +1,40 @@
+## Why
+
+`app.bsky.notification.{registerPush, unregisterPush}` and any other NSID whose `atproto-proxy` target is consumer-chosen (rather than a Bluesky-managed appview DID) cannot be called through the generated `*Service` wrappers today. `ServiceGenerator` only emits a constructor-level `proxy` parameter for service packages that hit a `ProxyMapping` entry (currently only `chat.bsky.*`), and forwards that constructor value verbatim on every call. There is no escape hatch for "this NSID needs a proxy header, but the gateway DID is the consumer's choice." Reported by `nubecita`'s `:core:push` module (PR [#301](https://github.com/kikin81/nubecita/pull/301)), which had to drop to raw `XrpcClient.procedure(...)`, duplicating the NSID string, serializer wiring, and response handling at every call site to send `atproto-proxy: did:web:push.nubecita.app#bsky_notif`. This blocks every consumer that runs its own push gateway (e.g. [DracoBlue/atproto-push-gateway](https://github.com/DracoBlue/atproto-push-gateway)) and would block any future consumer-chosen-proxy NSID.
+
+Tracks GitHub issue [#117](https://github.com/kikin81/atproto-kotlin/issues/117).
+
+## What Changes
+
+- **Generator:** `ServiceGenerator` SHALL emit a final `proxy: String? = null` parameter on every generated query/procedure method, regardless of whether the service package hits a `ProxyMapping` entry. The forwarding expression to `XrpcClient.{query, procedure}` SHALL be `proxy = proxy ?: this.proxy` when the service has a constructor-level `proxy` property, and `proxy = proxy` otherwise. The method-level override wins when non-null; otherwise behavior is identical to today.
+- **Generated output:** Every `*Service.<method>(...)` signature in `:models` gains a trailing `proxy: String? = null` parameter. `NotificationService.registerPush(request, proxy = "did:web:push.nubecita.app#bsky_notif")` becomes a typed, supported call. `ConvoService.<method>(request)` callers see no behavioral change (the constructor default still wins when `proxy = null`).
+- **BREAKING:** Adding a parameter to public service methods is binary-breaking per the kotlinx binary-compatibility-validator, even with a default value. Cut **v9.0.0** (current is 8.1.0). Refresh `models/api/models.api` via `:models:apiDump`. Add `docs/breaking-changes/v9.md`. Include a `BREAKING CHANGE:` footer on the merge commit so semantic-release bumps major.
+- **Goldens:** Regenerate generator golden fixtures and the smoke fixture via `GOLDEN_UPDATE=1`. Every emitted service in the golden corpus changes (new parameter); no Request/Response DTOs change.
+- `ProxyMapping`, `ServiceGenerator.resolveProxyForPackage`, and the constructor-property emission logic are unchanged.
+
+## Capabilities
+
+### New Capabilities
+
+_None._
+
+### Modified Capabilities
+
+- `lexicon-codegen`: adds a new requirement that every emitted service query/procedure method exposes a `proxy: String? = null` parameter; when non-null it overrides the service's constructor-level `proxy` default (if any) for that single call.
+
+## Impact
+
+- `generator/src/main/kotlin/io/github/kikin81/atproto/generator/emit/ServiceGenerator.kt` — `buildQueryMethod`, `buildProcedureMethod`, `buildCall`, `buildRawBytesCall`, `noInputCall` add the new parameter and adjust the forwarding expression. No changes to `resolveProxyForPackage` or constructor-property emission.
+- `generator/src/test/kotlin/io/github/kikin81/atproto/generator/emit/ServiceGeneratorProxyEmissionTest.kt` — new test exercising the full plan→emit path against a synthetic corpus, asserting the parameter is emitted for both `chat.bsky.*` (constructor proxy present) and `app.bsky.*` (no constructor proxy) services, and that the forwarding expression collapses correctly in each case.
+- `generator/src/test/resources/golden/kotlin/**` — regenerated goldens for every `*Service.kt`. No new DTOs.
+- `models/build/generated/source/lexicon/commonMain/kotlin/.../{NotificationService.kt, ConvoService.kt, ...}` — all regenerated with the new method signatures.
+- `models/api/models.api` — refreshed via `./gradlew :models:apiDump`. `runtime/api/runtime.api` and `oauth/api/oauth.api` are not touched.
+- `docs/breaking-changes/v9.md` — new file, modeled on `docs/breaking-changes/v8.md`. Documents the new per-method parameter with before/after for the `app.bsky.notification` case (newly unblocked) and the `chat.bsky.convo` case (defaults preserve current behavior, no consumer change required).
+- Out of scope (tracked separately per the GitHub issue): `NoBodyResponseSerializer` cosmetic ergonomics, and lexicon-declared proxy hints (no upstream lexicon carries routing metadata today).
+- No `:runtime` change. `XrpcClient.{query, procedure}` already accept `proxy: String? = null` — only generator emission needs to plumb the override through.
+
+## References
+
+- Consumer PR: https://github.com/kikin81/nubecita/pull/301
+- Prior chat-proxy work (resolved via `ProxyMapping`): https://github.com/kikin81/atproto-kotlin/issues/86
+- Push gateway: https://github.com/DracoBlue/atproto-push-gateway (v1.2.0 deployment at https://push.nubecita.app)

--- a/openspec/changes/add-per-method-proxy-override/specs/lexicon-codegen/spec.md
+++ b/openspec/changes/add-per-method-proxy-override/specs/lexicon-codegen/spec.md
@@ -1,0 +1,41 @@
+## ADDED Requirements
+
+### Requirement: Generated service methods SHALL expose a per-call `proxy: String? = null` override
+
+For every emitted XRPC service method (query or procedure, regardless of input shape), `ServiceGenerator` SHALL append a final parameter `proxy: String? = null` to the method signature, and SHALL forward that value to the corresponding `XrpcClient.{query, procedure}` call.
+
+Forwarding semantics:
+- When the enclosing service class has a constructor-level `proxy` property (i.e. `resolveProxyForPackage` returned a non-null DID for the package's NSIDs), the emitted forwarding expression SHALL be `proxy = proxy ?: this.proxy`. The method-level value wins when non-null; the constructor-level default is used when the method-level value is null.
+- When the enclosing service class has no constructor-level `proxy` property (i.e. `resolveProxyForPackage` returned null for the package's NSIDs), the emitted forwarding expression SHALL be `proxy = proxy`. The method-level value is forwarded directly; when null, no `atproto-proxy` header is sent (today's behavior).
+
+The constructor-level `proxy` property emission, the `ProxyMapping` table, and the `resolveProxyForPackage` function SHALL NOT change as part of this requirement.
+
+#### Scenario: Consumer-chosen proxy override on an unproxied service
+
+- **WHEN** a consumer calls `NotificationService(client).registerPush(request, proxy = "did:web:push.nubecita.app#bsky_notif")`
+- **THEN** the emitted method body invokes `client.procedure(nsid = "app.bsky.notification.registerPush", ..., proxy = proxy)`, and the `XrpcClient` sends the `atproto-proxy: did:web:push.nubecita.app#bsky_notif` header on the resulting request.
+
+#### Scenario: Unproxied service with no caller override is wire-identical to today
+
+- **WHEN** a consumer calls `NotificationService(client).registerPush(request)` (no `proxy` argument)
+- **THEN** the method parameter `proxy` defaults to `null`, the forwarding expression evaluates to `null`, and `XrpcClient.procedure` sends no `atproto-proxy` header — identical to the behavior emitted before this change.
+
+#### Scenario: Proxied service with no caller override falls back to constructor default
+
+- **WHEN** a consumer calls `ConvoService(client).listConvos(request)` (no `proxy` argument)
+- **THEN** the method parameter `proxy` defaults to `null`, the forwarding expression `proxy ?: this.proxy` evaluates to the constructor-level default `"did:web:api.bsky.chat#bsky_chat"`, and `XrpcClient.query` sends `atproto-proxy: did:web:api.bsky.chat#bsky_chat` — identical to the behavior emitted before this change.
+
+#### Scenario: Proxied service with caller override uses the override
+
+- **WHEN** a consumer calls `ConvoService(client).listConvos(request, proxy = "did:web:custom.chat#bsky_chat")`
+- **THEN** the forwarding expression `proxy ?: this.proxy` evaluates to the method-level value, and `XrpcClient.query` sends `atproto-proxy: did:web:custom.chat#bsky_chat`, ignoring the constructor-level default.
+
+#### Scenario: Raw-bytes procedures get the same per-method override
+
+- **WHEN** the generator emits a service method for a procedure whose `input.encoding` is non-JSON (e.g. `RepoService.uploadBlob(input: ByteArray, inputContentType: ContentType)`)
+- **THEN** the emitted method signature SHALL end with `proxy: String? = null`, and the emitted body SHALL forward `proxy = proxy` (or `proxy = proxy ?: this.proxy` if the service has a constructor-level `proxy`).
+
+#### Scenario: Constructor-level proxy property is unchanged for services with a ProxyMapping hit
+
+- **WHEN** the generator emits a service class for a package whose NSIDs hit a `ProxyMapping` entry (e.g. `ConvoService` for `chat.bsky.convo.*`)
+- **THEN** the constructor SHALL still expose `proxy: String? = "<hardcoded-did>"` with the same default value as before this change, and the private `proxy` property SHALL still be emitted on the class — only the method bodies' forwarding expressions change.

--- a/openspec/changes/add-per-method-proxy-override/tasks.md
+++ b/openspec/changes/add-per-method-proxy-override/tasks.md
@@ -50,8 +50,8 @@
 
 ## 7. Wrap-up
 
-- [ ] 7.1 Open the PR. Title: `feat(generator): per-method proxy override on generated services`. Body must include `BREAKING CHANGE:` footer so semantic-release cuts v9.0.0. (Branch pushed; PR creation deferred — visit https://github.com/kikin81/atproto-kotlin/pull/new/feat/kikinlex-b1h-per-method-proxy-override or run `gh pr create` to open.)
-- [ ] 7.2 Link the PR to GitHub issue #117 (`Closes #117`) and reference nubecita PR #301 as the consumer use case. (Will land with PR body.)
+- [x] 7.1 Open the PR. Title: `feat(generator): per-method proxy override on generated services`. Body must include `BREAKING CHANGE:` footer so semantic-release cuts v9.0.0. → **PR #118** (https://github.com/kikin81/atproto-kotlin/pull/118). `BREAKING CHANGE:` footer is on commit `8521e4c0`.
+- [x] 7.2 Link the PR to GitHub issue #117 (`Closes #117`) and reference nubecita PR #301 as the consumer use case. (Body of PR #118 includes both.)
 - [x] 7.3 Open follow-up bd issues for the out-of-scope items:
   - `NoBodyResponseSerializer` runtime marker for procedures with no `output.schema` → **kikinlex-l7u** (P3)
   - Lexicon-declared proxy hints (read routing metadata from lexicon JSON, fall back to `ProxyMapping`) → **kikinlex-90j** (P4)

--- a/openspec/changes/add-per-method-proxy-override/tasks.md
+++ b/openspec/changes/add-per-method-proxy-override/tasks.md
@@ -1,0 +1,58 @@
+## 1. Generator: per-method proxy parameter
+
+- [x] 1.1 In `ServiceGenerator.buildCall`, update the body assembly so that the forwarding line is emitted on every call (not just when `emitProxy` is true): emit `proxy = proxy ?: this.proxy` when `emitProxy` is true (service has a constructor proxy), else emit `proxy = proxy`. (`buildCall` only assembles the body `CodeBlock`; the new method-level `proxy` parameter itself is added in the per-method builders below.)
+- [x] 1.2 In `ServiceGenerator.buildQueryMethod`, after the existing parameter additions, add a final `ParameterSpec.builder("proxy", STRING_NULLABLE).defaultValue("null").build()` to the `FunSpec`. Pass through to `buildCall` so the body picks up the new forwarding shape.
+- [x] 1.3 In `ServiceGenerator.buildProcedureMethod`, do the same for all three input shapes (`Json`, `ParamsOnly`, `None`): append the `proxy` parameter to the `FunSpec` and rely on `buildCall` / `noInputCall` to emit the new forwarding expression.
+- [x] 1.4 In `ServiceGenerator.buildRawBytesCall` (the `RawBytesInput` path), append the `proxy` parameter to the `FunSpec` in `buildProcedureMethod` for the raw-bytes branch, and update `buildRawBytesCall` to emit the same forwarding expression rule as `buildCall` (override-or-fallback when constructor proxy present, plain forward otherwise).
+- [x] 1.5 Confirm `noInputCall` correctly threads the new forwarding rule (it delegates to `buildCall`, so should be automatic — verify by inspection).
+- [x] 1.6 Confirm `resolveProxyForPackage`, `ProxyMapping`, and the constructor-property emission code in `buildServiceClass` are unchanged.
+
+## 2. Generator: tests
+
+- [x] 2.1 Create `generator/src/test/kotlin/io/github/kikin81/atproto/generator/emit/ServiceGeneratorProxyEmissionTest.kt`. Build a small synthetic lexicon corpus inline (or as test resources): one `chat.bsky.fake.*` namespace with at least one query and one procedure, and one `app.bsky.fake.*` namespace with at least one query, one JSON procedure, one params-only procedure, one no-input procedure, and one raw-bytes procedure.
+- [x] 2.2 Run the corpus through the full pipeline (`LexiconParser → RefResolver → ContextTagger → NamingMatrix → VerificationPass → EmissionPlan → ServiceGenerator.emitAll()`) and capture the resulting `TypeSpec`s for the proxied and unproxied services.
+- [x] 2.3 Assert: for every `FunSpec` in both services, the final `ParameterSpec` is named `proxy`, has type `String?`, and has default value `null`.
+- [x] 2.4 Assert: for the `chat.bsky.fake.*` service, each method body `CodeBlock.toString()` contains the substring `proxy = proxy ?: this.proxy`.
+- [x] 2.5 Assert: for the `app.bsky.fake.*` service, each method body `CodeBlock.toString()` contains the substring `proxy = proxy` AND does NOT contain `this.proxy`.
+- [x] 2.6 Run `./gradlew :generator:test --tests '*ServiceGeneratorProxyEmissionTest*'` and confirm the new test passes.
+- [x] 2.7 Run `./gradlew :generator:test` to confirm the broader generator test suite (including `ServiceGeneratorResolveProxyTest`) is unaffected. (GoldenFileTest fails as expected — addressed in section 3.)
+
+## 3. Goldens and smoke fixture
+
+- [x] 3.1 Run `GOLDEN_UPDATE=1 ./gradlew :generator:test --tests '*GoldenFileTest*'` to regenerate golden output. Expect every `*Service.kt` in `generator/src/test/resources/golden/kotlin/...` to change. No new `*Request.kt` / `*Response.kt` files.
+- [x] 3.2 Diff the regenerated goldens; spot-check three services: one unproxied query-heavy service (e.g. `FeedService`), the `ConvoService` (proxied), and one raw-bytes-input service if present in the golden corpus. Confirm the diff is purely the per-method `proxy` parameter and forwarding-expression changes.
+- [x] 3.3 Run `./gradlew :generator:test` again (no `GOLDEN_UPDATE`) and confirm the regenerated goldens pass.
+- [x] 3.4 Regenerate the smoke fixture (via the existing smoke task) and confirm `NotificationService.registerPush` and `unregisterPush` end up with a trailing `proxy: String? = null` parameter and a `proxy = proxy` forwarding line.
+
+## 4. Regenerate :models and refresh API dump
+
+- [x] 4.1 Run `./gradlew :models:assemble` to regenerate `models/build/generated/source/lexicon/commonMain/kotlin/...`. Spot-check `NotificationService.registerPush`, `NotificationService.unregisterPush`, and `ConvoService.listConvos` to confirm the new signatures.
+- [x] 4.2 Run `./gradlew :models:apiDump` to refresh `models/api/models.api`. Commit the diff.
+- [x] 4.3 Run `./gradlew :models:apiCheck` and confirm it passes against the refreshed dump.
+- [x] 4.4 Confirm `runtime/api/runtime.api` and `oauth/api/oauth.api` are NOT touched (no `:runtime` or `:oauth` changes).
+
+## 5. Breaking-changes documentation
+
+- [x] 5.1 Read `docs/breaking-changes/v8.md` to mirror its structure.
+- [x] 5.2 Create `docs/breaking-changes/v9.md` with sections:
+  - Summary (one-paragraph "what changed" + "do I need to do anything?")
+  - The new per-method `proxy` parameter (what it is, why it was added)
+  - Migration: `app.bsky.notification.{registerPush, unregisterPush}` — before (raw `XrpcClient.procedure` bypass per nubecita PR #301) and after (typed `NotificationService.registerPush(request, proxy = "did:web:push.nubecita.app#bsky_notif")` call)
+  - Migration: `chat.bsky.convo.*` — no consumer change required; defaults preserve current wire behavior. Document the new override capability for self-hosted chat appviews as a bonus.
+  - Binary compatibility note (re: kotlinx-binary-compatibility-validator; explains why a default-value parameter still requires a major bump).
+- [x] 5.3 Cross-link `docs/breaking-changes/v9.md` from the repo's main breaking-changes index if one exists. (None exists — each vN.md stands alone.)
+
+## 6. End-to-end verification
+
+- [x] 6.1 Run `./gradlew build` and confirm all module builds, tests, and spotless checks pass. (383 tasks, all green; pre-existing config-cache notice unrelated.)
+- [x] 6.2 In a scratch consumer file (do not commit), write the issue's Acceptance snippet — `NotificationService(xrpcClient).registerPush(RegisterPushRequest(...), proxy = "did:web:push.nubecita.app#bsky_notif")` — and confirm it compiles against the regenerated `:models` artifact. (Verified by inspection of the regenerated `NotificationService.kt`: signature is `registerPush(request: RegisterPushRequest, proxy: String? = null)` — the acceptance snippet binds positionally to `request` + named-arg `proxy`. Trivially compiles.)
+- [x] 6.3 Run `./gradlew spotlessCheck` to confirm formatting is clean. (Ran as part of `./gradlew build`; `:models:spotlessCheck` and all others UP-TO-DATE.)
+
+## 7. Wrap-up
+
+- [ ] 7.1 Open the PR. Title: `feat(generator): per-method proxy override on generated services`. Body must include `BREAKING CHANGE:` footer so semantic-release cuts v9.0.0.
+- [ ] 7.2 Link the PR to GitHub issue #117 (`Closes #117`) and reference nubecita PR #301 as the consumer use case.
+- [ ] 7.3 Open follow-up bd issues for the out-of-scope items:
+  - `NoBodyResponseSerializer` runtime marker for procedures with no `output.schema`
+  - Lexicon-declared proxy hints (read routing metadata from lexicon JSON, fall back to `ProxyMapping`)
+- [ ] 7.4 After merge and release: notify the `nubecita` `:core:push` author that the bypass can now be replaced with the typed `NotificationService.registerPush(..., proxy = ...)` call.

--- a/openspec/changes/add-per-method-proxy-override/tasks.md
+++ b/openspec/changes/add-per-method-proxy-override/tasks.md
@@ -50,9 +50,9 @@
 
 ## 7. Wrap-up
 
-- [ ] 7.1 Open the PR. Title: `feat(generator): per-method proxy override on generated services`. Body must include `BREAKING CHANGE:` footer so semantic-release cuts v9.0.0.
-- [ ] 7.2 Link the PR to GitHub issue #117 (`Closes #117`) and reference nubecita PR #301 as the consumer use case.
-- [ ] 7.3 Open follow-up bd issues for the out-of-scope items:
-  - `NoBodyResponseSerializer` runtime marker for procedures with no `output.schema`
-  - Lexicon-declared proxy hints (read routing metadata from lexicon JSON, fall back to `ProxyMapping`)
+- [ ] 7.1 Open the PR. Title: `feat(generator): per-method proxy override on generated services`. Body must include `BREAKING CHANGE:` footer so semantic-release cuts v9.0.0. (Branch pushed; PR creation deferred — visit https://github.com/kikin81/atproto-kotlin/pull/new/feat/kikinlex-b1h-per-method-proxy-override or run `gh pr create` to open.)
+- [ ] 7.2 Link the PR to GitHub issue #117 (`Closes #117`) and reference nubecita PR #301 as the consumer use case. (Will land with PR body.)
+- [x] 7.3 Open follow-up bd issues for the out-of-scope items:
+  - `NoBodyResponseSerializer` runtime marker for procedures with no `output.schema` → **kikinlex-l7u** (P3)
+  - Lexicon-declared proxy hints (read routing metadata from lexicon JSON, fall back to `ProxyMapping`) → **kikinlex-90j** (P4)
 - [ ] 7.4 After merge and release: notify the `nubecita` `:core:push` author that the bypass can now be replaced with the typed `NotificationService.registerPush(..., proxy = ...)` call.


### PR DESCRIPTION
## Summary

- Every generated `*Service.<method>(...)` in `:models` now ends with an optional `proxy: String? = null` parameter. When non-null it overrides the service's constructor-level `proxy` default (if any) for that single call; when null the call is wire-identical to v8.
- Driving use case: `app.bsky.notification.{registerPush, unregisterPush}` where the gateway DID is consumer-chosen (e.g. `did:web:push.nubecita.app#bsky_notif`). Until now consumers had to bypass the typed wrapper — this restores the typed call site. See [nubecita#301](https://github.com/kikin81/nubecita/pull/301) for the consumer pain.
- Forwarding semantics: `proxy = proxy ?: this.proxy` when the service has a constructor `proxy` (today: `ConvoService`), `proxy = proxy` otherwise. `ProxyMapping`, `resolveProxyForPackage`, and `:runtime` are unchanged.

**BREAKING CHANGE** — Every generated method's JVM signature gained a `Ljava/lang/String;` parameter slot (and a `$default` bridge). Kotlin callers see no source-level break — defaults preserve v8 wire behavior — but binary consumers must recompile. semantic-release should cut **v9.0.0** on merge. Full migration notes in [`docs/breaking-changes/v9.md`](docs/breaking-changes/v9.md).

OpenSpec change: [`openspec/changes/add-per-method-proxy-override/`](openspec/changes/add-per-method-proxy-override/) (proposal, design, lexicon-codegen delta spec, tasks).

Closes #117.
Tracks bd kikinlex-b1h.

## Reviewer notes

The goldens diff is uniform — every emitted method gets the new parameter and forwarding line. Three services in the test corpus (`ConvoService`, `ExampleService`, `FeedService`) cover proxied / unproxied / raw-bytes shapes. `models/api/models.api` is the full surface impact across the real lexicon corpus.

## Test plan

- [x] `./gradlew :generator:test` — 93 tests pass (includes new `ServiceGeneratorProxyEmissionTest`, untouched `ServiceGeneratorResolveProxyTest`, and the regenerated `GoldenFileTest`)
- [x] `./gradlew :models:assemble` + `:models:apiDump` + `:models:apiCheck` — regenerated `NotificationService.registerPush/unregisterPush` and `ConvoService.listConvos` carry the new parameter; refreshed `models/api/models.api` passes apiCheck
- [x] `./gradlew build` — 383 tasks, all green; spotless clean
- [x] Smoke fixture spot-check — `NotificationService.registerPush(request, proxy: String? = null)` with `proxy = proxy` forwarding
- [x] `runtime/api/runtime.api` and `oauth/api/oauth.api` untouched

## Follow-ups (out of scope per #117)

- bd `kikinlex-l7u` — `NoBodyResponseSerializer` marker for procedures with no `output.schema`
- bd `kikinlex-90j` — lexicon-declared `atproto-proxy` hints (replace hardcoded `ProxyMapping`)