### PR TITLE
fix(generator): dereference ref-to-array-of-union defs instead of JsonObject (#132)

### DIFF
--- a/generator/src/main/kotlin/io/github/kikin81/atproto/generator/emit/CodeGenerator.kt
+++ b/generator/src/main/kotlin/io/github/kikin81/atproto/generator/emit/CodeGenerator.kt
@@ -60,7 +60,7 @@ public class CodeGenerator(
         // consumers can pass a CollisionOverrides to repair known
         // collisions with a per-pair rename map.
         VerificationPass().verify(buildVerificationInput(plan, services), overrides)
-        val typeResolver = TypeResolver(plan)
+        val typeResolver = TypeResolver(plan, symbols)
         val models = ModelGenerator(plan, typeResolver, contexts)
         val unions = UnionGenerator(plan)
         val xrpc = XrpcGenerator(plan, models)

--- a/generator/src/main/kotlin/io/github/kikin81/atproto/generator/emit/EmissionPlan.kt
+++ b/generator/src/main/kotlin/io/github/kikin81/atproto/generator/emit/EmissionPlan.kt
@@ -1,5 +1,6 @@
 package io.github.kikin81.atproto.generator.emit
 
+import io.github.kikin81.atproto.generator.ir.ArrayDefTopLevel
 import io.github.kikin81.atproto.generator.ir.ArrayType
 import io.github.kikin81.atproto.generator.ir.Definition
 import io.github.kikin81.atproto.generator.ir.FieldType
@@ -10,6 +11,7 @@ import io.github.kikin81.atproto.generator.ir.ParamsDefTopLevel
 import io.github.kikin81.atproto.generator.ir.ProcedureDef
 import io.github.kikin81.atproto.generator.ir.QueryDef
 import io.github.kikin81.atproto.generator.ir.RecordDef
+import io.github.kikin81.atproto.generator.ir.RefType
 import io.github.kikin81.atproto.generator.ir.SubscriptionDef
 import io.github.kikin81.atproto.generator.ir.UnionType
 import io.github.kikin81.atproto.generator.naming.EmittedClass
@@ -163,7 +165,7 @@ public class EmissionPlan(
 
             for (key in symbols.keys) {
                 val def = symbols.get(key) ?: continue
-                collectFromDef(def, key, classMap, unionSites, membership)
+                collectFromDef(def, key, classMap, unionSites, membership, symbols)
             }
 
             // Sort union sites deterministically by (owner, fieldName).
@@ -182,6 +184,7 @@ public class EmissionPlan(
             classMap: Map<DefKey, List<EmittedClass>>,
             sites: MutableList<UnionSite>,
             membership: MutableMap<DefKey, MutableSet<FqName>>,
+            symbols: SymbolTable,
         ) {
             val origin = key.nsid
             fun owner(role: NameRole): FqName? = classMap[key]?.firstOrNull { it.role == role }?.fqName
@@ -189,13 +192,13 @@ public class EmissionPlan(
 
             when (def) {
                 is ObjectDef -> primary?.let {
-                    collectFromProperties(def.properties, origin, it, sites, membership, classMap)
+                    collectFromProperties(def.properties, origin, it, sites, membership, classMap, symbols)
                 }
                 is ParamsDefTopLevel -> primary?.let {
-                    collectFromProperties(def.properties, origin, it, sites, membership, classMap)
+                    collectFromProperties(def.properties, origin, it, sites, membership, classMap, symbols)
                 }
                 is RecordDef -> primary?.let {
-                    collectFromProperties(def.record.properties, origin, it, sites, membership, classMap)
+                    collectFromProperties(def.record.properties, origin, it, sites, membership, classMap, symbols)
                 }
                 is QueryDef -> {
                     // Parameters go into the Request class; output goes into Response.
@@ -203,12 +206,12 @@ public class EmissionPlan(
                     val resp = owner(NameRole.Response)
                     if (req != null) {
                         def.parameters?.let {
-                            collectFromProperties(it.properties, origin, req, sites, membership, classMap)
+                            collectFromProperties(it.properties, origin, req, sites, membership, classMap, symbols)
                         }
                     }
                     if (resp != null) {
                         def.output?.let { body ->
-                            collectFromHttpBody(body, origin, resp, sites, membership, classMap)
+                            collectFromHttpBody(body, origin, resp, sites, membership, classMap, symbols)
                         }
                     }
                 }
@@ -217,15 +220,15 @@ public class EmissionPlan(
                     val resp = owner(NameRole.Response)
                     if (req != null) {
                         def.parameters?.let {
-                            collectFromProperties(it.properties, origin, req, sites, membership, classMap)
+                            collectFromProperties(it.properties, origin, req, sites, membership, classMap, symbols)
                         }
                         def.input?.let { body ->
-                            collectFromHttpBody(body, origin, req, sites, membership, classMap)
+                            collectFromHttpBody(body, origin, req, sites, membership, classMap, symbols)
                         }
                     }
                     if (resp != null) {
                         def.output?.let { body ->
-                            collectFromHttpBody(body, origin, resp, sites, membership, classMap)
+                            collectFromHttpBody(body, origin, resp, sites, membership, classMap, symbols)
                         }
                     }
                 }
@@ -241,10 +244,11 @@ public class EmissionPlan(
             sites: MutableList<UnionSite>,
             membership: MutableMap<DefKey, MutableSet<FqName>>,
             classMap: Map<DefKey, List<EmittedClass>>,
+            symbols: SymbolTable,
         ) {
             val schema = body.schema ?: return
             if (schema is ObjectType) {
-                collectFromProperties(schema.properties, origin, ownerFqName, sites, membership, classMap)
+                collectFromProperties(schema.properties, origin, ownerFqName, sites, membership, classMap, symbols)
             }
         }
 
@@ -255,10 +259,11 @@ public class EmissionPlan(
             sites: MutableList<UnionSite>,
             membership: MutableMap<DefKey, MutableSet<FqName>>,
             classMap: Map<DefKey, List<EmittedClass>>,
+            symbols: SymbolTable,
         ) {
             val sortedProps = props.toSortedMap()
             for ((fieldName, ft) in sortedProps) {
-                collectFromFieldType(ft, fieldName, origin, ownerFqName, sites, membership, classMap)
+                collectFromFieldType(ft, fieldName, origin, ownerFqName, sites, membership, classMap, symbols)
             }
         }
 
@@ -270,6 +275,7 @@ public class EmissionPlan(
             sites: MutableList<UnionSite>,
             membership: MutableMap<DefKey, MutableSet<FqName>>,
             classMap: Map<DefKey, List<EmittedClass>>,
+            symbols: SymbolTable,
         ) {
             when (ft) {
                 is UnionType -> {
@@ -305,7 +311,32 @@ public class EmissionPlan(
                     sites,
                     membership,
                     classMap,
+                    symbols,
                 )
+                is RefType -> {
+                    // A field whose `type: ref` points at a top-level
+                    // `type: array` def (e.g. app.bsky.actor.defs#preferences) is
+                    // a transparent typedef: dereference it and recurse on the
+                    // array's item type so any nested union still synthesizes a
+                    // UnionSite owned by (ownerFqName, fieldName). The array def's
+                    // item refs are local to its own file, so recurse under the
+                    // target's NSID. See issue #132. (TypeResolver mirrors this to
+                    // emit `List<...Union>` instead of falling back to JsonObject.)
+                    val target = DefKey.resolve(ft.ref, origin)
+                    val targetDef = symbols.get(target)
+                    if (targetDef is ArrayDefTopLevel) {
+                        collectFromFieldType(
+                            targetDef.items,
+                            fieldName,
+                            target.nsid,
+                            ownerFqName,
+                            sites,
+                            membership,
+                            classMap,
+                            symbols,
+                        )
+                    }
+                }
                 else -> Unit
             }
         }

--- a/generator/src/main/kotlin/io/github/kikin81/atproto/generator/emit/ServiceGenerator.kt
+++ b/generator/src/main/kotlin/io/github/kikin81/atproto/generator/emit/ServiceGenerator.kt
@@ -494,7 +494,7 @@ public class ServiceGenerator(
         val requestCn = ClassName(requestClass.fqName.pkg, requestClass.fqName.simpleName)
         val responseCn = ClassName(responseClass.fqName.pkg, responseClass.fqName.simpleName)
 
-        val typeResolver = TypeResolver(plan)
+        val typeResolver = TypeResolver(plan, symbols)
         val itemType = typeResolver.resolve(itemsArrayType.items, defKey.nsid, responseClass.fqName, itemsFieldName)
 
         val methodName = defKey.nsid.raw.substringAfterLast('.')

--- a/generator/src/main/kotlin/io/github/kikin81/atproto/generator/emit/TypeResolver.kt
+++ b/generator/src/main/kotlin/io/github/kikin81/atproto/generator/emit/TypeResolver.kt
@@ -9,6 +9,7 @@ import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.STRING
 import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.UNIT
+import io.github.kikin81.atproto.generator.ir.ArrayDefTopLevel
 import io.github.kikin81.atproto.generator.ir.ArrayType
 import io.github.kikin81.atproto.generator.ir.BlobType
 import io.github.kikin81.atproto.generator.ir.BooleanType
@@ -26,6 +27,7 @@ import io.github.kikin81.atproto.generator.ir.UnionType
 import io.github.kikin81.atproto.generator.ir.UnknownType
 import io.github.kikin81.atproto.generator.resolved.DefKey
 import io.github.kikin81.atproto.generator.resolved.Nsid
+import io.github.kikin81.atproto.generator.resolved.SymbolTable
 
 internal val RUNTIME_PKG = "io.github.kikin81.atproto.runtime"
 internal val DID = ClassName(RUNTIME_PKG, "Did")
@@ -53,6 +55,7 @@ internal val JSON_OBJECT = ClassName("kotlinx.serialization.json", "JsonObject")
  */
 public class TypeResolver(
     private val plan: EmissionPlan,
+    private val symbols: SymbolTable,
 ) {
     /**
      * Resolve a field type at [origin]. [ownerFqName] and [fieldName] are
@@ -85,8 +88,18 @@ public class TypeResolver(
             if (fq != null) {
                 ClassName(fq.pkg, fq.simpleName)
             } else {
-                System.err.println("[warn] ref '${ft.ref}' (target $target) has no emitted class; using JsonObject")
-                JSON_OBJECT
+                // A top-level `type: array` def is a transparent typedef and
+                // emits no class, so it has no primary FqName. Dereference it and
+                // resolve its item type under the target's NSID — yielding
+                // `List<...>` (e.g. `List<...Union>` for an array of a union)
+                // instead of silently collapsing to JsonObject. See issue #132.
+                val targetDef = symbols.get(target)
+                if (targetDef is ArrayDefTopLevel) {
+                    LIST.parameterizedBy(resolve(targetDef.items, target.nsid, ownerFqName, fieldName))
+                } else {
+                    System.err.println("[warn] ref '${ft.ref}' (target $target) has no emitted class; using JsonObject")
+                    JSON_OBJECT
+                }
             }
         }
         is UnionType -> {

--- a/generator/src/test/kotlin/io/github/kikin81/atproto/generator/emit/CodeGeneratorTest.kt
+++ b/generator/src/test/kotlin/io/github/kikin81/atproto/generator/emit/CodeGeneratorTest.kt
@@ -217,6 +217,69 @@ class CodeGeneratorTest {
         }
     """.trimIndent()
 
+    // Reproduces issue #132: a property whose `type: ref` points at a top-level
+    // def that is itself `type: array` (of a union). The defs file holds the
+    // array-of-union typedef plus its member object defs; the query refs it.
+    private val refToArrayOfUnionDefsJson = """
+        {
+          "lexicon": 1,
+          "id": "app.bsky.actor.defs",
+          "defs": {
+            "preferences": {
+              "type": "array",
+              "items": {
+                "type": "union",
+                "refs": [
+                  "app.bsky.actor.defs#adultContentPref",
+                  "app.bsky.actor.defs#contentLabelPref"
+                ]
+              }
+            },
+            "adultContentPref": {
+              "type": "object",
+              "required": ["enabled"],
+              "properties": {
+                "enabled": { "type": "boolean" }
+              }
+            },
+            "contentLabelPref": {
+              "type": "object",
+              "required": ["label", "visibility"],
+              "properties": {
+                "label": { "type": "string" },
+                "visibility": { "type": "string" }
+              }
+            }
+          }
+        }
+    """.trimIndent()
+
+    private val getPreferencesQueryJson = """
+        {
+          "lexicon": 1,
+          "id": "app.bsky.actor.getPreferences",
+          "defs": {
+            "main": {
+              "type": "query",
+              "parameters": { "type": "params", "properties": {} },
+              "output": {
+                "encoding": "application/json",
+                "schema": {
+                  "type": "object",
+                  "required": ["preferences"],
+                  "properties": {
+                    "preferences": {
+                      "type": "ref",
+                      "ref": "app.bsky.actor.defs#preferences"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+    """.trimIndent()
+
     private val subscriptionJson = """
         {
           "lexicon": 1,
@@ -344,6 +407,41 @@ class CodeGeneratorTest {
         assertNotNull(images)
         val imagesStr = images.toString()
         assertTrue("PostEmbedUnion" in imagesStr, "PostImages must extend PostEmbedUnion:\n$imagesStr")
+    }
+
+    @Test
+    fun `ref to a top-level array-of-union def emits List of a synthesized union (issue 132)`() {
+        val files = generate(refToArrayOfUnionDefsJson, getPreferencesQueryJson)
+        val text = renderAll(files)
+
+        // The response property `preferences` is `type: ref` -> a top-level
+        // `type: array` def of a union. It must dereference to `List<...Union>`,
+        // NOT collapse to JsonObject.
+        val resp = files.firstOrNull { it.name == "GetPreferencesResponse" }
+        assertNotNull(resp, "missing GetPreferencesResponse\n$text")
+        val respStr = resp.toString()
+        assertTrue(
+            "preferences: List<" in respStr,
+            "preferences must be a List of the synthesized union, not JsonObject:\n$respStr",
+        )
+        assertTrue("JsonObject" !in respStr, "preferences must not fall back to JsonObject:\n$respStr")
+
+        // A union sealed interface is synthesized for the field, owned by the
+        // Response class: `GetPreferencesResponse` + `Preferences` + `Union`.
+        val union = files.firstOrNull { it.name == "GetPreferencesResponsePreferencesUnion" }
+        assertNotNull(union, "missing synthesized union file\n$text")
+        val unionStr = union.toString()
+        assertTrue("interface GetPreferencesResponsePreferencesUnion" in unionStr, unionStr)
+        assertTrue("app.bsky.actor.defs#adultContentPref" in unionStr, unionStr)
+        assertTrue("app.bsky.actor.defs#contentLabelPref" in unionStr, unionStr)
+
+        // The member pref classes extend the synthesized union.
+        val adult = files.firstOrNull { it.name == "AdultContentPref" }
+        assertNotNull(adult, "missing AdultContentPref\n$text")
+        assertTrue(
+            "GetPreferencesResponsePreferencesUnion" in adult.toString(),
+            "AdultContentPref must extend the synthesized union:\n$adult",
+        )
     }
 
     @Test

--- a/models/api/models.api
+++ b/models/api/models.api
@@ -27,7 +27,7 @@ public final class io/github/kikin81/atproto/app/bsky/actor/ActorServiceKt {
 	public static synthetic fun suggestionsPageFlow$default (Lio/github/kikin81/atproto/app/bsky/actor/ActorService;Lio/github/kikin81/atproto/app/bsky/actor/GetSuggestionsRequest;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
 }
 
-public final class io/github/kikin81/atproto/app/bsky/actor/AdultContentPref {
+public final class io/github/kikin81/atproto/app/bsky/actor/AdultContentPref : io/github/kikin81/atproto/app/bsky/actor/GetPreferencesResponsePreferencesUnion, io/github/kikin81/atproto/app/bsky/actor/PutPreferencesRequestPreferencesUnion {
 	public static final field Companion Lio/github/kikin81/atproto/app/bsky/actor/AdultContentPref$Companion;
 	public fun <init> (Z)V
 	public final fun component1 ()Z
@@ -81,7 +81,7 @@ public final class io/github/kikin81/atproto/app/bsky/actor/BskyAppProgressGuide
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class io/github/kikin81/atproto/app/bsky/actor/BskyAppStatePref {
+public final class io/github/kikin81/atproto/app/bsky/actor/BskyAppStatePref : io/github/kikin81/atproto/app/bsky/actor/GetPreferencesResponsePreferencesUnion, io/github/kikin81/atproto/app/bsky/actor/PutPreferencesRequestPreferencesUnion {
 	public static final field Companion Lio/github/kikin81/atproto/app/bsky/actor/BskyAppStatePref$Companion;
 	public fun <init> ()V
 	public fun <init> (Lio/github/kikin81/atproto/app/bsky/actor/BskyAppProgressGuide;Ljava/util/List;Ljava/util/List;)V
@@ -114,7 +114,7 @@ public final class io/github/kikin81/atproto/app/bsky/actor/BskyAppStatePref$Com
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class io/github/kikin81/atproto/app/bsky/actor/ContentLabelPref {
+public final class io/github/kikin81/atproto/app/bsky/actor/ContentLabelPref : io/github/kikin81/atproto/app/bsky/actor/GetPreferencesResponsePreferencesUnion, io/github/kikin81/atproto/app/bsky/actor/PutPreferencesRequestPreferencesUnion {
 	public static final field Companion Lio/github/kikin81/atproto/app/bsky/actor/ContentLabelPref$Companion;
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -146,7 +146,7 @@ public final class io/github/kikin81/atproto/app/bsky/actor/ContentLabelPref$Com
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class io/github/kikin81/atproto/app/bsky/actor/DeclaredAgePref {
+public final class io/github/kikin81/atproto/app/bsky/actor/DeclaredAgePref : io/github/kikin81/atproto/app/bsky/actor/GetPreferencesResponsePreferencesUnion, io/github/kikin81/atproto/app/bsky/actor/PutPreferencesRequestPreferencesUnion {
 	public static final field Companion Lio/github/kikin81/atproto/app/bsky/actor/DeclaredAgePref$Companion;
 	public fun <init> ()V
 	public fun <init> (Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;)V
@@ -179,7 +179,7 @@ public final class io/github/kikin81/atproto/app/bsky/actor/DeclaredAgePref$Comp
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class io/github/kikin81/atproto/app/bsky/actor/FeedViewPref {
+public final class io/github/kikin81/atproto/app/bsky/actor/FeedViewPref : io/github/kikin81/atproto/app/bsky/actor/GetPreferencesResponsePreferencesUnion, io/github/kikin81/atproto/app/bsky/actor/PutPreferencesRequestPreferencesUnion {
 	public static final field Companion Lio/github/kikin81/atproto/app/bsky/actor/FeedViewPref$Companion;
 	public fun <init> (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/lang/Boolean;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -239,12 +239,12 @@ public final class io/github/kikin81/atproto/app/bsky/actor/GetPreferencesReques
 
 public final class io/github/kikin81/atproto/app/bsky/actor/GetPreferencesResponse {
 	public static final field Companion Lio/github/kikin81/atproto/app/bsky/actor/GetPreferencesResponse$Companion;
-	public fun <init> (Lkotlinx/serialization/json/JsonObject;)V
-	public final fun component1 ()Lkotlinx/serialization/json/JsonObject;
-	public final fun copy (Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/app/bsky/actor/GetPreferencesResponse;
-	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/actor/GetPreferencesResponse;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/actor/GetPreferencesResponse;
+	public fun <init> (Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lio/github/kikin81/atproto/app/bsky/actor/GetPreferencesResponse;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/actor/GetPreferencesResponse;Ljava/util/List;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/actor/GetPreferencesResponse;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getPreferences ()Lkotlinx/serialization/json/JsonObject;
+	public final fun getPreferences ()Ljava/util/List;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -262,6 +262,46 @@ public final synthetic class io/github/kikin81/atproto/app/bsky/actor/GetPrefere
 
 public final class io/github/kikin81/atproto/app/bsky/actor/GetPreferencesResponse$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class io/github/kikin81/atproto/app/bsky/actor/GetPreferencesResponsePreferencesUnion : io/github/kikin81/atproto/runtime/OpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/actor/GetPreferencesResponsePreferencesUnion$Companion;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/GetPreferencesResponsePreferencesUnion$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/GetPreferencesResponsePreferencesUnion$Unknown : io/github/kikin81/atproto/app/bsky/actor/GetPreferencesResponsePreferencesUnion, io/github/kikin81/atproto/runtime/UnknownOpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/actor/GetPreferencesResponsePreferencesUnion$Unknown$Companion;
+	public fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/app/bsky/actor/GetPreferencesResponsePreferencesUnion$Unknown;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/actor/GetPreferencesResponsePreferencesUnion$Unknown;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/actor/GetPreferencesResponsePreferencesUnion$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getRaw ()Lkotlinx/serialization/json/JsonObject;
+	public fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/GetPreferencesResponsePreferencesUnion$Unknown$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/GetPreferencesResponsePreferencesUnionSerializer : io/github/kikin81/atproto/runtime/OpenUnionSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/actor/GetPreferencesResponsePreferencesUnionSerializer;
+	public fun selectKnownDeserializer (Ljava/lang/String;)Lkotlinx/serialization/KSerializer;
+	public fun selectKnownSerializer (Lio/github/kikin81/atproto/app/bsky/actor/GetPreferencesResponsePreferencesUnion;)Lkotlinx/serialization/KSerializer;
+	public synthetic fun selectKnownSerializer (Lio/github/kikin81/atproto/runtime/OpenUnionMember;)Lkotlinx/serialization/KSerializer;
+	public fun unknownSerializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/GetPreferencesResponsePreferencesUnionUnknownSerializer : io/github/kikin81/atproto/runtime/UnknownMemberSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/actor/GetPreferencesResponsePreferencesUnionUnknownSerializer;
+	public fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/app/bsky/actor/GetPreferencesResponsePreferencesUnion$Unknown;
+	public synthetic fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/runtime/UnknownOpenUnionMember;
 }
 
 public final class io/github/kikin81/atproto/app/bsky/actor/GetProfileRequest {
@@ -410,7 +450,7 @@ public final class io/github/kikin81/atproto/app/bsky/actor/GetSuggestionsRespon
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class io/github/kikin81/atproto/app/bsky/actor/HiddenPostsPref {
+public final class io/github/kikin81/atproto/app/bsky/actor/HiddenPostsPref : io/github/kikin81/atproto/app/bsky/actor/GetPreferencesResponsePreferencesUnion, io/github/kikin81/atproto/app/bsky/actor/PutPreferencesRequestPreferencesUnion {
 	public static final field Companion Lio/github/kikin81/atproto/app/bsky/actor/HiddenPostsPref$Companion;
 	public fun <init> (Ljava/util/List;)V
 	public final fun component1 ()Ljava/util/List;
@@ -437,7 +477,7 @@ public final class io/github/kikin81/atproto/app/bsky/actor/HiddenPostsPref$Comp
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class io/github/kikin81/atproto/app/bsky/actor/InterestsPref {
+public final class io/github/kikin81/atproto/app/bsky/actor/InterestsPref : io/github/kikin81/atproto/app/bsky/actor/GetPreferencesResponsePreferencesUnion, io/github/kikin81/atproto/app/bsky/actor/PutPreferencesRequestPreferencesUnion {
 	public static final field Companion Lio/github/kikin81/atproto/app/bsky/actor/InterestsPref$Companion;
 	public fun <init> (Ljava/util/List;)V
 	public final fun component1 ()Ljava/util/List;
@@ -520,7 +560,7 @@ public final class io/github/kikin81/atproto/app/bsky/actor/LabelerPrefItem$Comp
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class io/github/kikin81/atproto/app/bsky/actor/LabelersPref {
+public final class io/github/kikin81/atproto/app/bsky/actor/LabelersPref : io/github/kikin81/atproto/app/bsky/actor/GetPreferencesResponsePreferencesUnion, io/github/kikin81/atproto/app/bsky/actor/PutPreferencesRequestPreferencesUnion {
 	public static final field Companion Lio/github/kikin81/atproto/app/bsky/actor/LabelersPref$Companion;
 	public fun <init> (Ljava/util/List;)V
 	public final fun component1 ()Ljava/util/List;
@@ -547,7 +587,7 @@ public final class io/github/kikin81/atproto/app/bsky/actor/LabelersPref$Compani
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class io/github/kikin81/atproto/app/bsky/actor/LiveEventPreferences {
+public final class io/github/kikin81/atproto/app/bsky/actor/LiveEventPreferences : io/github/kikin81/atproto/app/bsky/actor/GetPreferencesResponsePreferencesUnion, io/github/kikin81/atproto/app/bsky/actor/PutPreferencesRequestPreferencesUnion {
 	public static final field Companion Lio/github/kikin81/atproto/app/bsky/actor/LiveEventPreferences$Companion;
 	public fun <init> ()V
 	public fun <init> (Ljava/util/List;Ljava/lang/Boolean;)V
@@ -614,7 +654,7 @@ public final class io/github/kikin81/atproto/app/bsky/actor/MutedWord$Companion 
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class io/github/kikin81/atproto/app/bsky/actor/MutedWordsPref {
+public final class io/github/kikin81/atproto/app/bsky/actor/MutedWordsPref : io/github/kikin81/atproto/app/bsky/actor/GetPreferencesResponsePreferencesUnion, io/github/kikin81/atproto/app/bsky/actor/PutPreferencesRequestPreferencesUnion {
 	public static final field Companion Lio/github/kikin81/atproto/app/bsky/actor/MutedWordsPref$Companion;
 	public fun <init> (Ljava/util/List;)V
 	public final fun component1 ()Ljava/util/List;
@@ -675,7 +715,7 @@ public final class io/github/kikin81/atproto/app/bsky/actor/Nux$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class io/github/kikin81/atproto/app/bsky/actor/PersonalDetailsPref {
+public final class io/github/kikin81/atproto/app/bsky/actor/PersonalDetailsPref : io/github/kikin81/atproto/app/bsky/actor/GetPreferencesResponsePreferencesUnion, io/github/kikin81/atproto/app/bsky/actor/PutPreferencesRequestPreferencesUnion {
 	public static final field Companion Lio/github/kikin81/atproto/app/bsky/actor/PersonalDetailsPref$Companion;
 	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -703,7 +743,7 @@ public final class io/github/kikin81/atproto/app/bsky/actor/PersonalDetailsPref$
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class io/github/kikin81/atproto/app/bsky/actor/PostInteractionSettingsPref {
+public final class io/github/kikin81/atproto/app/bsky/actor/PostInteractionSettingsPref : io/github/kikin81/atproto/app/bsky/actor/GetPreferencesResponsePreferencesUnion, io/github/kikin81/atproto/app/bsky/actor/PutPreferencesRequestPreferencesUnion {
 	public static final field Companion Lio/github/kikin81/atproto/app/bsky/actor/PostInteractionSettingsPref$Companion;
 	public fun <init> ()V
 	public fun <init> (Ljava/util/List;Ljava/util/List;)V
@@ -1199,12 +1239,12 @@ public final class io/github/kikin81/atproto/app/bsky/actor/ProfileViewDetailed$
 
 public final class io/github/kikin81/atproto/app/bsky/actor/PutPreferencesRequest {
 	public static final field Companion Lio/github/kikin81/atproto/app/bsky/actor/PutPreferencesRequest$Companion;
-	public fun <init> (Lkotlinx/serialization/json/JsonObject;)V
-	public final fun component1 ()Lkotlinx/serialization/json/JsonObject;
-	public final fun copy (Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/app/bsky/actor/PutPreferencesRequest;
-	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/actor/PutPreferencesRequest;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/actor/PutPreferencesRequest;
+	public fun <init> (Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lio/github/kikin81/atproto/app/bsky/actor/PutPreferencesRequest;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/actor/PutPreferencesRequest;Ljava/util/List;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/actor/PutPreferencesRequest;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getPreferences ()Lkotlinx/serialization/json/JsonObject;
+	public final fun getPreferences ()Ljava/util/List;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -1222,6 +1262,46 @@ public final synthetic class io/github/kikin81/atproto/app/bsky/actor/PutPrefere
 
 public final class io/github/kikin81/atproto/app/bsky/actor/PutPreferencesRequest$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class io/github/kikin81/atproto/app/bsky/actor/PutPreferencesRequestPreferencesUnion : io/github/kikin81/atproto/runtime/OpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/actor/PutPreferencesRequestPreferencesUnion$Companion;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/PutPreferencesRequestPreferencesUnion$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/PutPreferencesRequestPreferencesUnion$Unknown : io/github/kikin81/atproto/app/bsky/actor/PutPreferencesRequestPreferencesUnion, io/github/kikin81/atproto/runtime/UnknownOpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/actor/PutPreferencesRequestPreferencesUnion$Unknown$Companion;
+	public fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/app/bsky/actor/PutPreferencesRequestPreferencesUnion$Unknown;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/actor/PutPreferencesRequestPreferencesUnion$Unknown;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/actor/PutPreferencesRequestPreferencesUnion$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getRaw ()Lkotlinx/serialization/json/JsonObject;
+	public fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/PutPreferencesRequestPreferencesUnion$Unknown$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/PutPreferencesRequestPreferencesUnionSerializer : io/github/kikin81/atproto/runtime/OpenUnionSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/actor/PutPreferencesRequestPreferencesUnionSerializer;
+	public fun selectKnownDeserializer (Ljava/lang/String;)Lkotlinx/serialization/KSerializer;
+	public fun selectKnownSerializer (Lio/github/kikin81/atproto/app/bsky/actor/PutPreferencesRequestPreferencesUnion;)Lkotlinx/serialization/KSerializer;
+	public synthetic fun selectKnownSerializer (Lio/github/kikin81/atproto/runtime/OpenUnionMember;)Lkotlinx/serialization/KSerializer;
+	public fun unknownSerializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/actor/PutPreferencesRequestPreferencesUnionUnknownSerializer : io/github/kikin81/atproto/runtime/UnknownMemberSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/actor/PutPreferencesRequestPreferencesUnionUnknownSerializer;
+	public fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/app/bsky/actor/PutPreferencesRequestPreferencesUnion$Unknown;
+	public synthetic fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/runtime/UnknownOpenUnionMember;
 }
 
 public final class io/github/kikin81/atproto/app/bsky/actor/SavedFeed {
@@ -1257,7 +1337,7 @@ public final class io/github/kikin81/atproto/app/bsky/actor/SavedFeed$Companion 
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class io/github/kikin81/atproto/app/bsky/actor/SavedFeedsPref {
+public final class io/github/kikin81/atproto/app/bsky/actor/SavedFeedsPref : io/github/kikin81/atproto/app/bsky/actor/GetPreferencesResponsePreferencesUnion, io/github/kikin81/atproto/app/bsky/actor/PutPreferencesRequestPreferencesUnion {
 	public static final field Companion Lio/github/kikin81/atproto/app/bsky/actor/SavedFeedsPref$Companion;
 	public fun <init> (Ljava/util/List;Ljava/util/List;Ljava/lang/Long;)V
 	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;Ljava/lang/Long;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -1289,7 +1369,7 @@ public final class io/github/kikin81/atproto/app/bsky/actor/SavedFeedsPref$Compa
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class io/github/kikin81/atproto/app/bsky/actor/SavedFeedsPrefV2 {
+public final class io/github/kikin81/atproto/app/bsky/actor/SavedFeedsPrefV2 : io/github/kikin81/atproto/app/bsky/actor/GetPreferencesResponsePreferencesUnion, io/github/kikin81/atproto/app/bsky/actor/PutPreferencesRequestPreferencesUnion {
 	public static final field Companion Lio/github/kikin81/atproto/app/bsky/actor/SavedFeedsPrefV2$Companion;
 	public fun <init> (Ljava/util/List;)V
 	public final fun component1 ()Ljava/util/List;
@@ -1599,7 +1679,7 @@ public final class io/github/kikin81/atproto/app/bsky/actor/StatusViewEmbedUnion
 	public synthetic fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/runtime/UnknownOpenUnionMember;
 }
 
-public final class io/github/kikin81/atproto/app/bsky/actor/ThreadViewPref {
+public final class io/github/kikin81/atproto/app/bsky/actor/ThreadViewPref : io/github/kikin81/atproto/app/bsky/actor/GetPreferencesResponsePreferencesUnion, io/github/kikin81/atproto/app/bsky/actor/PutPreferencesRequestPreferencesUnion {
 	public static final field Companion Lio/github/kikin81/atproto/app/bsky/actor/ThreadViewPref$Companion;
 	public fun <init> ()V
 	public fun <init> (Ljava/lang/String;)V
@@ -1628,7 +1708,7 @@ public final class io/github/kikin81/atproto/app/bsky/actor/ThreadViewPref$Compa
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class io/github/kikin81/atproto/app/bsky/actor/VerificationPrefs {
+public final class io/github/kikin81/atproto/app/bsky/actor/VerificationPrefs : io/github/kikin81/atproto/app/bsky/actor/GetPreferencesResponsePreferencesUnion, io/github/kikin81/atproto/app/bsky/actor/PutPreferencesRequestPreferencesUnion {
 	public static final field Companion Lio/github/kikin81/atproto/app/bsky/actor/VerificationPrefs$Companion;
 	public fun <init> ()V
 	public fun <init> (Ljava/lang/Boolean;)V


### PR DESCRIPTION
## Summary

Fixes #132. A property declared as `type: ref` pointing at a top-level `type: array` def (e.g. `app.bsky.actor.defs#preferences`, an array of a union) was generated as `kotlinx.serialization.json.JsonObject` instead of `List<…Union>` — so the field couldn't even deserialize the real wire value (a JSON array). Consumers had to bypass the generated types and discriminate `$type` by hand.

## Root cause

Top-level `type: array` defs are transparent typedefs that emit no class, so `plan.primaryFqName(target)` returns `null`. Both the emission plan and the type resolver treated a `null` primary as "unknown ref" and fell back to `JsonObject`, never dereferencing the ref to discover it pointed at an array (of a union). Inline `type: array` worked because the code recurses on `ArrayType.items` directly — only the ref-to-array-def path was missing.

## Changes

Dereference such refs through the `SymbolTable` (threaded into both collaborators):

- **`EmissionPlan`** (`collectFromFieldType`): when a field's ref resolves to an `ArrayDefTopLevel`, recurse on the array's item type under the target's NSID, so a nested union still synthesizes a `UnionSite` owned by `(owner, fieldName)` and member types are registered as union members.
- **`TypeResolver`** (`RefType` branch): when a ref has no primary class, look up the target and, if it's an `ArrayDefTopLevel`, emit `List<resolve(items)>` instead of `JsonObject`.
- Plumbed `symbols` into `TypeResolver`'s two construction sites (`CodeGenerator`, `ServiceGenerator`).

## Result (real corpus)

```kotlin
data class GetPreferencesResponse(val preferences: List<GetPreferencesResponsePreferencesUnion>)
data class PutPreferencesRequest(val preferences: List<PutPreferencesRequestPreferencesUnion>)
```

…with a synthesized open union dispatching all 16 member pref types on `$type`, each pref (e.g. `AdultContentPref`) implementing both union interfaces.

## Tests

- Added `ref to a top-level array-of-union def emits List of a synthesized union (issue 132)` in `CodeGeneratorTest` (written test-first; verified it fails on `JsonObject` before the fix, passes after). It asserts `preferences: List<…Union>`, no `JsonObject`, a synthesized union interface, and members extending it.
- Full `:generator` suite green, including `GoldenFileTest` and `FullCorpusSmokeTest` (no golden regeneration needed).
- `:models` regenerates and compiles against the live corpus.

## Follow-up

While here, noticed a distinct, pre-existing bug filed as #133: union fields collapse to `JsonObject` on contextual-split `Input` (mutation-shape) classes. Not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
