### PR TITLE
fix(oauth): cache PAR DPoP-Nonce and use it on first token exchange

### DIFF
--- a/oauth/src/main/kotlin/io/github/kikin81/atproto/oauth/AtOAuth.kt
+++ b/oauth/src/main/kotlin/io/github/kikin81/atproto/oauth/AtOAuth.kt
@@ -155,7 +155,7 @@ class AtOAuth(
         val codeChallenge = Pkce.computeChallenge(codeVerifier)
         val state = generateState()
 
-        val requestUri = pushAuthorizationRequest(
+        val parResult = pushAuthorizationRequest(
             metadata = metadata,
             signer = signer,
             codeChallenge = codeChallenge,
@@ -172,9 +172,10 @@ class AtOAuth(
             state = state,
             redirectUri = redirectUri,
             flowOrigin = flowOrigin,
+            authServerNonce = parResult.dpopNonce,
         )
 
-        return "${metadata.authorizationEndpoint}?client_id=$clientMetadataUrl&request_uri=$requestUri"
+        return "${metadata.authorizationEndpoint}?client_id=$clientMetadataUrl&request_uri=${parResult.requestUri}"
     }
 
     /**
@@ -217,6 +218,7 @@ class AtOAuth(
             code = code,
             codeVerifier = pending.codeVerifier,
             redirectUri = pending.redirectUri,
+            initialNonce = pending.authServerNonce,
         )
 
         val exported = pending.signer.exportKeyPair()
@@ -371,7 +373,7 @@ class AtOAuth(
         redirectUri: String,
         loginHint: String?,
         prompt: String?,
-    ): String {
+    ): ParResult {
         // First attempt: no nonce (expected to fail with use_dpop_nonce)
         val firstProof = signer.sign(method = "POST", url = metadata.parEndpoint)
         val firstResponse = httpClient.submitForm(
@@ -383,7 +385,7 @@ class AtOAuth(
 
         if (firstResponse.status == HttpStatusCode.OK) {
             val body = json.decodeFromString(ParResponse.serializer(), firstResponse.bodyAsText())
-            return body.request_uri
+            return ParResult(requestUri = body.request_uri, dpopNonce = firstResponse.headers["DPoP-Nonce"])
         }
 
         // Expected: 401 with use_dpop_nonce. Also calibrate the clock
@@ -408,7 +410,12 @@ class AtOAuth(
         }
 
         val body = json.decodeFromString(ParResponse.serializer(), retryResponse.bodyAsText())
-        return body.request_uri
+        // Prefer the nonce echoed on the successful retry; fall back to the one
+        // we just used (auth servers commonly keep the same nonce sticky).
+        return ParResult(
+            requestUri = body.request_uri,
+            dpopNonce = retryResponse.headers["DPoP-Nonce"] ?: nonce,
+        )
     }
 
     private fun parParams(
@@ -435,8 +442,14 @@ class AtOAuth(
         code: String,
         codeVerifier: String,
         redirectUri: String,
+        initialNonce: String?,
     ): TokenResponse {
-        val proof = signer.sign(method = "POST", url = metadata.tokenEndpoint)
+        // The authorization code is single-use: bsky.social's auth server
+        // consumes it even when it rejects the request for use_dpop_nonce.
+        // Sign the first proof with the nonce we captured from PAR so the
+        // first attempt succeeds; the retry below still covers the rare
+        // case where the nonce has rotated since PAR.
+        val proof = signer.sign(method = "POST", url = metadata.tokenEndpoint, nonce = initialNonce)
         val response = httpClient.submitForm(
             url = metadata.tokenEndpoint,
             formParameters = Parameters.build {
@@ -517,6 +530,12 @@ class AtOAuth(
         val state: String,
         val redirectUri: String,
         val flowOrigin: FlowOrigin,
+        val authServerNonce: String?,
+    )
+
+    private data class ParResult(
+        val requestUri: String,
+        val dpopNonce: String?,
     )
 }
 

--- a/oauth/src/main/kotlin/io/github/kikin81/atproto/oauth/AtOAuth.kt
+++ b/oauth/src/main/kotlin/io/github/kikin81/atproto/oauth/AtOAuth.kt
@@ -410,8 +410,9 @@ class AtOAuth(
         }
 
         val body = json.decodeFromString(ParResponse.serializer(), retryResponse.bodyAsText())
-        // Prefer the nonce echoed on the successful retry; fall back to the one
-        // we just used (auth servers commonly keep the same nonce sticky).
+        // Prefer the nonce echoed on the successful retry; the `?: nonce`
+        // fallback is defense-in-depth — atproto auth servers echo DPoP-Nonce
+        // on every response per the spec, so it should be unreachable.
         return ParResult(
             requestUri = body.request_uri,
             dpopNonce = retryResponse.headers["DPoP-Nonce"] ?: nonce,

--- a/oauth/src/test/kotlin/io/github/kikin81/atproto/oauth/AtOAuthTest.kt
+++ b/oauth/src/test/kotlin/io/github/kikin81/atproto/oauth/AtOAuthTest.kt
@@ -11,7 +11,13 @@ import io.ktor.http.headersOf
 import io.ktor.http.parseQueryString
 import io.ktor.utils.io.ByteReadChannel
 import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
 import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
@@ -998,10 +1004,13 @@ class AtOAuthTest {
         // code when the proof lacks a nonce; the subsequent retry returns
         // 400 invalid_grant. With the fix, the first /token request already
         // carries the PAR-issued nonce so the code survives.
+        // Verbatim from the issue #124 server-trace log — a real bsky.social
+        // DPoP-Nonce, so the assertion below pins the actual server-issued
+        // value rather than "any non-null string."
         val serverNonce = "BgT4Qx-dyAJVTGYC91DHu-jPX1XbrikVrr3prTDueOk"
         var tokenCallCount = 0
         var codeConsumed = false
-        var firstTokenAttemptHadNonce: Boolean? = null
+        var firstTokenAttemptNonce: String? = null
 
         val store = InMemorySessionStore()
         val client = HttpClient(
@@ -1011,7 +1020,7 @@ class AtOAuthTest {
                     url.contains("/par") -> {
                         // First PAR (no nonce in DPoP) -> 400 + nonce header,
                         // matching bsky.social's "use_dpop_nonce" cycle.
-                        if (!dpopProofHasNonce(request.headers["DPoP"])) {
+                        if (dpopProofNonce(request.headers["DPoP"]) == null) {
                             respond(
                                 ByteReadChannel("""{"error":"use_dpop_nonce"}"""),
                                 HttpStatusCode.BadRequest,
@@ -1034,13 +1043,13 @@ class AtOAuthTest {
 
                     url.contains("/token") -> {
                         tokenCallCount++
-                        val hasNonce = dpopProofHasNonce(request.headers["DPoP"])
-                        if (firstTokenAttemptHadNonce == null) firstTokenAttemptHadNonce = hasNonce
+                        val proofNonce = dpopProofNonce(request.headers["DPoP"])
+                        if (tokenCallCount == 1) firstTokenAttemptNonce = proofNonce
 
                         when {
                             // No nonce on the first attempt: this is the bug
                             // path — consume the code and return use_dpop_nonce.
-                            !hasNonce && !codeConsumed -> {
+                            proofNonce == null && !codeConsumed -> {
                                 codeConsumed = true
                                 respond(
                                     ByteReadChannel(
@@ -1089,8 +1098,8 @@ class AtOAuthTest {
         )
 
         assertEquals(
-            true,
-            firstTokenAttemptHadNonce,
+            serverNonce,
+            firstTokenAttemptNonce,
             "First /token request must carry the PAR-issued DPoP nonce, otherwise the auth-code gets burned",
         )
         assertEquals(1, tokenCallCount, "/token should be called exactly once when the cached nonce is still valid")
@@ -1101,17 +1110,24 @@ class AtOAuthTest {
     }
 
     /**
-     * Decodes the JWT payload of a DPoP proof and reports whether it carries
-     * a `nonce` claim. Used to assert what the SDK actually signs without
-     * relying on call-counting heuristics.
+     * Decodes the JWT payload of a DPoP proof and returns the value of its
+     * `nonce` claim, or null when no such claim is present.
+     *
+     * Errors on a missing or malformed header — production code always
+     * attaches a well-formed 3-part signed JWT, so a shape failure here is a
+     * real regression we want surfaced as a clear diagnostic rather than
+     * silently masked as "no nonce." Parses the payload as JSON so claims
+     * whose name merely contains `nonce` (`renonce`, `nonce_supported`, ...)
+     * don't produce false positives.
      */
-    private fun dpopProofHasNonce(header: String?): Boolean {
-        val h = header ?: return false
+    @OptIn(ExperimentalEncodingApi::class)
+    private fun dpopProofNonce(header: String?): String? {
+        val h = header ?: error("DPoP header missing on request")
         val parts = h.split('.')
-        if (parts.size != 3) return false
+        check(parts.size == 3) { "DPoP header is not a 3-part JWT: $h" }
         val padded = parts[1] + "=".repeat((4 - parts[1].length % 4) % 4)
-        val payload = String(java.util.Base64.getUrlDecoder().decode(padded))
-        return payload.contains("\"nonce\":")
+        val payload = Base64.UrlSafe.decode(padded).decodeToString()
+        return Json.parseToJsonElement(payload).jsonObject["nonce"]?.jsonPrimitive?.contentOrNull
     }
 
     /**

--- a/oauth/src/test/kotlin/io/github/kikin81/atproto/oauth/AtOAuthTest.kt
+++ b/oauth/src/test/kotlin/io/github/kikin81/atproto/oauth/AtOAuthTest.kt
@@ -985,6 +985,135 @@ class AtOAuthTest {
         assertContains(body, "prompt=create")
     }
 
+    @Test
+    fun tokenExchangeUsesParNonceOnFirstAttemptSoCodeIsNotBurned() = runTest {
+        // Regression for issue #124. bsky.social's auth server consumes the
+        // single-use authorization code on any token POST, even when it
+        // rejects the request for use_dpop_nonce. If exchangeCode signs the
+        // first proof without a nonce, the retry hits invalid_grant and login
+        // fails on every fresh attempt.
+        //
+        // This mock pins that exact state machine: PAR issues a sticky
+        // DPoP-Nonce; /token returns 400 + nonce header AND consumes the
+        // code when the proof lacks a nonce; the subsequent retry returns
+        // 400 invalid_grant. With the fix, the first /token request already
+        // carries the PAR-issued nonce so the code survives.
+        val serverNonce = "BgT4Qx-dyAJVTGYC91DHu-jPX1XbrikVrr3prTDueOk"
+        var tokenCallCount = 0
+        var codeConsumed = false
+        var firstTokenAttemptHadNonce: Boolean? = null
+
+        val store = InMemorySessionStore()
+        val client = HttpClient(
+            MockEngine { request ->
+                val url = request.url.toString()
+                respondToDiscovery(url) ?: when {
+                    url.contains("/par") -> {
+                        // First PAR (no nonce in DPoP) -> 400 + nonce header,
+                        // matching bsky.social's "use_dpop_nonce" cycle.
+                        if (!dpopProofHasNonce(request.headers["DPoP"])) {
+                            respond(
+                                ByteReadChannel("""{"error":"use_dpop_nonce"}"""),
+                                HttpStatusCode.BadRequest,
+                                headersOf(
+                                    HttpHeaders.ContentType to listOf("application/json"),
+                                    "DPoP-Nonce" to listOf(serverNonce),
+                                ),
+                            )
+                        } else {
+                            respond(
+                                ByteReadChannel("""{"request_uri":"urn:ietf:params:oauth:request_uri:par-ok","expires_in":3600}"""),
+                                HttpStatusCode.OK,
+                                headersOf(
+                                    HttpHeaders.ContentType to listOf("application/json"),
+                                    "DPoP-Nonce" to listOf(serverNonce),
+                                ),
+                            )
+                        }
+                    }
+
+                    url.contains("/token") -> {
+                        tokenCallCount++
+                        val hasNonce = dpopProofHasNonce(request.headers["DPoP"])
+                        if (firstTokenAttemptHadNonce == null) firstTokenAttemptHadNonce = hasNonce
+
+                        when {
+                            // No nonce on the first attempt: this is the bug
+                            // path — consume the code and return use_dpop_nonce.
+                            !hasNonce && !codeConsumed -> {
+                                codeConsumed = true
+                                respond(
+                                    ByteReadChannel(
+                                        """{"error":"use_dpop_nonce","error_description":"Authorization server requires nonce in DPoP proof"}""",
+                                    ),
+                                    HttpStatusCode.BadRequest,
+                                    headersOf(
+                                        HttpHeaders.ContentType to listOf("application/json"),
+                                        "DPoP-Nonce" to listOf(serverNonce),
+                                    ),
+                                )
+                            }
+                            // Retry after the code was burned: invalid_grant.
+                            codeConsumed -> respond(
+                                ByteReadChannel(
+                                    """{"error":"invalid_grant","error_description":"Invalid code"}""",
+                                ),
+                                HttpStatusCode.BadRequest,
+                                jsonHeaders,
+                            )
+                            // First attempt already carries the nonce — happy path.
+                            else -> respond(
+                                ByteReadChannel(
+                                    """{"access_token":"at_124","refresh_token":"rt_124","token_type":"DPoP","expires_in":3600,"sub":"did:plc:testuser"}""",
+                                ),
+                                HttpStatusCode.OK,
+                                jsonHeaders,
+                            )
+                        }
+                    }
+
+                    else -> respond(ByteReadChannel(""), HttpStatusCode.NotFound)
+                }
+            },
+        )
+
+        val oauth = AtOAuth(
+            clientMetadataUrl = "https://app.test/oauth/client-metadata.json",
+            redirectUri = "app.example:/oauth-redirect",
+            sessionStore = store,
+            httpClient = client,
+        )
+        oauth.beginLogin("alice.test")
+        oauth.completeLogin(
+            "app.example:/oauth-redirect?code=auth_code_124&state=${extractState(oauth)}&iss=https://auth.test",
+        )
+
+        assertEquals(
+            true,
+            firstTokenAttemptHadNonce,
+            "First /token request must carry the PAR-issued DPoP nonce, otherwise the auth-code gets burned",
+        )
+        assertEquals(1, tokenCallCount, "/token should be called exactly once when the cached nonce is still valid")
+        assertEquals(false, codeConsumed, "code must not be burned by a doomed no-nonce probe")
+        val session = store.session
+        assertNotNull(session)
+        assertEquals("at_124", session.accessToken)
+    }
+
+    /**
+     * Decodes the JWT payload of a DPoP proof and reports whether it carries
+     * a `nonce` claim. Used to assert what the SDK actually signs without
+     * relying on call-counting heuristics.
+     */
+    private fun dpopProofHasNonce(header: String?): Boolean {
+        val h = header ?: return false
+        val parts = h.split('.')
+        if (parts.size != 3) return false
+        val padded = parts[1] + "=".repeat((4 - parts[1].length % 4) % 4)
+        val payload = String(java.util.Base64.getUrlDecoder().decode(padded))
+        return payload.contains("\"nonce\":")
+    }
+
     /**
      * Extracts the state from a pending AtOAuth instance via reflection.
      * Only for testing — production consumers don't access internal state.


### PR DESCRIPTION
## Summary

- `AtOAuth.exchangeCode` signed its first DPoP proof against the token endpoint with `nonce = null`. bsky.social's auth server **consumes the single-use authorization code** on that doomed first POST, so the retry-with-nonce always hits `invalid_grant: Invalid code` and every fresh login fails.
- Capture the `DPoP-Nonce` from the PAR response, thread it through `PendingAuthState`, and sign the first token-exchange proof with it. The existing 400/401 + `DPoP-Nonce` retry path still covers the rare case where the server rotates the nonce between PAR and token exchange.

Fixes #124.

## Test plan

- [x] New regression test `tokenExchangeUsesParNonceOnFirstAttemptSoCodeIsNotBurned` in `AtOAuthTest.kt` reproduces bsky.social's state machine: PAR issues a sticky `DPoP-Nonce`; `/token` returns `400 use_dpop_nonce` **and** burns the code when the proof has no nonce; the retry returns `400 invalid_grant`. The test base64url-decodes the JWT payload (via a new `dpopProofHasNonce` helper) so it asserts what the SDK actually signs, not just call counts. Asserts: first `/token` request carries a nonce, `/token` is called exactly once, the code is never consumed, and the session is persisted.
- [x] `./gradlew :oauth:test` — all tests pass, including the existing full-flow and signup-flow tests (their mocks don't set `DPoP-Nonce`, so `initialNonce` is `null` and behavior is unchanged).
- [x] `./gradlew :oauth:spotlessCheck` — clean.
- [ ] Manual verification against bsky.social from the affected app once a `9.0.2` snapshot is available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)