### PR TITLE
feat(models): add chat.bsky.group lexicons for group chats

### DIFF
--- a/docs/superpowers/specs/2026-06-11-chat-bsky-group-service-design.md
+++ b/docs/superpowers/specs/2026-06-11-chat-bsky-group-service-design.md
@@ -1,0 +1,85 @@
+# chat.bsky.group.* service support — design
+
+_Date: 2026-06-11 · Branch: `feat/chat-bsky-group`_
+
+## Goal
+
+Opt the SDK into the 13 **published** `chat.bsky.group` lexicons so consumers can
+create and manage group chats (Bluesky's "group chats for up to 50 users").
+`createGroup` caps `members` at 49 DIDs; with the creator that is 50 participants.
+
+## Why now
+
+Unlike `app.bsky.embed.gallery` (merged to GitHub source but **not** published to
+the AT Protocol network — `RecordNotFound`, unresolvable by `@atproto/lex`), the
+group-chat lexicons are **published and proof-verifiable** on the network under the
+lexicon authority `did:plc:4v4y5r3lwsbtmsxhile2ljac`. They can be resolved and
+CID-pinned today. The SDK currently tracks none of the 17 `chat.bsky.group.*`
+operations (only `chat/bsky/group/defs.json`, pulled in transitively by
+`chat.bsky.convo.*`).
+
+## Scope
+
+In scope — the 13 published operations:
+
+| NSID | Kind | Input / Params | Output |
+|------|------|----------------|--------|
+| `createGroup` | procedure | `members` (≤49 DIDs), `name` | `convo` |
+| `addMembers` | procedure | `convoId`, `members` | `addedMembers`, `convo` |
+| `removeMembers` | procedure | `convoId`, `members` | `convo` |
+| `editGroup` | procedure | `convoId`, `name` | `convo` |
+| `requestJoin` | procedure | `code` | `convo`, `status` |
+| `approveJoinRequest` | procedure | `convoId`, `member` | `convo` |
+| `rejectJoinRequest` | procedure | `convoId`, `member` | — |
+| `createJoinLink` | procedure | `convoId`, `joinRule`, `requireApproval` | `joinLink` |
+| `editJoinLink` | procedure | `convoId`, `joinRule`, `requireApproval` | `joinLink` |
+| `enableJoinLink` | procedure | `convoId` | `joinLink` |
+| `disableJoinLink` | procedure | `convoId` | `joinLink` |
+| `listJoinRequests` | query | `convoId`, `cursor`, `limit` | `cursor`, `requests` |
+| `getGroupPublicInfo` | query | `code` | `group` |
+
+Out of scope — 4 GitHub-only, unpublished (`RecordNotFound`, cannot pin):
+`getJoinLinkPreviews`, `listMutualGroups`, `updateJoinRequestsRead`,
+`withdrawJoinRequest`. Tracked for a follow-up when published.
+
+## Approach
+
+No generator code changes expected; this is a corpus opt-in + regeneration.
+
+1. **Manifest.** Add the 13 NSIDs to the `lexicons` array in
+   `generator/lexicons.json`.
+2. **Resolve + pin.** `npx lex install <nsid>` for each (from `generator/`),
+   writing real CIDs into `resolutions` and the JSON into
+   `generator/lexicons/chat/bsky/group/`.
+3. **Regenerate.** `./gradlew :generator:generateModels` emits `GroupService`
+   (13 methods) + request/response models under
+   `models/build/generated/source/lexicon/.../chat/bsky/group/`. `chat.bsky.*`
+   auto-inherits the `did:web:api.bsky.chat#bsky_chat` proxy via existing
+   `ProxyMapping` — verify, do not modify.
+
+## Tests
+
+- **Models-level** `GroupServiceTest.kt` (new, `models/src/commonTest/.../chat/bsky/group/`)
+  using `MockXrpcFixture`, one test per generated method. Asserts: HTTP verb
+  (POST for procedures, GET for queries), XRPC path `/xrpc/chat.bsky.group.<m>`,
+  the proxy is applied, request serialization (notably `createGroup` with a
+  49-member `List<Did>`), and response deserialization. Mirrors `FeedServiceTest`.
+- **Generator golden** one case: add `chat.bsky.group.createGroup.json` to
+  `generator/src/test/resources/golden/lexicons/`, regenerate with
+  `GOLDEN_UPDATE=1`, commit the new golden Kotlin. Locks output + proxy wiring
+  for the new namespace and the `maxLength`-bounded-array procedure shape.
+
+## Verification
+
+`./gradlew spotlessApply build` — compiles generated KMP (JVM + iOS), runs all
+module tests plus the golden regression. Commit as
+`feat(models): add chat.bsky.group.* lexicons for group chats`; semantic-release
+will minor-bump.
+
+## Risks / notes
+
+- A full `lex install` of these 13 may pull transitive defs already present
+  (`chat.bsky.group.defs`, `chat.bsky.convo.defs`); expected to be no-ops or
+  additive.
+- If the generator emits anything non-additive elsewhere (it should not — these
+  are a new isolated namespace), pause and review before committing.

--- a/generator/lexicons.json
+++ b/generator/lexicons.json
@@ -111,6 +111,19 @@
     "chat.bsky.convo.unmuteConvo",
     "chat.bsky.convo.updateAllRead",
     "chat.bsky.convo.updateRead",
+    "chat.bsky.group.addMembers",
+    "chat.bsky.group.approveJoinRequest",
+    "chat.bsky.group.createGroup",
+    "chat.bsky.group.createJoinLink",
+    "chat.bsky.group.disableJoinLink",
+    "chat.bsky.group.editGroup",
+    "chat.bsky.group.editJoinLink",
+    "chat.bsky.group.enableJoinLink",
+    "chat.bsky.group.getGroupPublicInfo",
+    "chat.bsky.group.listJoinRequests",
+    "chat.bsky.group.rejectJoinRequest",
+    "chat.bsky.group.removeMembers",
+    "chat.bsky.group.requestJoin",
     "com.atproto.identity.resolveHandle",
     "com.atproto.identity.updateHandle",
     "com.atproto.label.queryLabels",
@@ -629,9 +642,61 @@
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/chat.bsky.convo.updateRead",
       "cid": "bafyreihba5bopb5vnlqqvtavipybqgemp6itwrz4xysnp6yi6iow5ntnv4"
     },
+    "chat.bsky.group.addMembers": {
+      "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/chat.bsky.group.addMembers",
+      "cid": "bafyreidz4it2vt6aryamffurawefazntxepyvfgkwbcqdjjc4c3h6qtsem"
+    },
+    "chat.bsky.group.approveJoinRequest": {
+      "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/chat.bsky.group.approveJoinRequest",
+      "cid": "bafyreif2gatuzapbhqwfv6j2fdwocnkb2whsxoagek25s7byirpslyw5pa"
+    },
+    "chat.bsky.group.createGroup": {
+      "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/chat.bsky.group.createGroup",
+      "cid": "bafyreifujsn7jyf26dmvsapfy4pfqifj57zxx3jeipcve2ubqhztv4pm24"
+    },
+    "chat.bsky.group.createJoinLink": {
+      "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/chat.bsky.group.createJoinLink",
+      "cid": "bafyreic2r6qjbm3x677iup4ldjuvyyud3o3gma62xyshyaul5iv3b4gllu"
+    },
     "chat.bsky.group.defs": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/chat.bsky.group.defs",
       "cid": "bafyreidzaadxqcphdzsw2alge3sjhhqbysasjhethrpne3hskpt5zkkhbe"
+    },
+    "chat.bsky.group.disableJoinLink": {
+      "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/chat.bsky.group.disableJoinLink",
+      "cid": "bafyreibn73w5rothrl7yoqyl52sk7lmxghkkhyjlyqvlwyj5lanqefcyce"
+    },
+    "chat.bsky.group.editGroup": {
+      "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/chat.bsky.group.editGroup",
+      "cid": "bafyreifbijqfi6xn2eikn2uwd6nc4q3chw2grup7wdt3lujdpd2fyvemvi"
+    },
+    "chat.bsky.group.editJoinLink": {
+      "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/chat.bsky.group.editJoinLink",
+      "cid": "bafyreidoctndxfcpgek3cuwbm3eawm6lmzw4rinyl6fvty63gypekfjzqq"
+    },
+    "chat.bsky.group.enableJoinLink": {
+      "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/chat.bsky.group.enableJoinLink",
+      "cid": "bafyreih2bxrn5okcduaqyrqye63cqjomceag7mh6uproralortxomd7pnu"
+    },
+    "chat.bsky.group.getGroupPublicInfo": {
+      "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/chat.bsky.group.getGroupPublicInfo",
+      "cid": "bafyreialxwym3ir4cext23izqt5nddbtjemvme6l3fgh5rz3h3j4sfynmy"
+    },
+    "chat.bsky.group.listJoinRequests": {
+      "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/chat.bsky.group.listJoinRequests",
+      "cid": "bafyreiaqwkeq3hyflrcetnxzgznf5t2kqfkhyk4a37ac3pmwcmlsnyydw4"
+    },
+    "chat.bsky.group.rejectJoinRequest": {
+      "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/chat.bsky.group.rejectJoinRequest",
+      "cid": "bafyreiaen4jmy467wurzsuugx5k6vidp5bxnztwfu7323nkroaj6kwldmi"
+    },
+    "chat.bsky.group.removeMembers": {
+      "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/chat.bsky.group.removeMembers",
+      "cid": "bafyreictig3qsep2iwigxkn3stdfzrqnwad2kxvqb35n3o4lfjihmp3qzq"
+    },
+    "chat.bsky.group.requestJoin": {
+      "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/chat.bsky.group.requestJoin",
+      "cid": "bafyreid44ifkqtpefyqig2qhwbsutgybc7pbevzwtgxhkxlikhtqi5t4t4"
     },
     "com.atproto.admin.defs": {
       "uri": "at://did:plc:6msi3pj7krzih5qxqtryxlzw/com.atproto.lexicon.schema/com.atproto.admin.defs",

--- a/generator/src/test/resources/golden/kotlin/io/github/kikin81/atproto/chat/bsky/group/CreateGroupRequest.kt
+++ b/generator/src/test/resources/golden/kotlin/io/github/kikin81/atproto/chat/bsky/group/CreateGroupRequest.kt
@@ -1,0 +1,15 @@
+package io.github.kikin81.atproto.chat.bsky.group
+
+import io.github.kikin81.atproto.runtime.Did
+import kotlin.String
+import kotlin.collections.List
+import kotlinx.serialization.Serializable
+
+/**
+ * Create a group convo with up to 49 invited members.
+ */
+@Serializable
+public data class CreateGroupRequest(
+  public val members: List<Did>,
+  public val name: String,
+)

--- a/generator/src/test/resources/golden/kotlin/io/github/kikin81/atproto/chat/bsky/group/CreateGroupResponse.kt
+++ b/generator/src/test/resources/golden/kotlin/io/github/kikin81/atproto/chat/bsky/group/CreateGroupResponse.kt
@@ -1,0 +1,9 @@
+package io.github.kikin81.atproto.chat.bsky.group
+
+import kotlin.String
+import kotlinx.serialization.Serializable
+
+@Serializable
+public data class CreateGroupResponse(
+  public val convoId: String,
+)

--- a/generator/src/test/resources/golden/kotlin/io/github/kikin81/atproto/chat/bsky/group/GroupService.kt
+++ b/generator/src/test/resources/golden/kotlin/io/github/kikin81/atproto/chat/bsky/group/GroupService.kt
@@ -1,0 +1,23 @@
+package io.github.kikin81.atproto.chat.bsky.group
+
+import io.github.kikin81.atproto.runtime.NoXrpcParams
+import io.github.kikin81.atproto.runtime.XrpcClient
+import kotlin.String
+
+public class GroupService(
+  private val client: XrpcClient,
+  private val proxy: String? = "did:web:api.bsky.chat#bsky_chat",
+) {
+  /**
+   * Create a group convo with up to 49 invited members.
+   */
+  public suspend fun createGroup(request: CreateGroupRequest, proxy: String? = null): CreateGroupResponse = client.procedure(
+      nsid = "chat.bsky.group.createGroup",
+      params = NoXrpcParams,
+      paramsSerializer = NoXrpcParams.serializer(),
+      input = request,
+      inputSerializer = CreateGroupRequest.serializer(),
+      responseSerializer = CreateGroupResponse.serializer(),
+      proxy = proxy ?: this.proxy,
+  )
+}

--- a/generator/src/test/resources/golden/lexicons/chat.bsky.group.createGroup.json
+++ b/generator/src/test/resources/golden/lexicons/chat.bsky.group.createGroup.json
@@ -1,0 +1,36 @@
+{
+  "lexicon": 1,
+  "id": "chat.bsky.group.createGroup",
+  "description": "Creates a group convo. Exercises a maxLength-bounded array of DIDs in a procedure input plus the atproto-proxy emission for chat.bsky.* namespaces.",
+  "defs": {
+    "main": {
+      "type": "procedure",
+      "description": "Create a group convo with up to 49 invited members.",
+      "input": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["members", "name"],
+          "properties": {
+            "members": {
+              "type": "array",
+              "maxLength": 49,
+              "items": { "type": "string", "format": "did" }
+            },
+            "name": { "type": "string" }
+          }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["convoId"],
+          "properties": {
+            "convoId": { "type": "string" }
+          }
+        }
+      }
+    }
+  }
+}

--- a/models/api/models.api
+++ b/models/api/models.api
@@ -13403,6 +13403,510 @@ public final class io/github/kikin81/atproto/chat/bsky/convo/UpdateReadResponse$
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class io/github/kikin81/atproto/chat/bsky/group/AddMembersRequest {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/group/AddMembersRequest$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;)Lio/github/kikin81/atproto/chat/bsky/group/AddMembersRequest;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/group/AddMembersRequest;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/group/AddMembersRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConvoId ()Ljava/lang/String;
+	public final fun getMembers ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/group/AddMembersRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/group/AddMembersRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/group/AddMembersRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/group/AddMembersRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/AddMembersRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/AddMembersResponse {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/group/AddMembersResponse$Companion;
+	public fun <init> (Lio/github/kikin81/atproto/chat/bsky/convo/ConvoView;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/chat/bsky/convo/ConvoView;
+	public final fun copy (Lio/github/kikin81/atproto/chat/bsky/convo/ConvoView;)Lio/github/kikin81/atproto/chat/bsky/group/AddMembersResponse;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/group/AddMembersResponse;Lio/github/kikin81/atproto/chat/bsky/convo/ConvoView;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/group/AddMembersResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConvo ()Lio/github/kikin81/atproto/chat/bsky/convo/ConvoView;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/group/AddMembersResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/group/AddMembersResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/group/AddMembersResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/group/AddMembersResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/AddMembersResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/ApproveJoinRequestRequest {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/group/ApproveJoinRequestRequest$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2-UyB9Nic ()Ljava/lang/String;
+	public final fun copy-aB4ouW8 (Ljava/lang/String;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/group/ApproveJoinRequestRequest;
+	public static synthetic fun copy-aB4ouW8$default (Lio/github/kikin81/atproto/chat/bsky/group/ApproveJoinRequestRequest;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/group/ApproveJoinRequestRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConvoId ()Ljava/lang/String;
+	public final fun getMember-UyB9Nic ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/group/ApproveJoinRequestRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/group/ApproveJoinRequestRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/group/ApproveJoinRequestRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/group/ApproveJoinRequestRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/ApproveJoinRequestRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/ApproveJoinRequestResponse {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/group/ApproveJoinRequestResponse$Companion;
+	public fun <init> (Lio/github/kikin81/atproto/chat/bsky/convo/ConvoView;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/chat/bsky/convo/ConvoView;
+	public final fun copy (Lio/github/kikin81/atproto/chat/bsky/convo/ConvoView;)Lio/github/kikin81/atproto/chat/bsky/group/ApproveJoinRequestResponse;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/group/ApproveJoinRequestResponse;Lio/github/kikin81/atproto/chat/bsky/convo/ConvoView;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/group/ApproveJoinRequestResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConvo ()Lio/github/kikin81/atproto/chat/bsky/convo/ConvoView;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/group/ApproveJoinRequestResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/group/ApproveJoinRequestResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/group/ApproveJoinRequestResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/group/ApproveJoinRequestResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/ApproveJoinRequestResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/CreateGroupRequest {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/group/CreateGroupRequest$Companion;
+	public fun <init> (Ljava/util/List;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/util/List;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/group/CreateGroupRequest;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/group/CreateGroupRequest;Ljava/util/List;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/group/CreateGroupRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMembers ()Ljava/util/List;
+	public final fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/group/CreateGroupRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/group/CreateGroupRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/group/CreateGroupRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/group/CreateGroupRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/CreateGroupRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/CreateGroupResponse {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/group/CreateGroupResponse$Companion;
+	public fun <init> (Lio/github/kikin81/atproto/chat/bsky/convo/ConvoView;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/chat/bsky/convo/ConvoView;
+	public final fun copy (Lio/github/kikin81/atproto/chat/bsky/convo/ConvoView;)Lio/github/kikin81/atproto/chat/bsky/group/CreateGroupResponse;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/group/CreateGroupResponse;Lio/github/kikin81/atproto/chat/bsky/convo/ConvoView;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/group/CreateGroupResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConvo ()Lio/github/kikin81/atproto/chat/bsky/convo/ConvoView;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/group/CreateGroupResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/group/CreateGroupResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/group/CreateGroupResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/group/CreateGroupResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/CreateGroupResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/CreateJoinLinkRequest {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/group/CreateJoinLinkRequest$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;)Lio/github/kikin81/atproto/chat/bsky/group/CreateJoinLinkRequest;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/group/CreateJoinLinkRequest;Ljava/lang/String;Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/group/CreateJoinLinkRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConvoId ()Ljava/lang/String;
+	public final fun getJoinRule ()Ljava/lang/String;
+	public final fun getRequireApproval ()Lio/github/kikin81/atproto/runtime/AtField;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/group/CreateJoinLinkRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/group/CreateJoinLinkRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/group/CreateJoinLinkRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/group/CreateJoinLinkRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/CreateJoinLinkRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/CreateJoinLinkResponse {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/group/CreateJoinLinkResponse$Companion;
+	public fun <init> (Lio/github/kikin81/atproto/chat/bsky/group/JoinLinkView;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/chat/bsky/group/JoinLinkView;
+	public final fun copy (Lio/github/kikin81/atproto/chat/bsky/group/JoinLinkView;)Lio/github/kikin81/atproto/chat/bsky/group/CreateJoinLinkResponse;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/group/CreateJoinLinkResponse;Lio/github/kikin81/atproto/chat/bsky/group/JoinLinkView;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/group/CreateJoinLinkResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getJoinLink ()Lio/github/kikin81/atproto/chat/bsky/group/JoinLinkView;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/group/CreateJoinLinkResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/group/CreateJoinLinkResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/group/CreateJoinLinkResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/group/CreateJoinLinkResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/CreateJoinLinkResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/DisableJoinLinkRequest {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/group/DisableJoinLinkRequest$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/group/DisableJoinLinkRequest;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/group/DisableJoinLinkRequest;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/group/DisableJoinLinkRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConvoId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/group/DisableJoinLinkRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/group/DisableJoinLinkRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/group/DisableJoinLinkRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/group/DisableJoinLinkRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/DisableJoinLinkRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/DisableJoinLinkResponse {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/group/DisableJoinLinkResponse$Companion;
+	public fun <init> (Lio/github/kikin81/atproto/chat/bsky/group/JoinLinkView;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/chat/bsky/group/JoinLinkView;
+	public final fun copy (Lio/github/kikin81/atproto/chat/bsky/group/JoinLinkView;)Lio/github/kikin81/atproto/chat/bsky/group/DisableJoinLinkResponse;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/group/DisableJoinLinkResponse;Lio/github/kikin81/atproto/chat/bsky/group/JoinLinkView;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/group/DisableJoinLinkResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getJoinLink ()Lio/github/kikin81/atproto/chat/bsky/group/JoinLinkView;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/group/DisableJoinLinkResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/group/DisableJoinLinkResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/group/DisableJoinLinkResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/group/DisableJoinLinkResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/DisableJoinLinkResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/EditGroupRequest {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/group/EditGroupRequest$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/group/EditGroupRequest;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/group/EditGroupRequest;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/group/EditGroupRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConvoId ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/group/EditGroupRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/group/EditGroupRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/group/EditGroupRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/group/EditGroupRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/EditGroupRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/EditGroupResponse {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/group/EditGroupResponse$Companion;
+	public fun <init> (Lio/github/kikin81/atproto/chat/bsky/convo/ConvoView;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/chat/bsky/convo/ConvoView;
+	public final fun copy (Lio/github/kikin81/atproto/chat/bsky/convo/ConvoView;)Lio/github/kikin81/atproto/chat/bsky/group/EditGroupResponse;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/group/EditGroupResponse;Lio/github/kikin81/atproto/chat/bsky/convo/ConvoView;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/group/EditGroupResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConvo ()Lio/github/kikin81/atproto/chat/bsky/convo/ConvoView;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/group/EditGroupResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/group/EditGroupResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/group/EditGroupResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/group/EditGroupResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/EditGroupResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/EditJoinLinkRequest {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/group/EditJoinLinkRequest$Companion;
+	public fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;)V
+	public synthetic fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun component3 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun copy (Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;)Lio/github/kikin81/atproto/chat/bsky/group/EditJoinLinkRequest;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/group/EditJoinLinkRequest;Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/group/EditJoinLinkRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConvoId ()Ljava/lang/String;
+	public final fun getJoinRule ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun getRequireApproval ()Lio/github/kikin81/atproto/runtime/AtField;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/group/EditJoinLinkRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/group/EditJoinLinkRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/group/EditJoinLinkRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/group/EditJoinLinkRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/EditJoinLinkRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/EditJoinLinkResponse {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/group/EditJoinLinkResponse$Companion;
+	public fun <init> (Lio/github/kikin81/atproto/chat/bsky/group/JoinLinkView;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/chat/bsky/group/JoinLinkView;
+	public final fun copy (Lio/github/kikin81/atproto/chat/bsky/group/JoinLinkView;)Lio/github/kikin81/atproto/chat/bsky/group/EditJoinLinkResponse;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/group/EditJoinLinkResponse;Lio/github/kikin81/atproto/chat/bsky/group/JoinLinkView;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/group/EditJoinLinkResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getJoinLink ()Lio/github/kikin81/atproto/chat/bsky/group/JoinLinkView;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/group/EditJoinLinkResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/group/EditJoinLinkResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/group/EditJoinLinkResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/group/EditJoinLinkResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/EditJoinLinkResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/EnableJoinLinkRequest {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/group/EnableJoinLinkRequest$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/group/EnableJoinLinkRequest;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/group/EnableJoinLinkRequest;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/group/EnableJoinLinkRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConvoId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/group/EnableJoinLinkRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/group/EnableJoinLinkRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/group/EnableJoinLinkRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/group/EnableJoinLinkRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/EnableJoinLinkRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/EnableJoinLinkResponse {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/group/EnableJoinLinkResponse$Companion;
+	public fun <init> (Lio/github/kikin81/atproto/chat/bsky/group/JoinLinkView;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/chat/bsky/group/JoinLinkView;
+	public final fun copy (Lio/github/kikin81/atproto/chat/bsky/group/JoinLinkView;)Lio/github/kikin81/atproto/chat/bsky/group/EnableJoinLinkResponse;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/group/EnableJoinLinkResponse;Lio/github/kikin81/atproto/chat/bsky/group/JoinLinkView;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/group/EnableJoinLinkResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getJoinLink ()Lio/github/kikin81/atproto/chat/bsky/group/JoinLinkView;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/group/EnableJoinLinkResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/group/EnableJoinLinkResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/group/EnableJoinLinkResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/group/EnableJoinLinkResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/EnableJoinLinkResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/GetGroupPublicInfoRequest {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/group/GetGroupPublicInfoRequest$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/group/GetGroupPublicInfoRequest;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/group/GetGroupPublicInfoRequest;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/group/GetGroupPublicInfoRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCode ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/group/GetGroupPublicInfoRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/group/GetGroupPublicInfoRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/group/GetGroupPublicInfoRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/group/GetGroupPublicInfoRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/GetGroupPublicInfoRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/GetGroupPublicInfoResponse {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/group/GetGroupPublicInfoResponse$Companion;
+	public fun <init> (Lio/github/kikin81/atproto/chat/bsky/group/GroupPublicView;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/chat/bsky/group/GroupPublicView;
+	public final fun copy (Lio/github/kikin81/atproto/chat/bsky/group/GroupPublicView;)Lio/github/kikin81/atproto/chat/bsky/group/GetGroupPublicInfoResponse;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/group/GetGroupPublicInfoResponse;Lio/github/kikin81/atproto/chat/bsky/group/GroupPublicView;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/group/GetGroupPublicInfoResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getGroup ()Lio/github/kikin81/atproto/chat/bsky/group/GroupPublicView;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/group/GetGroupPublicInfoResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/group/GetGroupPublicInfoResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/group/GetGroupPublicInfoResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/group/GetGroupPublicInfoResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/GetGroupPublicInfoResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
 public final class io/github/kikin81/atproto/chat/bsky/group/GroupPublicView {
 	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/group/GroupPublicView$Companion;
 	public fun <init> (JLjava/lang/String;Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;Z)V
@@ -13434,6 +13938,42 @@ public final synthetic class io/github/kikin81/atproto/chat/bsky/group/GroupPubl
 
 public final class io/github/kikin81/atproto/chat/bsky/group/GroupPublicView$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/GroupService {
+	public fun <init> (Lio/github/kikin81/atproto/runtime/XrpcClient;Ljava/lang/String;)V
+	public synthetic fun <init> (Lio/github/kikin81/atproto/runtime/XrpcClient;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun addMembers (Lio/github/kikin81/atproto/chat/bsky/group/AddMembersRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun addMembers$default (Lio/github/kikin81/atproto/chat/bsky/group/GroupService;Lio/github/kikin81/atproto/chat/bsky/group/AddMembersRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun approveJoinRequest (Lio/github/kikin81/atproto/chat/bsky/group/ApproveJoinRequestRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun approveJoinRequest$default (Lio/github/kikin81/atproto/chat/bsky/group/GroupService;Lio/github/kikin81/atproto/chat/bsky/group/ApproveJoinRequestRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun createGroup (Lio/github/kikin81/atproto/chat/bsky/group/CreateGroupRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun createGroup$default (Lio/github/kikin81/atproto/chat/bsky/group/GroupService;Lio/github/kikin81/atproto/chat/bsky/group/CreateGroupRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun createJoinLink (Lio/github/kikin81/atproto/chat/bsky/group/CreateJoinLinkRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun createJoinLink$default (Lio/github/kikin81/atproto/chat/bsky/group/GroupService;Lio/github/kikin81/atproto/chat/bsky/group/CreateJoinLinkRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun disableJoinLink (Lio/github/kikin81/atproto/chat/bsky/group/DisableJoinLinkRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun disableJoinLink$default (Lio/github/kikin81/atproto/chat/bsky/group/GroupService;Lio/github/kikin81/atproto/chat/bsky/group/DisableJoinLinkRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun editGroup (Lio/github/kikin81/atproto/chat/bsky/group/EditGroupRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun editGroup$default (Lio/github/kikin81/atproto/chat/bsky/group/GroupService;Lio/github/kikin81/atproto/chat/bsky/group/EditGroupRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun editJoinLink (Lio/github/kikin81/atproto/chat/bsky/group/EditJoinLinkRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun editJoinLink$default (Lio/github/kikin81/atproto/chat/bsky/group/GroupService;Lio/github/kikin81/atproto/chat/bsky/group/EditJoinLinkRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun enableJoinLink (Lio/github/kikin81/atproto/chat/bsky/group/EnableJoinLinkRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun enableJoinLink$default (Lio/github/kikin81/atproto/chat/bsky/group/GroupService;Lio/github/kikin81/atproto/chat/bsky/group/EnableJoinLinkRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getGroupPublicInfo (Lio/github/kikin81/atproto/chat/bsky/group/GetGroupPublicInfoRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getGroupPublicInfo$default (Lio/github/kikin81/atproto/chat/bsky/group/GroupService;Lio/github/kikin81/atproto/chat/bsky/group/GetGroupPublicInfoRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun listJoinRequests (Lio/github/kikin81/atproto/chat/bsky/group/ListJoinRequestsRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun listJoinRequests$default (Lio/github/kikin81/atproto/chat/bsky/group/GroupService;Lio/github/kikin81/atproto/chat/bsky/group/ListJoinRequestsRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun rejectJoinRequest (Lio/github/kikin81/atproto/chat/bsky/group/RejectJoinRequestRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun rejectJoinRequest$default (Lio/github/kikin81/atproto/chat/bsky/group/GroupService;Lio/github/kikin81/atproto/chat/bsky/group/RejectJoinRequestRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun removeMembers (Lio/github/kikin81/atproto/chat/bsky/group/RemoveMembersRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun removeMembers$default (Lio/github/kikin81/atproto/chat/bsky/group/GroupService;Lio/github/kikin81/atproto/chat/bsky/group/RemoveMembersRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun requestJoin (Lio/github/kikin81/atproto/chat/bsky/group/RequestJoinRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun requestJoin$default (Lio/github/kikin81/atproto/chat/bsky/group/GroupService;Lio/github/kikin81/atproto/chat/bsky/group/RequestJoinRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/GroupServiceKt {
+	public static final fun listJoinRequestsFlow (Lio/github/kikin81/atproto/chat/bsky/group/GroupService;Lio/github/kikin81/atproto/chat/bsky/group/ListJoinRequestsRequest;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun listJoinRequestsPageFlow (Lio/github/kikin81/atproto/chat/bsky/group/GroupService;Lio/github/kikin81/atproto/chat/bsky/group/ListJoinRequestsRequest;)Lkotlinx/coroutines/flow/Flow;
 }
 
 public final class io/github/kikin81/atproto/chat/bsky/group/JoinLinkView {
@@ -13499,6 +14039,230 @@ public final synthetic class io/github/kikin81/atproto/chat/bsky/group/JoinReque
 }
 
 public final class io/github/kikin81/atproto/chat/bsky/group/JoinRequestView$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/ListJoinRequestsRequest {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/group/ListJoinRequestsRequest$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/Long;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;)Lio/github/kikin81/atproto/chat/bsky/group/ListJoinRequestsRequest;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/group/ListJoinRequestsRequest;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/group/ListJoinRequestsRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConvoId ()Ljava/lang/String;
+	public final fun getCursor ()Ljava/lang/String;
+	public final fun getLimit ()Ljava/lang/Long;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/group/ListJoinRequestsRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/group/ListJoinRequestsRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/group/ListJoinRequestsRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/group/ListJoinRequestsRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/ListJoinRequestsRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/ListJoinRequestsResponse {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/group/ListJoinRequestsResponse$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;)Lio/github/kikin81/atproto/chat/bsky/group/ListJoinRequestsResponse;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/group/ListJoinRequestsResponse;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/group/ListJoinRequestsResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCursor ()Ljava/lang/String;
+	public final fun getRequests ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/group/ListJoinRequestsResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/group/ListJoinRequestsResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/group/ListJoinRequestsResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/group/ListJoinRequestsResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/ListJoinRequestsResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/RejectJoinRequestRequest {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/group/RejectJoinRequestRequest$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2-UyB9Nic ()Ljava/lang/String;
+	public final fun copy-aB4ouW8 (Ljava/lang/String;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/group/RejectJoinRequestRequest;
+	public static synthetic fun copy-aB4ouW8$default (Lio/github/kikin81/atproto/chat/bsky/group/RejectJoinRequestRequest;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/group/RejectJoinRequestRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConvoId ()Ljava/lang/String;
+	public final fun getMember-UyB9Nic ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/group/RejectJoinRequestRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/group/RejectJoinRequestRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/group/RejectJoinRequestRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/group/RejectJoinRequestRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/RejectJoinRequestRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/RejectJoinRequestResponse {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/group/RejectJoinRequestResponse$Companion;
+	public fun <init> ()V
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/group/RejectJoinRequestResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/group/RejectJoinRequestResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/group/RejectJoinRequestResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/group/RejectJoinRequestResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/RejectJoinRequestResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/RemoveMembersRequest {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/group/RemoveMembersRequest$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;)Lio/github/kikin81/atproto/chat/bsky/group/RemoveMembersRequest;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/group/RemoveMembersRequest;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/group/RemoveMembersRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConvoId ()Ljava/lang/String;
+	public final fun getMembers ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/group/RemoveMembersRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/group/RemoveMembersRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/group/RemoveMembersRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/group/RemoveMembersRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/RemoveMembersRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/RemoveMembersResponse {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/group/RemoveMembersResponse$Companion;
+	public fun <init> (Lio/github/kikin81/atproto/chat/bsky/convo/ConvoView;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/chat/bsky/convo/ConvoView;
+	public final fun copy (Lio/github/kikin81/atproto/chat/bsky/convo/ConvoView;)Lio/github/kikin81/atproto/chat/bsky/group/RemoveMembersResponse;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/group/RemoveMembersResponse;Lio/github/kikin81/atproto/chat/bsky/convo/ConvoView;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/group/RemoveMembersResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConvo ()Lio/github/kikin81/atproto/chat/bsky/convo/ConvoView;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/group/RemoveMembersResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/group/RemoveMembersResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/group/RemoveMembersResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/group/RemoveMembersResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/RemoveMembersResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/RequestJoinRequest {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/group/RequestJoinRequest$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/group/RequestJoinRequest;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/group/RequestJoinRequest;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/group/RequestJoinRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCode ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/group/RequestJoinRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/group/RequestJoinRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/group/RequestJoinRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/group/RequestJoinRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/RequestJoinRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/RequestJoinResponse {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/group/RequestJoinResponse$Companion;
+	public fun <init> (Lio/github/kikin81/atproto/chat/bsky/convo/ConvoView;Ljava/lang/String;)V
+	public synthetic fun <init> (Lio/github/kikin81/atproto/chat/bsky/convo/ConvoView;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/chat/bsky/convo/ConvoView;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Lio/github/kikin81/atproto/chat/bsky/convo/ConvoView;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/group/RequestJoinResponse;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/group/RequestJoinResponse;Lio/github/kikin81/atproto/chat/bsky/convo/ConvoView;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/group/RequestJoinResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConvo ()Lio/github/kikin81/atproto/chat/bsky/convo/ConvoView;
+	public final fun getStatus ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/group/RequestJoinResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/group/RequestJoinResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/group/RequestJoinResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/group/RequestJoinResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/RequestJoinResponse$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 

--- a/models/src/commonTest/kotlin/io/github/kikin81/atproto/chat/bsky/group/GroupServiceTest.kt
+++ b/models/src/commonTest/kotlin/io/github/kikin81/atproto/chat/bsky/group/GroupServiceTest.kt
@@ -1,0 +1,282 @@
+package io.github.kikin81.atproto.chat.bsky.group
+
+import io.github.kikin81.atproto.runtime.AtField
+import io.github.kikin81.atproto.runtime.Did
+import io.github.kikin81.atproto.test.MockXrpcFixture
+import io.ktor.http.HttpMethod
+import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class GroupServiceTest {
+
+    private lateinit var fixture: MockXrpcFixture
+
+    @BeforeTest
+    fun setup() {
+        fixture = MockXrpcFixture()
+    }
+
+    private fun service() = GroupService(fixture.client)
+
+    /** Minimal valid JSON for the reused complex view types. */
+    private val convoJson =
+        """{"id":"3kconvo","members":[],"muted":false,"rev":"r1","unreadCount":0}"""
+    private val joinLinkJson =
+        """{"code":"abc123","createdAt":"2026-01-01T00:00:00Z",""" +
+            """"enabledStatus":"enabled","joinRule":"open","requireApproval":false}"""
+
+    private fun assertChatProxyApplied() {
+        // chat.bsky.* services route through the bsky chat appview by default.
+        assertEquals(
+            "did:web:api.bsky.chat#bsky_chat",
+            fixture.capturedHeaders["atproto-proxy"],
+        )
+    }
+
+    // ---- procedures returning ConvoView ----------------------------------
+
+    @Test
+    fun createGroupPostsMembersAndNameWithChatProxy() = runTest {
+        fixture.respondWith("""{"convo":$convoJson}""")
+
+        val response = service().createGroup(
+            CreateGroupRequest(
+                members = listOf(Did("did:plc:alice"), Did("did:plc:bob")),
+                name = "Trip planning",
+            ),
+        )
+
+        assertEquals(HttpMethod.Post, fixture.capturedMethod)
+        val url = fixture.capturedUrl
+        assertNotNull(url)
+        assertContains(url, "/xrpc/chat.bsky.group.createGroup")
+        assertChatProxyApplied()
+        val body = fixture.capturedBody
+        assertNotNull(body)
+        assertContains(body, "did:plc:alice")
+        assertContains(body, "did:plc:bob")
+        assertContains(body, "Trip planning")
+        assertEquals("3kconvo", response.convo.id)
+    }
+
+    @Test
+    fun createGroupSerializesUpTo49Members() = runTest {
+        fixture.respondWith("""{"convo":$convoJson}""")
+
+        val members = (1..49).map { Did("did:plc:member$it") }
+        service().createGroup(CreateGroupRequest(members = members, name = "Max group"))
+
+        val body = fixture.capturedBody
+        assertNotNull(body)
+        assertContains(body, "did:plc:member1\"")
+        assertContains(body, "did:plc:member49")
+    }
+
+    @Test
+    fun addMembersPostsConvoIdAndMembers() = runTest {
+        fixture.respondWith("""{"convo":$convoJson}""")
+
+        val response = service().addMembers(
+            AddMembersRequest(convoId = "3kconvo", members = listOf(Did("did:plc:carol"))),
+        )
+
+        assertEquals(HttpMethod.Post, fixture.capturedMethod)
+        assertContains(fixture.capturedUrl!!, "/xrpc/chat.bsky.group.addMembers")
+        assertChatProxyApplied()
+        assertContains(fixture.capturedBody!!, "did:plc:carol")
+        assertEquals("3kconvo", response.convo.id)
+    }
+
+    @Test
+    fun removeMembersPostsConvoIdAndMembers() = runTest {
+        fixture.respondWith("""{"convo":$convoJson}""")
+
+        val response = service().removeMembers(
+            RemoveMembersRequest(convoId = "3kconvo", members = listOf(Did("did:plc:carol"))),
+        )
+
+        assertEquals(HttpMethod.Post, fixture.capturedMethod)
+        assertContains(fixture.capturedUrl!!, "/xrpc/chat.bsky.group.removeMembers")
+        assertChatProxyApplied()
+        assertContains(fixture.capturedBody!!, "did:plc:carol")
+        assertEquals("3kconvo", response.convo.id)
+    }
+
+    @Test
+    fun editGroupPostsConvoIdAndName() = runTest {
+        fixture.respondWith("""{"convo":$convoJson}""")
+
+        val response = service().editGroup(EditGroupRequest(convoId = "3kconvo", name = "Renamed"))
+
+        assertEquals(HttpMethod.Post, fixture.capturedMethod)
+        assertContains(fixture.capturedUrl!!, "/xrpc/chat.bsky.group.editGroup")
+        assertChatProxyApplied()
+        assertContains(fixture.capturedBody!!, "Renamed")
+        assertEquals("3kconvo", response.convo.id)
+    }
+
+    @Test
+    fun approveJoinRequestPostsConvoIdAndMember() = runTest {
+        fixture.respondWith("""{"convo":$convoJson}""")
+
+        val response = service().approveJoinRequest(
+            ApproveJoinRequestRequest(convoId = "3kconvo", member = Did("did:plc:dan")),
+        )
+
+        assertEquals(HttpMethod.Post, fixture.capturedMethod)
+        assertContains(fixture.capturedUrl!!, "/xrpc/chat.bsky.group.approveJoinRequest")
+        assertChatProxyApplied()
+        assertContains(fixture.capturedBody!!, "did:plc:dan")
+        assertEquals("3kconvo", response.convo.id)
+    }
+
+    @Test
+    fun requestJoinPostsCodeAndDeserializesStatus() = runTest {
+        fixture.respondWith("""{"status":"joined","convo":$convoJson}""")
+
+        val response = service().requestJoin(RequestJoinRequest(code = "invite-xyz"))
+
+        assertEquals(HttpMethod.Post, fixture.capturedMethod)
+        assertContains(fixture.capturedUrl!!, "/xrpc/chat.bsky.group.requestJoin")
+        assertChatProxyApplied()
+        assertContains(fixture.capturedBody!!, "invite-xyz")
+        assertEquals("joined", response.status)
+        assertEquals("3kconvo", response.convo?.id)
+    }
+
+    // ---- procedure with empty response -----------------------------------
+
+    @Test
+    fun rejectJoinRequestPostsConvoIdAndMember() = runTest {
+        fixture.respondWith("{}")
+
+        service().rejectJoinRequest(
+            RejectJoinRequestRequest(convoId = "3kconvo", member = Did("did:plc:dan")),
+        )
+
+        assertEquals(HttpMethod.Post, fixture.capturedMethod)
+        assertContains(fixture.capturedUrl!!, "/xrpc/chat.bsky.group.rejectJoinRequest")
+        assertChatProxyApplied()
+        assertContains(fixture.capturedBody!!, "did:plc:dan")
+    }
+
+    // ---- join-link procedures returning JoinLinkView ---------------------
+
+    @Test
+    fun createJoinLinkPostsRuleAndApproval() = runTest {
+        fixture.respondWith("""{"joinLink":$joinLinkJson}""")
+
+        val response = service().createJoinLink(
+            CreateJoinLinkRequest(
+                convoId = "3kconvo",
+                joinRule = "open",
+                requireApproval = AtField.Defined(true),
+            ),
+        )
+
+        assertEquals(HttpMethod.Post, fixture.capturedMethod)
+        assertContains(fixture.capturedUrl!!, "/xrpc/chat.bsky.group.createJoinLink")
+        assertChatProxyApplied()
+        assertContains(fixture.capturedBody!!, "\"requireApproval\":true")
+        assertEquals("abc123", response.joinLink.code)
+    }
+
+    @Test
+    fun editJoinLinkPostsConvoId() = runTest {
+        fixture.respondWith("""{"joinLink":$joinLinkJson}""")
+
+        val response = service().editJoinLink(
+            EditJoinLinkRequest(convoId = "3kconvo", joinRule = AtField.Defined("closed")),
+        )
+
+        assertEquals(HttpMethod.Post, fixture.capturedMethod)
+        assertContains(fixture.capturedUrl!!, "/xrpc/chat.bsky.group.editJoinLink")
+        assertChatProxyApplied()
+        assertContains(fixture.capturedBody!!, "closed")
+        assertEquals("abc123", response.joinLink.code)
+    }
+
+    @Test
+    fun enableJoinLinkPostsConvoId() = runTest {
+        fixture.respondWith("""{"joinLink":$joinLinkJson}""")
+
+        val response = service().enableJoinLink(EnableJoinLinkRequest(convoId = "3kconvo"))
+
+        assertEquals(HttpMethod.Post, fixture.capturedMethod)
+        assertContains(fixture.capturedUrl!!, "/xrpc/chat.bsky.group.enableJoinLink")
+        assertChatProxyApplied()
+        assertContains(fixture.capturedBody!!, "3kconvo")
+        assertEquals("abc123", response.joinLink.code)
+    }
+
+    @Test
+    fun disableJoinLinkPostsConvoId() = runTest {
+        fixture.respondWith("""{"joinLink":$joinLinkJson}""")
+
+        val response = service().disableJoinLink(DisableJoinLinkRequest(convoId = "3kconvo"))
+
+        assertEquals(HttpMethod.Post, fixture.capturedMethod)
+        assertContains(fixture.capturedUrl!!, "/xrpc/chat.bsky.group.disableJoinLink")
+        assertChatProxyApplied()
+        assertContains(fixture.capturedBody!!, "3kconvo")
+        assertEquals("abc123", response.joinLink.code)
+    }
+
+    // ---- queries ----------------------------------------------------------
+
+    @Test
+    fun listJoinRequestsIsGetWithPaginatedParams() = runTest {
+        fixture.respondWith("""{"cursor":"next","requests":[]}""")
+
+        val response = service().listJoinRequests(
+            ListJoinRequestsRequest(convoId = "3kconvo", limit = 25, cursor = "abc"),
+        )
+
+        assertEquals(HttpMethod.Get, fixture.capturedMethod)
+        val url = fixture.capturedUrl
+        assertNotNull(url)
+        assertContains(url, "/xrpc/chat.bsky.group.listJoinRequests")
+        assertContains(url, "convoId=3kconvo")
+        assertContains(url, "limit=25")
+        assertContains(url, "cursor=abc")
+        assertChatProxyApplied()
+        assertEquals("next", response.cursor)
+        assertEquals(emptyList(), response.requests)
+    }
+
+    @Test
+    fun getGroupPublicInfoIsGetWithCodeParam() = runTest {
+        fixture.respondWith(
+            """{"group":{"memberCount":5,"name":"My Group",""" +
+                """"owner":{"did":"did:plc:owner","handle":"owner.test"},""" +
+                """"requireApproval":false}}""",
+        )
+
+        val response = service().getGroupPublicInfo(GetGroupPublicInfoRequest(code = "invite-xyz"))
+
+        assertEquals(HttpMethod.Get, fixture.capturedMethod)
+        val url = fixture.capturedUrl
+        assertNotNull(url)
+        assertContains(url, "/xrpc/chat.bsky.group.getGroupPublicInfo")
+        assertContains(url, "code=invite-xyz")
+        assertChatProxyApplied()
+        assertEquals(5L, response.group.memberCount)
+        assertEquals("My Group", response.group.name)
+    }
+
+    @Test
+    fun methodProxyOverrideWins() = runTest {
+        fixture.respondWith("""{"convo":$convoJson}""")
+
+        service().editGroup(
+            EditGroupRequest(convoId = "3kconvo", name = "x"),
+            proxy = "did:web:custom#svc",
+        )
+
+        assertEquals("did:web:custom#svc", fixture.capturedHeaders["atproto-proxy"])
+    }
+}

--- a/models/src/commonTest/kotlin/io/github/kikin81/atproto/test/MockXrpcFixture.kt
+++ b/models/src/commonTest/kotlin/io/github/kikin81/atproto/test/MockXrpcFixture.kt
@@ -15,7 +15,7 @@ import io.ktor.utils.io.ByteReadChannel
  * Lightweight test fixture for generated XRPC service tests.
  *
  * Sets up a Ktor [MockEngine]-backed [XrpcClient] that captures the most
- * recent outgoing request (URL, method, content-type, body) and serves
+ * recent outgoing request (URL, method, headers, content-type, body) and serves
  * the most recently configured canned response. Designed for `@BeforeTest`
  * construction; per-test response is configured via [respondWith] before
  * invoking the service under test.
@@ -36,6 +36,8 @@ class MockXrpcFixture(baseUrl: String = "https://pds.test") {
         private set
     var capturedBody: String? = null
         private set
+    var capturedHeaders: Map<String, String> = emptyMap()
+        private set
 
     val client: XrpcClient = XrpcClient(
         baseUrl = baseUrl,
@@ -43,6 +45,8 @@ class MockXrpcFixture(baseUrl: String = "https://pds.test") {
             MockEngine { request ->
                 capturedUrl = request.url.toString()
                 capturedMethod = request.method
+                capturedHeaders = request.headers.entries()
+                    .associate { it.key to it.value.first() }
                 val body = request.body
                 if (body is OutgoingContent.ByteArrayContent) {
                     capturedBody = body.bytes().decodeToString()

--- a/models/src/commonTest/kotlin/io/github/kikin81/atproto/test/MockXrpcFixture.kt
+++ b/models/src/commonTest/kotlin/io/github/kikin81/atproto/test/MockXrpcFixture.kt
@@ -45,8 +45,12 @@ class MockXrpcFixture(baseUrl: String = "https://pds.test") {
             MockEngine { request ->
                 capturedUrl = request.url.toString()
                 capturedMethod = request.method
+                // Normalize names to lower-case (HTTP header names are
+                // case-insensitive) and join multi-valued headers rather than
+                // dropping all but the first, so assertions are stable and
+                // never throw on an empty value list.
                 capturedHeaders = request.headers.entries()
-                    .associate { it.key to it.value.first() }
+                    .associate { (name, values) -> name.lowercase() to values.joinToString(",") }
                 val body = request.body
                 if (body is OutgoingContent.ByteArrayContent) {
                     capturedBody = body.bytes().decodeToString()


### PR DESCRIPTION
## Summary

Opts the SDK into the **13 published** `chat.bsky.group.*` operations, enabling group chats of up to **50 participants** (`createGroup` caps `members` at 49 DIDs + the creator).

Verified these lexicons are published to the AT Protocol network (proof-verifiable, CID-pinnable) — unlike `app.bsky.embed.gallery`, which is merged to GitHub source but not yet published (`RecordNotFound`) and is therefore not included here.

## What's included

`GroupService` (13 methods — 11 procedures + 2 queries) + request/response models, generated from the pinned corpus:

`createGroup`, `addMembers`, `removeMembers`, `editGroup`, `requestJoin`, `approveJoinRequest`, `rejectJoinRequest`, `listJoinRequests` (query, paginated), `createJoinLink`, `editJoinLink`, `enableJoinLink`, `disableJoinLink`, `getGroupPublicInfo` (query).

`chat.bsky.*` auto-inherits the `did:web:api.bsky.chat#bsky_chat` proxy via existing `ProxyMapping` — no generator change.

## Out of scope

The 4 GitHub-only endpoints (`getJoinLinkPreviews`, `listMutualGroups`, `updateJoinRequestsRead`, `withdrawJoinRequest`) are unpublished to the network (`RecordNotFound`); deferred until resolvable.

## Tests

- **`GroupServiceTest`** — 15 tests (one per method): HTTP verb, XRPC path, `atproto-proxy` header, request serialization (incl. a 49-member list), response deserialization, plus method-level proxy override.
- **`MockXrpcFixture`** — additive request-header capture, so chat proxy routing can be asserted.
- **Golden** — self-contained `createGroup` case locking the `maxLength`-bounded array-of-DID procedure input and the chat proxy emission.

## Verification

- ✅ All JVM tests (models incl. the 15 new, runtime, generator + golden regression, oauth)
- ✅ Android tests (compose, compose-material3)
- ✅ iOS-arm64 compile of the new generated models
- ✅ `spotlessCheck`
- ⚠️ iOS **simulator** test-linking not run locally (dev machine is CLT-only, no Xcode) — covered by CI.

Design doc: `docs/superpowers/specs/2026-06-11-chat-bsky-group-service-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)