### PR TITLE
fix(generator): keep union fields typed on contextual-split Input classes (#133)

### DIFF
--- a/generator/src/main/kotlin/io/github/kikin81/atproto/generator/emit/EmissionPlan.kt
+++ b/generator/src/main/kotlin/io/github/kikin81/atproto/generator/emit/EmissionPlan.kt
@@ -73,7 +73,13 @@ public sealed interface KtorContentTypeRef {
 
 /**
  * One synthesized sealed-interface union arising from a `union` field on a
- * named definition. Owner is the class that contains the field.
+ * named definition. [owner] is the class that contains the field.
+ *
+ * [aliasOwners] are additional class FqNames that share this same field and must
+ * resolve to the same union. The motivating case is a contextually-split def,
+ * where the field appears on both the read-shape Primary ([owner]) and the
+ * mutation-shape `Input` class (an alias) — both reference one synthesized union
+ * rather than duplicating it. See issue #133.
  */
 public data class UnionSite(
     public val owner: FqName,
@@ -83,6 +89,7 @@ public data class UnionSite(
     public val description: String? = null,
     public val deprecated: Boolean = false,
     public val deprecatedMessage: String? = null,
+    public val aliasOwners: List<FqName> = emptyList(),
 )
 
 /**
@@ -189,13 +196,18 @@ public class EmissionPlan(
             val origin = key.nsid
             fun owner(role: NameRole): FqName? = classMap[key]?.firstOrNull { it.role == role }?.fqName
             val primary = owner(NameRole.Primary) ?: classMap[key]?.firstOrNull()?.fqName
+            // A contextually-split def also emits an `Input` (mutation-shape)
+            // class that carries the same union field. Register it as an alias
+            // owner so the field resolves to the same synthesized union instead
+            // of collapsing to JsonObject on the Input. See issue #133.
+            val splitAliases = listOfNotNull(owner(NameRole.Input))
 
             when (def) {
                 is ObjectDef -> primary?.let {
-                    collectFromProperties(def.properties, origin, it, sites, membership, classMap, symbols)
+                    collectFromProperties(def.properties, origin, it, sites, membership, classMap, symbols, splitAliases)
                 }
                 is ParamsDefTopLevel -> primary?.let {
-                    collectFromProperties(def.properties, origin, it, sites, membership, classMap, symbols)
+                    collectFromProperties(def.properties, origin, it, sites, membership, classMap, symbols, splitAliases)
                 }
                 is RecordDef -> primary?.let {
                     collectFromProperties(def.record.properties, origin, it, sites, membership, classMap, symbols)
@@ -260,10 +272,11 @@ public class EmissionPlan(
             membership: MutableMap<DefKey, MutableSet<FqName>>,
             classMap: Map<DefKey, List<EmittedClass>>,
             symbols: SymbolTable,
+            aliasOwners: List<FqName> = emptyList(),
         ) {
             val sortedProps = props.toSortedMap()
             for ((fieldName, ft) in sortedProps) {
-                collectFromFieldType(ft, fieldName, origin, ownerFqName, sites, membership, classMap, symbols)
+                collectFromFieldType(ft, fieldName, origin, ownerFqName, sites, membership, classMap, symbols, aliasOwners)
             }
         }
 
@@ -276,6 +289,7 @@ public class EmissionPlan(
             membership: MutableMap<DefKey, MutableSet<FqName>>,
             classMap: Map<DefKey, List<EmittedClass>>,
             symbols: SymbolTable,
+            aliasOwners: List<FqName> = emptyList(),
         ) {
             when (ft) {
                 is UnionType -> {
@@ -296,6 +310,7 @@ public class EmissionPlan(
                         description = ft.description,
                         deprecated = ft.deprecated,
                         deprecatedMessage = ft.deprecatedMessage,
+                        aliasOwners = aliasOwners,
                     )
                     for (target in targets) {
                         if (classMap.containsKey(target)) {
@@ -312,6 +327,7 @@ public class EmissionPlan(
                     membership,
                     classMap,
                     symbols,
+                    aliasOwners,
                 )
                 is RefType -> {
                     // A field whose `type: ref` points at a top-level
@@ -334,6 +350,7 @@ public class EmissionPlan(
                             membership,
                             classMap,
                             symbols,
+                            aliasOwners,
                         )
                     }
                 }

--- a/generator/src/main/kotlin/io/github/kikin81/atproto/generator/emit/TypeResolver.kt
+++ b/generator/src/main/kotlin/io/github/kikin81/atproto/generator/emit/TypeResolver.kt
@@ -104,7 +104,7 @@ public class TypeResolver(
         }
         is UnionType -> {
             val site = plan.unionSites.firstOrNull {
-                it.owner == ownerFqName && it.fieldName == fieldName
+                (it.owner == ownerFqName || ownerFqName in it.aliasOwners) && it.fieldName == fieldName
             }
             if (site != null) {
                 ClassName(site.fqName.pkg, site.fqName.simpleName)

--- a/generator/src/test/kotlin/io/github/kikin81/atproto/generator/emit/CodeGeneratorTest.kt
+++ b/generator/src/test/kotlin/io/github/kikin81/atproto/generator/emit/CodeGeneratorTest.kt
@@ -280,6 +280,84 @@ class CodeGeneratorTest {
         }
     """.trimIndent()
 
+    // Reproduces issue #133: a shared `.defs` object with a `union` field reached
+    // from both a mutation root (procedure input) and a read root (query output)
+    // → contextual split into `Payload` + `PayloadInput`. The union must survive
+    // on BOTH the read-shape Primary and the mutation-shape Input, not collapse
+    // to JsonObject on the Input. (Mirrors app.bsky.draft.defs#draftPost.)
+    private val splitUnionDefsJson = """
+        {
+          "lexicon": 1,
+          "id": "app.bsky.test.defs",
+          "defs": {
+            "payload": {
+              "type": "object",
+              "required": ["name"],
+              "properties": {
+                "name": { "type": "string" },
+                "embed": {
+                  "type": "union",
+                  "refs": ["app.bsky.test.defs#imageEmbed", "app.bsky.test.defs#videoEmbed"]
+                }
+              }
+            },
+            "imageEmbed": {
+              "type": "object",
+              "required": ["count"],
+              "properties": { "count": { "type": "integer" } }
+            },
+            "videoEmbed": {
+              "type": "object",
+              "required": ["url"],
+              "properties": { "url": { "type": "string", "format": "uri" } }
+            }
+          }
+        }
+    """.trimIndent()
+
+    private val splitUnionMutationRootJson = """
+        {
+          "lexicon": 1,
+          "id": "app.bsky.test.putThing",
+          "defs": {
+            "main": {
+              "type": "procedure",
+              "input": {
+                "encoding": "application/json",
+                "schema": {
+                  "type": "ref",
+                  "ref": "app.bsky.test.defs#payload"
+                }
+              }
+            }
+          }
+        }
+    """.trimIndent()
+
+    private val splitUnionReadRootJson = """
+        {
+          "lexicon": 1,
+          "id": "app.bsky.test.getThing",
+          "defs": {
+            "main": {
+              "type": "query",
+              "parameters": {
+                "type": "params",
+                "required": ["id"],
+                "properties": { "id": { "type": "string" } }
+              },
+              "output": {
+                "encoding": "application/json",
+                "schema": {
+                  "type": "ref",
+                  "ref": "app.bsky.test.defs#payload"
+                }
+              }
+            }
+          }
+        }
+    """.trimIndent()
+
     private val subscriptionJson = """
         {
           "lexicon": 1,
@@ -379,6 +457,43 @@ class CodeGeneratorTest {
         assertTrue("accent: String? = null" in primaryStr, primaryStr)
         // Input is mutation-shape: AtField<String> accent
         assertTrue("AtField" in inputStr, inputStr)
+    }
+
+    @Test
+    fun `union field survives on the contextual-split Input class (issue 133)`() {
+        val files = generate(splitUnionDefsJson, splitUnionMutationRootJson, splitUnionReadRootJson)
+        val text = renderAll(files)
+
+        // `#payload` is reached from both a mutation root (record) and a read
+        // root (query output) and has an optional union field → splits into
+        // Payload (read) + PayloadInput (mutation). Exactly one union interface
+        // is synthesized and must be referenced from BOTH classes.
+        val union = files.firstOrNull { it.name == "PayloadEmbedUnion" }
+        assertNotNull(union, "missing synthesized union\n$text")
+        assertEquals(
+            1,
+            files.count { it.name == "PayloadEmbedUnion" },
+            "expected exactly one union interface shared by Primary and Input:\n$text",
+        )
+
+        val primary = files.firstOrNull { it.name == "Payload" }
+        assertNotNull(primary, "missing Payload primary\n$text")
+        val input = files.firstOrNull { it.name == "PayloadInput" }
+        assertNotNull(input, "missing PayloadInput\n$text")
+
+        val primaryStr = primary.toString()
+        val inputStr = input.toString()
+
+        // Read-shape Primary: nullable union.
+        assertTrue("embed: PayloadEmbedUnion? = null" in primaryStr, primaryStr)
+
+        // Mutation-shape Input must keep the typed union (wrapped in AtField),
+        // NOT collapse to JsonObject.
+        assertTrue(
+            "AtField<PayloadEmbedUnion>" in inputStr,
+            "PayloadInput.embed must be AtField<PayloadEmbedUnion>, not JsonObject:\n$inputStr",
+        )
+        assertTrue("JsonObject" !in inputStr, "PayloadInput must not fall back to JsonObject:\n$inputStr")
     }
 
     @Test


### PR DESCRIPTION
## Summary

Fixes #133. When a definition with a `union` field is reached from both a read root and a mutation root, it is contextually split into a read-shape **Primary** class and a mutation-shape **`Input`** class. The union resolved correctly on the Primary but collapsed to `JsonObject` on the `Input`:

```kotlin
// before — DraftInput.kt
public val threadgateAllow: AtField<List<JsonObject>> = AtField.Missing
public val postgateEmbeddingRules: AtField<List<JsonObject>> = AtField.Missing
// before — DraftPostInput.kt
public val labels: AtField<JsonObject> = AtField.Missing
```

The generator also logged a `union field … missing from plan; using JsonObject` warning for each.

## Root cause

`EmissionPlan` keys each synthesized `UnionSite` by the **Primary** owner `FqName`. `TypeResolver` looks up the site by `(ownerFqName, fieldName)`; for the `Input` class — a different `FqName` (`DraftInput`) for the same `DefKey` — there is no matching site, so it warns and falls back to `JsonObject`.

## Fix

Register the `Input` class as an **alias owner** on the *same* `UnionSite` (one synthesized union, shared by Primary and Input), and match either `owner` or `aliasOwners` in `TypeResolver`. The alias is threaded through the union/array/ref collectors so nested array-of-union and ref-to-array-of-union fields on split Inputs are covered too.

```kotlin
// after — DraftInput.kt
public val threadgateAllow: AtField<List<DraftThreadgateAllowUnion>> = AtField.Missing
public val postgateEmbeddingRules: AtField<List<DraftPostgateEmbeddingRulesUnion>> = AtField.Missing
// after — DraftPostInput.kt
public val labels: AtField<DraftPostLabelsUnion> = AtField.Missing
```

Exactly one union interface is emitted per field and shared by both classes (verified: 1 file each for `DraftThreadgateAllowUnion`, `DraftPostgateEmbeddingRulesUnion`, `DraftPostLabelsUnion`).

## Tests

- Added `union field survives on the contextual-split Input class (issue 133)` in `CodeGeneratorTest` (written test-first; fails on `JsonObject` before the fix, passes after). It forces a split via a shared `.defs` object referenced from a procedure input (mutation) and a query output (read), and asserts a single shared union, `embed: PayloadEmbedUnion? = null` on the Primary, and `AtField<PayloadEmbedUnion>` (no `JsonObject`) on the Input.
- Full `:generator` suite green, including `GoldenFileTest`, `VerificationPassTest`, and `FullCorpusSmokeTest`.
- Live corpus: `:models` regenerates with **zero** `missing from plan` warnings and compiles.

## No binary-API change

Unlike #132, the `models/api/models.api` baseline is unchanged: the difference is only the erased generic argument inside `AtField<…>`, and the union interfaces already existed (used by the Primary class). `:models:apiDump` produces no diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
