### PR TITLE
fix(runtime): accept empty response body for Unit-returning XRPC calls

### DIFF
--- a/runtime/src/commonMain/kotlin/io/github/kikin81/atproto/runtime/XrpcClient.kt
+++ b/runtime/src/commonMain/kotlin/io/github/kikin81/atproto/runtime/XrpcClient.kt
@@ -242,6 +242,16 @@ public class XrpcClient(
     ): R {
         val body = response.bodyAsText()
         if (response.status.isSuccess()) {
+            // Spec-conforming PDS behavior: procedures whose lexicon declares
+            // no `output.schema` return HTTP 2xx with a literally empty body.
+            // UnitSerializer expects `{}` and throws on empty input, surfacing
+            // a successful call as a non-XrpcError JsonDecodingException. Only
+            // short-circuit when the caller is actually expecting Unit — any
+            // other typed response still fails loudly on a truncated body.
+            if (body.isBlank() && responseSerializer.descriptor == UnitResponseSerializer.descriptor) {
+                @Suppress("UNCHECKED_CAST")
+                return Unit as R
+            }
             return json.decodeFromString(responseSerializer, body)
         }
         val decoded = runCatching {

--- a/runtime/src/commonTest/kotlin/io/github/kikin81/atproto/runtime/XrpcClientTest.kt
+++ b/runtime/src/commonTest/kotlin/io/github/kikin81/atproto/runtime/XrpcClientTest.kt
@@ -435,6 +435,78 @@ class XrpcClientTest {
     }
 
     @Test
+    fun procedure_with_unit_response_accepts_empty_body() = runTest {
+        // Spec-conforming PDS behavior for procedures with no output.schema —
+        // e.g. app.bsky.notification.registerPush returns HTTP 2xx with an
+        // empty body. See GitHub issue #119.
+        val (client, engine) = makeClient {
+            respond(ByteReadChannel(""), HttpStatusCode.OK, jsonHeaders)
+        }
+
+        client.procedure(
+            nsid = "app.bsky.notification.registerPush",
+            params = Unit,
+            paramsSerializer = Unit.serializer(),
+            input = CreateSessionInput(identifier = "x", password = "y"),
+            inputSerializer = CreateSessionInput.serializer(),
+            responseSerializer = UnitResponseSerializer,
+        )
+
+        assertEquals(1, engine.requestHistory.size)
+    }
+
+    @Test
+    fun procedure_with_unit_response_accepts_whitespace_body() = runTest {
+        val (client, _) = makeClient {
+            respond(ByteReadChannel("   \n  "), HttpStatusCode.OK, jsonHeaders)
+        }
+
+        client.procedure(
+            nsid = "app.bsky.notification.unregisterPush",
+            params = Unit,
+            paramsSerializer = Unit.serializer(),
+            input = CreateSessionInput(identifier = "x", password = "y"),
+            inputSerializer = CreateSessionInput.serializer(),
+            responseSerializer = UnitResponseSerializer,
+        )
+    }
+
+    @Test
+    fun procedure_with_unit_response_still_accepts_empty_object_body() = runTest {
+        // Existing behavior must keep working — some PDS implementations do
+        // return `{}` for Unit-shaped procedures.
+        val (client, _) = makeClient { ok("{}") }
+
+        client.procedure(
+            nsid = "com.atproto.repo.deleteRecord",
+            params = Unit,
+            paramsSerializer = Unit.serializer(),
+            input = CreateSessionInput(identifier = "x", password = "y"),
+            inputSerializer = CreateSessionInput.serializer(),
+            responseSerializer = UnitResponseSerializer,
+        )
+    }
+
+    @Test
+    fun empty_body_with_non_unit_serializer_still_fails() = runTest {
+        // The short-circuit must be Unit-only — a procedure that declares an
+        // output schema but gets an empty body is a real protocol error and
+        // should surface, not silently succeed.
+        val (client, _) = makeClient {
+            respond(ByteReadChannel(""), HttpStatusCode.OK, jsonHeaders)
+        }
+
+        assertFailsWith<kotlinx.serialization.SerializationException> {
+            client.query(
+                nsid = "app.bsky.feed.getTimeline",
+                params = TimelineParams(),
+                paramsSerializer = TimelineParams.serializer(),
+                responseSerializer = TimelineResponse.serializer(),
+            )
+        }
+    }
+
+    @Test
     fun unknown_error_falls_through_to_unknown() = runTest {
         val (client, _) = makeClient {
             respond(


### PR DESCRIPTION
## Summary

- `UnitResponseSerializer` delegates to kotlinx `UnitSerializer`, which only accepts `{}` as input. Real PDS deployments (Bluesky included) return HTTP 2xx with a **literally empty body** for any procedure whose lexicon declares no `output.schema` — e.g. `app.bsky.notification.registerPush`, `app.bsky.notification.unregisterPush`, and most `*.deleteRecord` / `*.putRecord` variants.
- `XrpcClient.handle` was decoding that empty body and throwing `JsonDecodingException`, surfacing a successful call to callers as a non-XrpcError failure. Caught end-to-end in [`net.kikin.nubecita` PR #304](https://github.com/kikin81/nubecita/pull/304) during real-device push-registration smoke testing.
- Short-circuit in `handle()`: when the body is blank **and** `responseSerializer.descriptor` matches `Unit`'s, return `Unit` directly. Non-Unit responses with empty bodies still fail loudly — that's a real protocol violation, not a Unit shape, and silently coercing would mask real bugs.

The simpler "custom `KSerializer<Unit>` that returns `Unit` without consuming the decoder" sketch from the issue can't actually work — `Json.decodeFromString(serializer, "")` fails at the parse step before our deserializer is ever called.

No public API change (private `handle()` body only); `:runtime:apiCheck` passes.

Closes #119
Refs: kikinlex-9hp

## Test plan

- [x] `./gradlew :runtime:check` (commonTest + jvmTest + iosSimulatorArm64Test + apiCheck) passes
- [x] New test `procedure_with_unit_response_accepts_empty_body` — empty body + `UnitResponseSerializer` ⇒ `Result.success`
- [x] New test `procedure_with_unit_response_accepts_whitespace_body` — whitespace-only body also accepted
- [x] New test `procedure_with_unit_response_still_accepts_empty_object_body` — existing `{}` path still works
- [x] New test `empty_body_with_non_unit_serializer_still_fails` — guards against accidentally swallowing real protocol violations
- [ ] Smoke-tested in `nubecita` against a real PDS (follow-up after this is merged + a 9.x patch is published)

🤖 Generated with [Claude Code](https://claude.com/claude-code)