### PR TITLE
chore(lexicons): bump @atproto/lex to 0.1.2

### DIFF
--- a/generator/package-lock.json
+++ b/generator/package-lock.json
@@ -8,265 +8,320 @@
       "name": "kikinlex-atproto-generator-lexicons",
       "version": "0.0.0",
       "dependencies": {
-        "@atproto/lex": "0.0.26"
+        "@atproto/lex": "0.1.2"
       }
     },
     "node_modules/@atproto-labs/did-resolver": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@atproto-labs/did-resolver/-/did-resolver-0.2.6.tgz",
-      "integrity": "sha512-2K1bC04nI2fmgNcvof+yA28IhGlpWn2JKYlPa7To9JTKI45FINCGkQSGiL2nyXlyzDJJ34fZ1aq6/IRFIOIiqg==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@atproto-labs/did-resolver/-/did-resolver-0.3.0.tgz",
+      "integrity": "sha512-6w8UxJQVj40TqKJm+D5s6pcH45eWH/KvfAR+gYC6KOux/mM7ZI3IKOhI1Gq7GIte1eOp9WXwASN1RQAFYZ4MFw==",
       "license": "MIT",
       "dependencies": {
-        "@atproto-labs/fetch": "0.2.3",
-        "@atproto-labs/pipe": "0.1.1",
-        "@atproto-labs/simple-store": "0.3.0",
-        "@atproto-labs/simple-store-memory": "0.1.4",
-        "@atproto/did": "0.3.0",
+        "@atproto-labs/fetch": "^0.3.0",
+        "@atproto-labs/pipe": "^0.2.0",
+        "@atproto-labs/simple-store": "^0.4.0",
+        "@atproto-labs/simple-store-memory": "^0.2.0",
+        "@atproto/did": "^0.4.0",
         "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@atproto-labs/fetch": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@atproto-labs/fetch/-/fetch-0.2.3.tgz",
-      "integrity": "sha512-NZtbJOCbxKUFRFKMpamT38PUQMY0hX0p7TG5AEYOPhZKZEP7dHZ1K2s1aB8MdVH0qxmqX7nQleNrrvLf09Zfdw==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@atproto-labs/fetch/-/fetch-0.3.0.tgz",
+      "integrity": "sha512-yZhNsRZyqhjmzHlXmE9k6XU0f6+ynfNyrHhB4FlEyUjkBvf5vNLjdJyBq+Jp7ISGMigA1fn2lAgaE/qkrVo9iw==",
       "license": "MIT",
       "dependencies": {
-        "@atproto-labs/pipe": "0.1.1"
+        "@atproto-labs/pipe": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@atproto-labs/pipe": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@atproto-labs/pipe/-/pipe-0.1.1.tgz",
-      "integrity": "sha512-hdNw2oUs2B6BN1lp+32pF7cp8EMKuIN5Qok2Vvv/aOpG/3tNSJ9YkvfI0k6Zd188LeDDYRUpYpxcoFIcGH/FNg==",
-      "license": "MIT"
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@atproto-labs/pipe/-/pipe-0.2.0.tgz",
+      "integrity": "sha512-89X6gv+8/SiZYwJ4+Hw8iaU1WymbElZO6LsMgHd+c1XFs/78KhsIL4xp0RCs7/W8izK9BxaTEnYN5csRmwQ99Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22"
+      }
     },
     "node_modules/@atproto-labs/simple-store": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@atproto-labs/simple-store/-/simple-store-0.3.0.tgz",
-      "integrity": "sha512-nOb6ONKBRJHRlukW1sVawUkBqReLlLx6hT35VS3imaNPwiXDxLnTK7lxw3Lrl9k5yugSBDQAkZAq3MPTEFSUBQ==",
-      "license": "MIT"
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@atproto-labs/simple-store/-/simple-store-0.4.0.tgz",
+      "integrity": "sha512-sbPEju2QXzN6lGWfr5p2Kg82ZeaG1UyVFOrMQc4eCjUvxGOjIxuYOVIiTuPTFOC5Rsvsb8jMOmLjLi8FR/CMYw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22"
+      }
     },
     "node_modules/@atproto-labs/simple-store-memory": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@atproto-labs/simple-store-memory/-/simple-store-memory-0.1.4.tgz",
-      "integrity": "sha512-3mKY4dP8I7yKPFj9VKpYyCRzGJOi5CEpOLPlRhoJyLmgs3J4RzDrjn323Oakjz2Aj2JzRU/AIvWRAZVhpYNJHw==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@atproto-labs/simple-store-memory/-/simple-store-memory-0.2.0.tgz",
+      "integrity": "sha512-nDZIS6vOBvR8NqObGmj0GFSdz3N6gyQ7ny3l/uiezwuCWShsxtA9OkYcjaQ7Kw3hydXTe4iEGu/BDOACncnxDg==",
       "license": "MIT",
       "dependencies": {
-        "@atproto-labs/simple-store": "0.3.0",
+        "@atproto-labs/simple-store": "^0.4.0",
         "lru-cache": "^10.2.0"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@atproto/common": {
-      "version": "0.5.16",
-      "resolved": "https://registry.npmjs.org/@atproto/common/-/common-0.5.16.tgz",
-      "integrity": "sha512-DTWgaVlDJN3zDxJ3agZK3pbiSZc+z8QQe9iy15sIuorLrceIp4kHXMO/QqjWBXnmLVTd6+/5BVDzex5amYc0rg==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@atproto/common/-/common-0.6.1.tgz",
+      "integrity": "sha512-mXR4R8nYFgs4gncFXNyIcxMcjuvpeCn3spu4pIlfWsri+MxXPr4jHWkjyv+b2JIvI+nns3L3ElFKWPEO4GlZdA==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/common-web": "^0.4.20",
-        "@atproto/lex-cbor": "^0.0.16",
-        "@atproto/lex-data": "^0.0.15",
-        "multiformats": "^9.9.0",
+        "@atproto/common-web": "^0.5.0",
+        "@atproto/lex-cbor": "^0.1.0",
+        "@atproto/lex-data": "^0.1.1",
+        "multiformats": "^13.0.0",
         "pino": "^8.21.0"
       },
       "engines": {
-        "node": ">=18.7.0"
+        "node": ">=22"
       }
     },
     "node_modules/@atproto/common-web": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@atproto/common-web/-/common-web-0.4.21.tgz",
-      "integrity": "sha512-Odq+wdk3YNasGCjjlpl3bCIPvqYHige5DLfMkIffNv/2PI/iIj5ZvAvMvJlJ59OhReKSxtpI0invx5UQPc3+fw==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@atproto/common-web/-/common-web-0.5.0.tgz",
+      "integrity": "sha512-ReWnkuZdDU/74/I47gaI26uxQjHmpq4edp41NnZZQ5vIIKGb7Ei6pZHzDTUD9JURo109SKrPx9RMP2IQm0fOKA==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/lex-data": "^0.0.15",
-        "@atproto/lex-json": "^0.0.16",
-        "@atproto/syntax": "^0.5.4",
+        "@atproto/lex-data": "^0.1.0",
+        "@atproto/lex-json": "^0.1.0",
+        "@atproto/syntax": "^0.6.0",
         "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@atproto/crypto": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/@atproto/crypto/-/crypto-0.4.5.tgz",
-      "integrity": "sha512-n40aKkMoCatP0u9Yvhrdk6fXyOHFDDbkdm4h4HCyWW+KlKl8iXfD5iV+ECq+w5BM+QH25aIpt3/j6EUNerhLxw==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@atproto/crypto/-/crypto-0.5.0.tgz",
+      "integrity": "sha512-HBfq6z+tzkiBzPhHOvRFkQU3inTQIUJAkb1UEyGx+pdPTnFFtnfIoo9Kr1ZV/FzMIgnHOA8H2UJC3dxxFl1eVg==",
       "license": "MIT",
       "dependencies": {
         "@noble/curves": "^1.7.0",
         "@noble/hashes": "^1.6.1",
-        "uint8arrays": "3.0.0"
+        "uint8arrays": "^5.0.0"
       },
       "engines": {
-        "node": ">=18.7.0"
+        "node": ">=22"
       }
     },
     "node_modules/@atproto/did": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@atproto/did/-/did-0.3.0.tgz",
-      "integrity": "sha512-raUPzUGegtW/6OxwCmM8bhZvuIMzxG5t9oWsth6Tp91Kb5fTnHV2h/KKNF1C82doeA4BdXCErTyg7ISwLbQkzA==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@atproto/did/-/did-0.4.0.tgz",
+      "integrity": "sha512-OADX1NXCkScMkNJmSQnTUfPoDJ2IoOUTtqVfuY4z+a8//JDIsY6FDygv3GR8Sh2laz5qodlCA7XM+u6XVine3g==",
       "license": "MIT",
       "dependencies": {
         "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@atproto/lex": {
-      "version": "0.0.26",
-      "resolved": "https://registry.npmjs.org/@atproto/lex/-/lex-0.0.26.tgz",
-      "integrity": "sha512-grZoe+Aqh4Q/nr4nBYN+bVjv5EJyb4Oup57ZRbGueR+yOyy9zWrwen4k3qRmLBdoFlU2b9RNoR896ARxdi/gNg==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@atproto/lex/-/lex-0.1.2.tgz",
+      "integrity": "sha512-s4Z29QUcnsKPCJeN9VZiCQIpP9vklm/6EoO7znsUDNN4jZknvnd8vrJbCV9HQRHM8C6ZuHxh7vtsjlE8tzxnyw==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/lex-builder": "^0.0.23",
-        "@atproto/lex-client": "^0.0.21",
-        "@atproto/lex-data": "^0.0.15",
-        "@atproto/lex-installer": "^0.0.26",
-        "@atproto/lex-json": "^0.0.16",
-        "@atproto/lex-schema": "^0.0.20",
+        "@atproto/lex-builder": "^0.1.2",
+        "@atproto/lex-client": "^0.1.2",
+        "@atproto/lex-data": "^0.1.1",
+        "@atproto/lex-installer": "^0.1.0",
+        "@atproto/lex-json": "^0.1.0",
+        "@atproto/lex-schema": "^0.1.1",
         "tslib": "^2.8.1",
         "yargs": "^17.0.0"
       },
       "bin": {
         "lex": "bin/lex",
         "ts-lex": "bin/lex"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@atproto/lex-builder": {
-      "version": "0.0.23",
-      "resolved": "https://registry.npmjs.org/@atproto/lex-builder/-/lex-builder-0.0.23.tgz",
-      "integrity": "sha512-3eHs4mUy9QRYET82Fh9R/jJD8hpGKIyzuUpmeiY6/o8fA4pcynfTew5O4AHIBns6eyGCbCnLLQEDwPTlrsXDSA==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@atproto/lex-builder/-/lex-builder-0.1.2.tgz",
+      "integrity": "sha512-cBkuJiBkiIO6KzO2AGTc/0EOJKRfBxWwAQbmy4WYnNO3ewC/8BztQuAxY99mAf/NWuksEKXL+UY6J/ZEKLK1pA==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/lex-document": "^0.0.21",
-        "@atproto/lex-schema": "^0.0.20",
+        "@atproto/lex-document": "^0.1.0",
+        "@atproto/lex-schema": "^0.1.1",
         "prettier": "^3.2.5",
         "ts-morph": "^27.0.0",
         "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@atproto/lex-cbor": {
-      "version": "0.0.16",
-      "resolved": "https://registry.npmjs.org/@atproto/lex-cbor/-/lex-cbor-0.0.16.tgz",
-      "integrity": "sha512-x3NTvOX5/4Wh7uk8RNJpUJqZjcWRSUYDYRJ6VZPLmp/CAnsMySmBAinBu/dva/1hqS3C1oiYz258x6bRYpKJ4w==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@atproto/lex-cbor/-/lex-cbor-0.1.0.tgz",
+      "integrity": "sha512-SGL7BHPYN0OmvtnVixieYWyh2ghxI7iHADTLfz52Xp5zR+BZY3QggIKJ32KfyYN9Ss2tduaqsY5aclEki2Aq0A==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/lex-data": "^0.0.15",
+        "@atproto/lex-data": "^0.1.0",
+        "cborg": "^4.5.8",
         "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@atproto/lex-client": {
-      "version": "0.0.21",
-      "resolved": "https://registry.npmjs.org/@atproto/lex-client/-/lex-client-0.0.21.tgz",
-      "integrity": "sha512-xd4QieOU3TFsukB1EyPPRXBkr6znju/ECopM3lVCLI9CRt7i5R8FeaaGJ93M68BoGWmrdmuDaHEe9zD+1N8utQ==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@atproto/lex-client/-/lex-client-0.1.2.tgz",
+      "integrity": "sha512-ZZXaqRWeVjRrUoc/7Of3gP2KN7z7Sb8OnNT462ZIUlruxZfrLz9roFUr6jHOpnEIR+5xNk5fnHPAD8KSl7KkXw==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/lex-data": "^0.0.15",
-        "@atproto/lex-json": "^0.0.16",
-        "@atproto/lex-schema": "^0.0.20",
+        "@atproto/lex-data": "^0.1.1",
+        "@atproto/lex-json": "^0.1.0",
+        "@atproto/lex-schema": "^0.1.1",
         "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@atproto/lex-data": {
-      "version": "0.0.15",
-      "resolved": "https://registry.npmjs.org/@atproto/lex-data/-/lex-data-0.0.15.tgz",
-      "integrity": "sha512-ZsbGiaM5S3CnGrcTMbDGON3bLZzCi/Mx9UvcMREKSRujnF68eHgMiXxJqvykP7+QpOX6tYCK93axZkuJVhtSEw==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@atproto/lex-data/-/lex-data-0.1.1.tgz",
+      "integrity": "sha512-/xza8nU/YhtzhETnHL3QKKofaJ28/0NCzhT7LaYoUkm8EgypWp5ykEtmW52yLhQM2JF6fVa25g1soQmNTGqtSg==",
       "license": "MIT",
       "dependencies": {
-        "multiformats": "^9.9.0",
+        "multiformats": "^13.0.0",
         "tslib": "^2.8.1",
-        "uint8arrays": "3.0.0",
+        "uint8arrays": "^5.0.0",
         "unicode-segmenter": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@atproto/lex-document": {
-      "version": "0.0.21",
-      "resolved": "https://registry.npmjs.org/@atproto/lex-document/-/lex-document-0.0.21.tgz",
-      "integrity": "sha512-A437njagW01meDhAhT8L7y36jmYBaBCzuCBYwyfGYZjZdjoiwZU5W78k5tajKeJwTOLG/4NwfNVXhwy8gWQaAA==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@atproto/lex-document/-/lex-document-0.1.0.tgz",
+      "integrity": "sha512-I2q2iwK8RnSHkBeAj5xdJNYdHiUQqlkbbleBSJKJXlYOYy5y86dWRo9IfE0l9E3qZ3/zvy1ydlEZmZupEt0FGg==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/lex-schema": "^0.0.20",
+        "@atproto/lex-schema": "^0.1.0",
         "core-js": "^3",
         "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@atproto/lex-installer": {
-      "version": "0.0.26",
-      "resolved": "https://registry.npmjs.org/@atproto/lex-installer/-/lex-installer-0.0.26.tgz",
-      "integrity": "sha512-D48ywgbmDhTf6vcbQJi8tVjs5dhxmXqGidKr7qf4flZYALJLL1CEDvvl3Wa9pOtmcl66bAp1m0eVnuq/iu1LhA==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@atproto/lex-installer/-/lex-installer-0.1.0.tgz",
+      "integrity": "sha512-NXrJNe2qY4YreC82VgPE7stXnzSnI+xMeNXvgJDiMZj4MeSQeQn5ElFVd1yzRRV9sZREf6Y/HE+y1ffb2uewXA==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/lex-builder": "^0.0.23",
-        "@atproto/lex-cbor": "^0.0.16",
-        "@atproto/lex-data": "^0.0.15",
-        "@atproto/lex-document": "^0.0.21",
-        "@atproto/lex-resolver": "^0.0.23",
-        "@atproto/lex-schema": "^0.0.20",
-        "@atproto/syntax": "^0.5.4",
+        "@atproto/lex-builder": "^0.1.0",
+        "@atproto/lex-cbor": "^0.1.0",
+        "@atproto/lex-data": "^0.1.0",
+        "@atproto/lex-document": "^0.1.0",
+        "@atproto/lex-resolver": "^0.1.0",
+        "@atproto/lex-schema": "^0.1.0",
+        "@atproto/syntax": "^0.6.0",
         "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@atproto/lex-json": {
-      "version": "0.0.16",
-      "resolved": "https://registry.npmjs.org/@atproto/lex-json/-/lex-json-0.0.16.tgz",
-      "integrity": "sha512-IgLgQ0krshVlrIYZ+heTBDbCnM3LmAgWvsaYn5MxvKA3LcBot3PG3ptdO8VOweVZ+WgCLuo39cz9EbUmIbqdtg==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@atproto/lex-json/-/lex-json-0.1.0.tgz",
+      "integrity": "sha512-oWUrRMwFyWpmi/5k1Se3xBTbP06XdxBS5iFuUz9LmqItaPXwrWRD87a9ldPvINQ/A2/mn7J6/qug8sDVlhD+vQ==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/lex-data": "^0.0.15",
+        "@atproto/lex-data": "^0.1.0",
         "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@atproto/lex-resolver": {
-      "version": "0.0.23",
-      "resolved": "https://registry.npmjs.org/@atproto/lex-resolver/-/lex-resolver-0.0.23.tgz",
-      "integrity": "sha512-y0N0uopZl8Xen2MHPM+2ZYtFnyC/rNvOs/At15K2l6EL0LB6Efz58JRmvpR511TiH+0p3AOt/kGAjz5pkLCZgw==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@atproto/lex-resolver/-/lex-resolver-0.1.0.tgz",
+      "integrity": "sha512-zliMiRW4ttSNFreKxyvSpaYQjeWrKpV/lutnXI9BNE8Ysgnw8Rltm0bR7kG/y0OlyClxhhU/vAG+OR8NpjhU1Q==",
       "license": "MIT",
       "dependencies": {
-        "@atproto-labs/did-resolver": "^0.2.6",
-        "@atproto/crypto": "^0.4.5",
-        "@atproto/lex-client": "^0.0.21",
-        "@atproto/lex-data": "^0.0.15",
-        "@atproto/lex-document": "^0.0.21",
-        "@atproto/lex-schema": "^0.0.20",
-        "@atproto/repo": "^0.9.1",
-        "@atproto/syntax": "^0.5.4",
+        "@atproto-labs/did-resolver": "^0.3.0",
+        "@atproto/crypto": "^0.5.0",
+        "@atproto/lex-client": "^0.1.0",
+        "@atproto/lex-data": "^0.1.0",
+        "@atproto/lex-document": "^0.1.0",
+        "@atproto/lex-schema": "^0.1.0",
+        "@atproto/repo": "^0.10.0",
+        "@atproto/syntax": "^0.6.0",
         "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@atproto/lex-schema": {
-      "version": "0.0.20",
-      "resolved": "https://registry.npmjs.org/@atproto/lex-schema/-/lex-schema-0.0.20.tgz",
-      "integrity": "sha512-Q6BDt59A1XrLSDlMuxh6nyw8iNHIxmTpglC5fjVeEXYlntMBFBf4TmWjFotkThCdpcE3FPVVfpGGpU1bC6C9KQ==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@atproto/lex-schema/-/lex-schema-0.1.1.tgz",
+      "integrity": "sha512-/PX8q2Pd5PT9ozb9Pvw6gRifsGIU1LA/ccnu0IMyvstpCeAYyvdN6y0iHlUrzN0iSNTwStfA9H3hVaVaeZyDVQ==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/lex-data": "^0.0.15",
-        "@atproto/syntax": "^0.5.4",
+        "@atproto/lex-data": "^0.1.0",
+        "@atproto/syntax": "^0.6.1",
         "@standard-schema/spec": "^1.1.0",
-        "iso-datestring-validator": "^2.2.2",
         "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@atproto/repo": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@atproto/repo/-/repo-0.9.1.tgz",
-      "integrity": "sha512-++MUbILqVraIpTiTvixGZK9RK/fIfa2nQvRzT1mrSX6Kd/r1XKTzqz0wCfZkSNU+MsWmQPkvmmaykYBE00RSgg==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@atproto/repo/-/repo-0.10.0.tgz",
+      "integrity": "sha512-dGnU3R+geXepOZFIn3YUu6WaXLuT1NxqNvusR/JmAqPjjT6dT4tjouZeDPrumSnZm2f5Z8xMeDfVxpMWQ4stFw==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/common": "^0.5.16",
-        "@atproto/common-web": "^0.4.20",
-        "@atproto/crypto": "^0.4.5",
-        "@atproto/lex-cbor": "^0.0.16",
-        "@atproto/lex-data": "^0.0.15",
-        "@atproto/syntax": "^0.5.3",
+        "@atproto/common": "^0.6.0",
+        "@atproto/common-web": "^0.5.0",
+        "@atproto/crypto": "^0.5.0",
+        "@atproto/lex-cbor": "^0.1.0",
+        "@atproto/lex-data": "^0.1.0",
+        "@atproto/syntax": "^0.6.0",
         "varint": "^6.0.0",
         "zod": "^3.23.8"
       },
       "engines": {
-        "node": ">=18.7.0"
+        "node": ">=22"
       }
     },
     "node_modules/@atproto/syntax": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/@atproto/syntax/-/syntax-0.5.4.tgz",
-      "integrity": "sha512-9XJOpMAgsGFxMEIp8nJ8AIWv+krrY1xQMj+wULbbXhQztQV+9aZ0TbG9Jtn3Op2or8Kr6OqyWR4ga9Z189kKDw==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@atproto/syntax/-/syntax-0.6.1.tgz",
+      "integrity": "sha512-kA4dQDoMPpWCH8N0Q4KoSq024u5MkVfDVa8DdhyLjGA72z/khbOf1jXKPv7NIL2oEc9aj7geKELdvqyf4ogopA==",
       "license": "MIT",
       "dependencies": {
+        "iso-datestring-validator": "^2.2.2",
         "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@noble/curves": {
@@ -421,6 +476,15 @@
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/cborg": {
+      "version": "4.5.8",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-4.5.8.tgz",
+      "integrity": "sha512-6/viltD51JklRhq4L7jC3zgy6gryuG5xfZ3kzpE+PravtyeQLeQmCYLREhQH7pWENg5pY4Yu/XCd6a7dKScVlw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "cborg": "lib/bin.js"
       }
     },
     "node_modules/cliui": {
@@ -597,10 +661,10 @@
       }
     },
     "node_modules/multiformats": {
-      "version": "9.9.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
-      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==",
-      "license": "(Apache-2.0 AND MIT)"
+      "version": "13.4.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.4.2.tgz",
+      "integrity": "sha512-eh6eHCrRi1+POZ3dA+Dq1C6jhP1GNtr9CRINMb67OKzqW9I5DUuZM/3jLPlzhgpGeiNUlEGEbkCYChXMCc/8DQ==",
+      "license": "Apache-2.0 OR MIT"
     },
     "node_modules/on-exit-leak-free": {
       "version": "2.1.2",
@@ -861,12 +925,12 @@
       "license": "0BSD"
     },
     "node_modules/uint8arrays": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.0.0.tgz",
-      "integrity": "sha512-HRCx0q6O9Bfbp+HHSfQQKD7wU70+lydKVt4EghkdOvlK/NlrF90z+eXV34mUd48rNvVJXwkrMSPpCATkct8fJA==",
-      "license": "MIT",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.1.tgz",
+      "integrity": "sha512-9muQwa4wZG4dKi9gMAIBtnk2Pw87SRpvWTH6lOGm19V2Uqxr4uomUf2PGqPnWc+qs06sN8owUU4jfcoWOcfwVQ==",
+      "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "multiformats": "^9.4.2"
+        "multiformats": "^13.0.0"
       }
     },
     "node_modules/unicode-segmenter": {

--- a/generator/package.json
+++ b/generator/package.json
@@ -4,6 +4,6 @@
   "private": true,
   "description": "Pins the @atproto/lex release whose lexicon JSON is consumed by :generator. Not published.",
   "dependencies": {
-    "@atproto/lex": "0.0.26"
+    "@atproto/lex": "0.1.2"
   }
 }


### PR DESCRIPTION
## Lexicon corpus update

Bumps `@atproto/lex` from `0.0.26` to `0.1.2`.

### lexicons.json changes

**Added** (0):
- _(none)_

**Removed** (0):
- _(none)_

**Updated** (0):
- _(none)_

### What reviewers should check

- [ ] CI passes (generator regeneration, runtime tests, sample APK build)
- [ ] Skim the generator golden-file diff if any generator logic was affected
- [ ] Verify no new lexicon references are missing Kotlin types (compile failure in `:models`)

### Release impact

If this PR merges with only additive changes (new types, new fields), expect a `feat:` release. If it removes or renames anything, expect a `BREAKING CHANGE:` release — update the PR title to `feat!: bump @atproto/lex to <version>` before merging.