### PR TITLE
feat: lexicon overlays for not-yet-published schemas (+ getConvoMembers)

### DIFF
--- a/.github/workflows/overlay-staleness.yaml
+++ b/.github/workflows/overlay-staleness.yaml
@@ -1,0 +1,157 @@
+name: Overlay staleness
+
+# Surfaces vendored lexicon overlays (generator/overlay-lexicons.json) that
+# should be RETIRED or RE-VENDORED:
+#   - retire: the record is now resolvable on-network (npx lex install
+#     succeeds), so the NSID belongs in generator/lexicons.json
+#   - re-vendor: the vendored JSON drifted from bluesky-social/atproto@main
+#
+# Complements .github/workflows/lexicon-drift-detect.yaml. That workflow flags
+# brand-new upstream NSIDs missing from our manifest (and now excludes overlay
+# NSIDs, deferring them here). This workflow manages the overlay lifecycle.
+#
+# Maintains a single tracking issue labeled `overlay-stale`:
+#   - staleness detected with no open issue -> create one
+#   - staleness detected with an open issue -> edit body in place
+#   - nothing stale with an open issue -> auto-close with comment
+
+on:
+  schedule:
+    # 12:00 UTC Mondays — one hour before lexicon-drift-detect (13:00 UTC).
+    - cron: "0 12 * * 1"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: overlay-staleness
+  cancel-in-progress: false
+
+jobs:
+  detect:
+    name: Detect overlay staleness
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: generator/package-lock.json
+
+      - name: Set up JDK
+        uses: actions/setup-java@v5
+        with:
+          distribution: zulu
+          java-version-file: .java-version
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
+
+      - name: Install generator npm deps
+        working-directory: generator
+        run: npm ci
+
+      - name: Probe overlay publishability
+        # For each overlay NSID, run the REAL `npx lex install` resolver
+        # against a THROWAWAY manifest + lexicons dir; exit 0 means the
+        # on-network record now exists (so the overlay can be retired).
+        # GITHUB_TOKEN is intentionally NOT exposed: the resolver hits the
+        # public PLC/PDS network, not the GitHub API, and we keep the token
+        # scoped to the gh-issue-management steps below so the probe process
+        # can't leak a credential it doesn't have.
+        working-directory: generator
+        run: |
+          set -euo pipefail
+          map='{}'
+          for nsid in $(jq -r '.overlays[].nsid' overlay-lexicons.json); do
+            tmp_manifest="$(mktemp)"
+            tmp_dir="$(mktemp -d)"
+            if npx lex install "$nsid" \
+                 --manifest "$tmp_manifest" \
+                 --lexicons "$tmp_dir" >/dev/null 2>&1; then
+              publishable=true
+            else
+              publishable=false
+            fi
+            echo "probe: $nsid -> publishable=$publishable"
+            map="$(jq --arg n "$nsid" --argjson v "$publishable" \
+              '. + {($n): $v}' <<<"$map")"
+          done
+          {
+            echo "OVERLAY_PUBLISHABLE_JSON<<EOF_overlay_publishable"
+            echo "$map"
+            echo "EOF_overlay_publishable"
+          } >> "$GITHUB_ENV"
+
+      - name: Run overlay staleness detection
+        id: detect
+        # GITHUB_TOKEN intentionally NOT exposed here either — the detector
+        # makes one HTTPS request per overlay against public
+        # raw.githubusercontent.com; unauthenticated suffices at our weekly
+        # cadence. It reads OVERLAY_PUBLISHABLE_JSON from the probe step.
+        run: ./gradlew :generator:detectStaleOverlays --quiet --no-configuration-cache
+
+      - name: Ensure overlay-stale label exists
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh label create overlay-stale \
+            --color FBCA04 \
+            --description "A vendored overlay can be retired or re-vendored" \
+            --force
+
+      - name: Find existing overlay-stale issue
+        id: find
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          existing=$(gh issue list \
+            --label overlay-stale \
+            --state open \
+            --json number \
+            --jq '.[0].number // empty')
+          echo "issue_number=${existing}" >> "$GITHUB_OUTPUT"
+
+      - name: Open or update tracking issue
+        if: steps.detect.outputs.has_stale == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BODY: ${{ steps.detect.outputs.body }}
+          STALE_COUNT: ${{ steps.detect.outputs.stale_count }}
+          EXISTING: ${{ steps.find.outputs.issue_number }}
+        run: |
+          set -euo pipefail
+          title="Overlay staleness: ${STALE_COUNT} overlay(s) need attention"
+          tmp=$(mktemp)
+          printf '%s' "$BODY" > "$tmp"
+          if [ -n "$EXISTING" ]; then
+            gh issue edit "$EXISTING" \
+              --title "$title" \
+              --body-file "$tmp"
+            echo "Updated existing overlay-stale issue #${EXISTING}"
+          else
+            gh issue create \
+              --title "$title" \
+              --body-file "$tmp" \
+              --label overlay-stale
+            echo "Created new overlay-stale tracking issue"
+          fi
+
+      - name: Auto-close overlay-stale issue when clean
+        if: steps.detect.outputs.has_stale == 'false' && steps.find.outputs.issue_number != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EXISTING: ${{ steps.find.outputs.issue_number }}
+        run: |
+          set -euo pipefail
+          gh issue close "$EXISTING" \
+            --reason completed \
+            --comment "No stale overlays detected on $(date -u +%Y-%m-%d). Closing automatically; will reopen if an overlay becomes retirable or drifts."

--- a/.github/workflows/overlay-staleness.yaml
+++ b/.github/workflows/overlay-staleness.yaml
@@ -74,6 +74,14 @@ jobs:
           for nsid in $(jq -r '.overlays[].nsid' overlay-lexicons.json); do
             tmp_manifest="$(mktemp)"
             tmp_dir="$(mktemp -d)"
+            # Seed a valid EMPTY manifest. @atproto/lex parses --manifest BEFORE
+            # any network resolution, so a zero-byte file (bare mktemp) — or one
+            # missing the required `resolutions` key — fails with "Unexpected end
+            # of JSON input" and the probe would ALWAYS fall to publishable=false,
+            # making the retire signal unreachable even after Bluesky publishes the
+            # record. An empty-but-valid manifest lets the resolver actually run, so
+            # exit 0 genuinely means "now resolvable on-network".
+            printf '%s' '{"version":1,"lexicons":[],"resolutions":{}}' > "$tmp_manifest"
             if npx lex install "$nsid" \
                  --manifest "$tmp_manifest" \
                  --lexicons "$tmp_dir" >/dev/null 2>&1; then

--- a/generator/build.gradle.kts
+++ b/generator/build.gradle.kts
@@ -93,3 +93,29 @@ tasks.register<JavaExec>("detectLexiconDrift") {
     // intentional opt-out from up-to-date caching.
     outputs.upToDateWhen { false }
 }
+
+/**
+ * Flags vendored overlays in `generator/overlay-lexicons.json` that should be
+ * retired (now resolvable on-network) or re-vendored (drifted from upstream).
+ *
+ * Reads the per-overlay publishable verdict from the `OVERLAY_PUBLISHABLE_JSON`
+ * env var (a `{nsid: bool}` map produced by the workflow's `npx lex install`
+ * probe); does its own upstream-drift HTTP comparison.
+ *
+ *   ./gradlew :generator:detectStaleOverlays
+ */
+val overlayManifestFile = layout.projectDirectory.file("overlay-lexicons.json")
+
+tasks.register<JavaExec>("detectStaleOverlays") {
+    group = "verification"
+    description = "Flag vendored overlays ready to retire or re-vendor."
+    notCompatibleWithConfigurationCache("overlay task captures script-level path values")
+
+    classpath = sourceSets.main.get().runtimeClasspath
+    mainClass.set("io.github.kikin81.atproto.generator.tools.DetectStaleOverlaysKt")
+    args = listOf(overlayManifestFile.asFile.absolutePath)
+
+    // Always reaches over the network for an authoritative upstream diff;
+    // intentional opt-out from up-to-date caching.
+    outputs.upToDateWhen { false }
+}

--- a/generator/build.gradle.kts
+++ b/generator/build.gradle.kts
@@ -32,6 +32,7 @@ tasks.test {
  * for a rarely-run codegen task; day-to-day builds still use the cc.
  */
 val lexiconsDir = layout.projectDirectory.dir("lexicons")
+val overlayDir = layout.projectDirectory.dir("overlay-lexicons")
 val generatedModelsDir = project(":models")
     .layout.buildDirectory.dir("generated/source/lexicon/commonMain/kotlin")
 
@@ -47,11 +48,19 @@ tasks.register<JavaExec>("generateModels") {
 
     classpath = sourceSets.main.get().runtimeClasspath
     mainClass.set("io.github.kikin81.atproto.generator.MainKt")
-    args = listOf(lexiconsDirFile.absolutePath, generatedModelsDirFile.absolutePath)
+    args = listOf(
+        lexiconsDirFile.absolutePath,
+        generatedModelsDirFile.absolutePath,
+        overlayDir.asFile.absolutePath,
+    )
 
     inputs.dir(lexiconsDir)
         .withPathSensitivity(PathSensitivity.RELATIVE)
         .withPropertyName("lexicons")
+        .optional()
+    inputs.dir(overlayDir)
+        .withPathSensitivity(PathSensitivity.RELATIVE)
+        .withPropertyName("overlayLexicons")
         .optional()
     outputs.dir(generatedModelsDir).withPropertyName("generatedSources")
 

--- a/generator/overlay-lexicons.json
+++ b/generator/overlay-lexicons.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "overlays": [
+    {
+      "nsid": "chat.bsky.convo.getConvoMembers",
+      "source": "https://github.com/bluesky-social/atproto/blob/3cb156907a15f3f22a1be734f82b3b0c855b4da0/lexicons/chat/bsky/convo/getConvoMembers.json",
+      "commit": "3cb156907a15f3f22a1be734f82b3b0c855b4da0",
+      "vendoredAt": "2026-06-20",
+      "reason": "Served by appview + present in bluesky-social/atproto main, but not yet published on-network (npx lex install -> RecordNotFound). Retire once publishable.",
+      "removeWhenPublished": true
+    }
+  ]
+}

--- a/generator/overlay-lexicons/chat/bsky/convo/getConvoMembers.json
+++ b/generator/overlay-lexicons/chat/bsky/convo/getConvoMembers.json
@@ -1,0 +1,42 @@
+{
+  "lexicon": 1,
+  "id": "chat.bsky.convo.getConvoMembers",
+  "defs": {
+    "main": {
+      "type": "query",
+      "description": "Returns a paginated list of members from a conversation.",
+      "errors": [{ "name": "InvalidConvo" }],
+      "parameters": {
+        "type": "params",
+        "required": ["convoId"],
+        "properties": {
+          "convoId": { "type": "string" },
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100,
+            "default": 50
+          },
+          "cursor": { "type": "string" }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["members"],
+          "properties": {
+            "cursor": { "type": "string" },
+            "members": {
+              "type": "array",
+              "items": {
+                "type": "ref",
+                "ref": "chat.bsky.actor.defs#profileViewBasic"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/generator/src/main/kotlin/io/github/kikin81/atproto/generator/Main.kt
+++ b/generator/src/main/kotlin/io/github/kikin81/atproto/generator/Main.kt
@@ -1,21 +1,27 @@
 package io.github.kikin81.atproto.generator
 
 import io.github.kikin81.atproto.generator.emit.CodeGenerator
+import io.github.kikin81.atproto.generator.ir.LexiconDocument
 import io.github.kikin81.atproto.generator.parser.LexiconParser
 import java.nio.file.Path
 import kotlin.io.path.exists
 import kotlin.system.exitProcess
 
 /**
- * CLI entry point: `java -jar generator.jar <lexiconsDir> <outputDir>`.
+ * CLI entry point: `java -jar generator.jar <lexiconsDir> <outputDir> [overlayDir]`.
  *
  * Parses every `*.json` under [lexiconsDir] and writes Kotlin source files
  * mirroring the AT Protocol lexicon corpus under [outputDir]. Used by the
  * Gradle `generateModels` task but also runnable by hand during development.
+ *
+ * An optional third argument points at an overlay-lexicons directory: hand-vendored
+ * lexicon JSON (for methods Bluesky serves but hasn't published on-network yet).
+ * Overlay docs are parsed and merged into the installed corpus by NSID with
+ * overlay-wins semantics; shadowing an installed NSID logs a stderr WARN.
  */
 public fun main(args: Array<String>) {
-    if (args.size != 2) {
-        System.err.println("Usage: <lexiconsDir> <outputDir>")
+    if (args.size !in 2..3) {
+        System.err.println("Usage: <lexiconsDir> <outputDir> [overlayDir]")
         exitProcess(2)
     }
     val lexiconsDir = Path.of(args[0])
@@ -34,7 +40,20 @@ public fun main(args: Array<String>) {
     } else {
         java.nio.file.Files.createDirectories(outputDir)
     }
-    val docs = LexiconParser().parseDirectory(lexiconsDir)
+    val overlayDir = args.getOrNull(2)?.let(Path::of)?.takeIf { it.exists() }
+    val installed = LexiconParser().parseDirectory(lexiconsDir)
+    val overlay = overlayDir?.let { LexiconParser().parseDirectory(it) } ?: emptyList()
+    val byId = LinkedHashMap<String, LexiconDocument>()
+    installed.forEach { byId[it.id] = it }
+    overlay.forEach { doc ->
+        if (byId.put(doc.id, doc) != null) {
+            System.err.println(
+                "WARN overlay shadows installed lexicon: ${doc.id} — " +
+                    "upstream may have published it; consider retiring the overlay.",
+            )
+        }
+    }
+    val docs = byId.values.toList()
     CodeGenerator().writeTo(docs, outputDir)
     println("generated lexicon sources for ${docs.size} documents into $outputDir")
 }

--- a/generator/src/main/kotlin/io/github/kikin81/atproto/generator/tools/DetectStaleOverlays.kt
+++ b/generator/src/main/kotlin/io/github/kikin81/atproto/generator/tools/DetectStaleOverlays.kt
@@ -1,0 +1,341 @@
+package io.github.kikin81.atproto.generator.tools
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardOpenOption
+import java.time.Duration
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+import kotlin.io.path.exists
+import kotlin.system.exitProcess
+
+/**
+ * Detects when a vendored lexicon overlay should be RETIRED or RE-VENDORED.
+ *
+ * An overlay is a lexicon we ship from `generator/overlay-lexicons/` because
+ * the real record isn't yet resolvable on-network via `npx lex install`
+ * (so it can't go in `generator/lexicons.json`). Each overlay carries a
+ * manifest entry in `generator/overlay-lexicons.json`. This tool flags two
+ * conditions per overlay:
+ *
+ *   - **publishable** — the on-network record now exists (the workflow probed
+ *     it with the real `npx lex install` resolver and passed the result in via
+ *     `OVERLAY_PUBLISHABLE_JSON`). The overlay should be RETIRED: move the NSID
+ *     into `generator/lexicons.json`, `npx lex install`, delete the vendored
+ *     file + manifest entry, regen.
+ *   - **drifted** — the vendored JSON no longer matches the upstream
+ *     `bluesky-social/atproto@main` copy (or upstream removed the path). The
+ *     overlay should be RE-VENDORED: re-copy the upstream JSON + bump the
+ *     manifest commit.
+ *
+ * Runnable locally (prints a markdown report to stdout) and from
+ * `.github/workflows/overlay-staleness.yaml` (writes `has_stale`,
+ * `stale_count`, and `body` to `$GITHUB_OUTPUT`).
+ *
+ * Honors `GITHUB_TOKEN` for the raw.githubusercontent.com fetches (auth bumps
+ * the rate limit). Unauthenticated also works.
+ */
+
+private const val UPSTREAM_RAW_BASE =
+    "https://raw.githubusercontent.com/bluesky-social/atproto/main/lexicons"
+
+private val overlayJson = Json {
+    ignoreUnknownKeys = true
+    prettyPrint = false
+}
+
+@Serializable
+internal data class OverlayEntry(
+    val nsid: String,
+    val source: String = "",
+    val commit: String = "",
+    val vendoredAt: String = "",
+    val reason: String = "",
+    val removeWhenPublished: Boolean = false,
+)
+
+@Serializable
+internal data class OverlayManifest(
+    val version: Int = 1,
+    val overlays: List<OverlayEntry> = emptyList(),
+)
+
+/** Drift outcome for a single overlay. */
+internal sealed interface DriftStatus {
+    /** Vendored copy matches upstream@main. */
+    data object InSync : DriftStatus
+
+    /** Vendored copy differs from upstream@main. */
+    data object Drifted : DriftStatus
+
+    /** Upstream path 404s — the lexicon was removed/renamed upstream. */
+    data object UpstreamRemoved : DriftStatus
+}
+
+internal fun parseOverlayManifest(manifestJson: String): OverlayManifest = overlayJson.decodeFromString<OverlayManifest>(manifestJson)
+
+/** Parses the workflow-supplied `{nsid: bool}` publishable map. Empty/blank -> empty. */
+internal fun parsePublishableMap(raw: String?): Map<String, Boolean> {
+    if (raw.isNullOrBlank()) return emptyMap()
+    val element = overlayJson.parseToJsonElement(raw)
+    if (element !is JsonObject) return emptyMap()
+    return element.mapNotNull { (key, value) ->
+        val prim = value as? JsonPrimitive ?: return@mapNotNull null
+        val bool = prim.content.toBooleanStrictOrNull() ?: return@mapNotNull null
+        key to bool
+    }.toMap()
+}
+
+private fun String.toBooleanStrictOrNull(): Boolean? = when (this) {
+    "true" -> true
+    "false" -> false
+    else -> null
+}
+
+/** `chat.bsky.convo.getConvoMembers` -> `chat/bsky/convo/getConvoMembers`. */
+internal fun nsidToPath(nsid: String): String = nsid.replace('.', '/')
+
+/**
+ * Canonical, whitespace-insensitive serialization of a lexicon JSON document.
+ *
+ * Object keys are sorted recursively so re-ordered-but-equivalent upstream
+ * edits don't read as drift; arrays preserve order (lexicon array order is
+ * semantically meaningful). Returns null if the input isn't parseable JSON.
+ */
+internal fun canonicalizeJson(raw: String): String? = runCatching {
+    overlayJson.encodeToString(JsonElement.serializer(), sortKeys(overlayJson.parseToJsonElement(raw)))
+}.getOrNull()
+
+private fun sortKeys(element: JsonElement): JsonElement = when (element) {
+    is JsonObject ->
+        JsonObject(element.entries.sortedBy { it.key }.associate { it.key to sortKeys(it.value) })
+    is JsonArray ->
+        JsonArray(element.map(::sortKeys))
+    else -> element
+}
+
+/** Drift verdict for one overlay: compare the vendored file to upstream@main. */
+internal fun computeDrift(
+    vendoredRaw: String,
+    upstreamRaw: String?,
+): DriftStatus {
+    if (upstreamRaw == null) return DriftStatus.UpstreamRemoved
+    val vendoredCanon = canonicalizeJson(vendoredRaw)
+    val upstreamCanon = canonicalizeJson(upstreamRaw)
+    // If either side won't canonicalize, fall back to a trimmed raw compare.
+    val left = vendoredCanon ?: vendoredRaw.trim()
+    val right = upstreamCanon ?: upstreamRaw.trim()
+    return if (left == right) DriftStatus.InSync else DriftStatus.Drifted
+}
+
+private val timestampFormatter: DateTimeFormatter =
+    DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm 'UTC'")
+
+/** Per-overlay result fed to the report renderer. */
+internal data class OverlayStatus(
+    val nsid: String,
+    val publishable: Boolean,
+    val drift: DriftStatus,
+) {
+    /** Stale = actionable: retire (publishable) or re-vendor (drifted/removed). */
+    val isStale: Boolean get() = publishable || drift != DriftStatus.InSync
+}
+
+internal fun renderReport(
+    statuses: List<OverlayStatus>,
+    now: OffsetDateTime,
+): String = buildString {
+    appendLine(
+        "_Generated ${timestampFormatter.format(now)} by " +
+            "`.github/workflows/overlay-staleness.yaml`._",
+    )
+    appendLine()
+    appendLine(
+        "Tracks vendored lexicon overlays in `generator/overlay-lexicons.json`. " +
+            "An overlay should be **retired** once its record is resolvable " +
+            "on-network (so it belongs in `generator/lexicons.json`), or " +
+            "**re-vendored** when its source JSON drifts from " +
+            "[`bluesky-social/atproto@main`]" +
+            "(https://github.com/bluesky-social/atproto/tree/main/lexicons).",
+    )
+    appendLine()
+
+    val stale = statuses.filter { it.isStale }
+    appendLine("## Overlays needing attention (${stale.size})")
+    appendLine()
+    if (stale.isEmpty()) {
+        appendLine("_(none — every overlay is still required and in sync with upstream.)_")
+        appendLine()
+    } else {
+        for (status in stale.sortedBy { it.nsid }) {
+            appendLine(renderStaleLine(status))
+            appendLine()
+        }
+    }
+
+    appendLine("## All overlays (${statuses.size})")
+    appendLine()
+    if (statuses.isEmpty()) {
+        appendLine("_(no overlays vendored.)_")
+        appendLine()
+    } else {
+        for (status in statuses.sortedBy { it.nsid }) {
+            val pub = if (status.publishable) "publishable" else "not-yet-publishable"
+            val drift = when (status.drift) {
+                DriftStatus.InSync -> "in-sync"
+                DriftStatus.Drifted -> "DRIFTED"
+                DriftStatus.UpstreamRemoved -> "UPSTREAM-REMOVED"
+            }
+            appendLine("- `${status.nsid}` — $pub, $drift")
+        }
+        appendLine()
+    }
+
+    appendLine("---")
+    appendLine()
+    append(
+        "**Note.** The publishable probe runs the real `npx lex install` " +
+            "resolver against a throwaway manifest; success means the " +
+            "on-network record now exists. Drift compares the vendored file " +
+            "to upstream `main` with a key-sorted, whitespace-insensitive " +
+            "JSON canonicalization.",
+    )
+}
+
+private fun renderStaleLine(status: OverlayStatus): String {
+    val nsid = status.nsid
+    val path = nsidToPath(nsid)
+    return when {
+        status.publishable -> {
+            "✅ `$nsid` — now resolvable on-network. **RETIRE:** add to " +
+                "`generator/lexicons.json` + `npx lex install`, " +
+                "`rm generator/overlay-lexicons/$path.json` + its manifest entry, " +
+                "`./gradlew :generator:generateModels apiDump`."
+        }
+        status.drift == DriftStatus.UpstreamRemoved -> {
+            "⚠️ `$nsid` — upstream removed `lexicons/$path.json` from " +
+                "bluesky-social/atproto@main. **TRIAGE:** confirm rename/deprecation; " +
+                "if gone for good, retire the overlay or pin to a tagged commit."
+        }
+        else -> {
+            "⚠️ `$nsid` — overlay drifted from bluesky-social/atproto@main. " +
+                "**RE-VENDOR:** re-copy the upstream JSON into " +
+                "`generator/overlay-lexicons/$path.json` + bump the manifest `commit`."
+        }
+    }
+}
+
+/** GET a raw upstream lexicon. Returns null on 404, throws on other non-200. */
+private fun fetchUpstreamLexicon(nsid: String, token: String?): String? {
+    val url = "$UPSTREAM_RAW_BASE/${nsidToPath(nsid)}.json"
+    val builder = HttpRequest.newBuilder()
+        .uri(URI.create(url))
+        .timeout(Duration.ofSeconds(30))
+        .header("Accept", "application/vnd.github.raw+json")
+        .header("User-Agent", "kikinlex-overlay-staleness-detect")
+        .GET()
+    if (!token.isNullOrEmpty()) builder.header("Authorization", "Bearer $token")
+    val client = HttpClient.newBuilder()
+        .connectTimeout(Duration.ofSeconds(15))
+        .build()
+    val response = client.send(builder.build(), HttpResponse.BodyHandlers.ofString())
+    return when (response.statusCode()) {
+        200 -> response.body()
+        404 -> null
+        else -> error(
+            "GitHub raw returned ${response.statusCode()} for $url: " +
+                response.body().take(200),
+        )
+    }
+}
+
+private fun emitActionsOutputs(
+    outputFile: Path,
+    body: String,
+    hasStale: Boolean,
+    staleCount: Int,
+) {
+    val delim = "EOF_overlay_body_marker"
+    val payload = buildString {
+        append("has_stale=").append(if (hasStale) "true" else "false").append('\n')
+        append("stale_count=").append(staleCount).append('\n')
+        append("body<<").append(delim).append('\n')
+        append(body)
+        append('\n').append(delim).append('\n')
+    }
+    Files.writeString(
+        outputFile,
+        payload,
+        StandardOpenOption.CREATE,
+        StandardOpenOption.APPEND,
+    )
+}
+
+/**
+ * CLI entry point: `java -jar generator.jar <overlayManifestPath?>`.
+ *
+ * If no path is given, defaults to `generator/overlay-lexicons.json` relative
+ * to the working directory (the layout when invoked via
+ * `./gradlew :generator:detectStaleOverlays` from the repo root). Vendored
+ * files are read from `generator/overlay-lexicons/<nsid-as-path>.json`
+ * alongside the manifest.
+ */
+public fun main(args: Array<String>) {
+    val manifestPath =
+        if (args.isNotEmpty()) {
+            Path.of(args[0])
+        } else {
+            Path.of("generator/overlay-lexicons.json")
+        }
+    if (!manifestPath.exists()) {
+        System.err.println("overlay manifest not found: $manifestPath")
+        exitProcess(2)
+    }
+    val overlayDir = manifestPath.resolveSibling("overlay-lexicons")
+
+    val manifest = parseOverlayManifest(Files.readString(manifestPath))
+    val publishable = parsePublishableMap(System.getenv("OVERLAY_PUBLISHABLE_JSON"))
+    val token = System.getenv("GITHUB_TOKEN")
+
+    val statuses = manifest.overlays.map { overlay ->
+        val vendoredFile = overlayDir.resolve("${nsidToPath(overlay.nsid)}.json")
+        val drift = if (!vendoredFile.exists()) {
+            System.err.println(
+                "WARNING: manifest lists ${overlay.nsid} but " +
+                    "$vendoredFile is missing; treating as drifted",
+            )
+            DriftStatus.Drifted
+        } else {
+            computeDrift(
+                Files.readString(vendoredFile),
+                fetchUpstreamLexicon(overlay.nsid, token),
+            )
+        }
+        OverlayStatus(
+            nsid = overlay.nsid,
+            publishable = publishable[overlay.nsid] == true,
+            drift = drift,
+        )
+    }
+
+    val staleCount = statuses.count { it.isStale }
+    val hasStale = staleCount > 0
+    val body = renderReport(statuses, OffsetDateTime.now(ZoneOffset.UTC))
+
+    println(body)
+
+    System.getenv("GITHUB_OUTPUT")?.takeIf { it.isNotEmpty() }?.let { outFilePath ->
+        emitActionsOutputs(Path.of(outFilePath), body, hasStale, staleCount)
+    }
+}

--- a/generator/src/main/kotlin/io/github/kikin81/atproto/generator/tools/DetectStaleOverlays.kt
+++ b/generator/src/main/kotlin/io/github/kikin81/atproto/generator/tools/DetectStaleOverlays.kt
@@ -147,9 +147,17 @@ internal data class OverlayStatus(
     val nsid: String,
     val publishable: Boolean,
     val drift: DriftStatus,
+    // Honors the manifest opt-out: an overlay pinned with removeWhenPublished=false
+    // is intentionally kept even after upstream publishes, so it must NOT be flagged
+    // for retirement. Defaults true (the common case).
+    val removeWhenPublished: Boolean = true,
 ) {
-    /** Stale = actionable: retire (publishable) or re-vendor (drifted/removed). */
-    val isStale: Boolean get() = publishable || drift != DriftStatus.InSync
+    /**
+     * Stale = actionable: retire (publishable AND opted in to removal) or re-vendor
+     * (drifted/removed). A pinned overlay (removeWhenPublished=false) still surfaces
+     * drift — we just never tell the maintainer to retire it.
+     */
+    val isStale: Boolean get() = (publishable && removeWhenPublished) || drift != DriftStatus.InSync
 }
 
 internal fun renderReport(
@@ -191,7 +199,11 @@ internal fun renderReport(
         appendLine()
     } else {
         for (status in statuses.sortedBy { it.nsid }) {
-            val pub = if (status.publishable) "publishable" else "not-yet-publishable"
+            val pub = when {
+                status.publishable && !status.removeWhenPublished -> "publishable (pinned: removeWhenPublished=false)"
+                status.publishable -> "publishable"
+                else -> "not-yet-publishable"
+            }
             val drift = when (status.drift) {
                 DriftStatus.InSync -> "in-sync"
                 DriftStatus.Drifted -> "DRIFTED"
@@ -217,7 +229,7 @@ private fun renderStaleLine(status: OverlayStatus): String {
     val nsid = status.nsid
     val path = nsidToPath(nsid)
     return when {
-        status.publishable -> {
+        status.publishable && status.removeWhenPublished -> {
             "✅ `$nsid` — now resolvable on-network. **RETIRE:** add to " +
                 "`generator/lexicons.json` + `npx lex install`, " +
                 "`rm generator/overlay-lexicons/$path.json` + its manifest entry, " +
@@ -326,6 +338,7 @@ public fun main(args: Array<String>) {
             nsid = overlay.nsid,
             publishable = publishable[overlay.nsid] == true,
             drift = drift,
+            removeWhenPublished = overlay.removeWhenPublished,
         )
     }
 

--- a/generator/src/main/kotlin/io/github/kikin81/atproto/generator/tools/LexiconDriftDetect.kt
+++ b/generator/src/main/kotlin/io/github/kikin81/atproto/generator/tools/LexiconDriftDetect.kt
@@ -69,6 +69,23 @@ internal fun parseUpstreamNsids(treeJson: String): Set<String> {
 
 internal fun parseManifestNsids(manifestJson: String): Set<String> = json.decodeFromString<Manifest>(manifestJson).lexicons.toSet()
 
+@Serializable
+internal data class OverlayManifestRef(val overlays: List<OverlayRef> = emptyList())
+
+@Serializable
+internal data class OverlayRef(val nsid: String)
+
+/**
+ * NSIDs handled by vendored overlays (`generator/overlay-lexicons.json`).
+ *
+ * These are intentionally absent from `lexicons.json` — they're served by the
+ * appview but not yet resolvable on-network — so the drift report subtracts
+ * them from the "new upstream" set to avoid flagging them forever. Their
+ * lifecycle is tracked by the overlay-staleness job instead. Missing file ->
+ * empty set.
+ */
+internal fun parseOverlayNsids(overlayManifestJson: String): Set<String> = json.decodeFromString<OverlayManifestRef>(overlayManifestJson).overlays.map { it.nsid }.toSet()
+
 internal fun isSubscription(nsid: String): Boolean = nsid.substringAfterLast('.').startsWith("subscribe")
 
 /**
@@ -98,6 +115,7 @@ internal fun renderReport(
     newNsids: Set<String>,
     removedNsids: Set<String>,
     now: OffsetDateTime,
+    overlayCount: Int = 0,
 ): String = buildString {
     appendLine(
         "_Generated ${timestampFormatter.format(now)} by " +
@@ -110,6 +128,13 @@ internal fun renderReport(
             "(https://github.com/bluesky-social/atproto/tree/main/lexicons).",
     )
     appendLine()
+    if (overlayCount > 0) {
+        appendLine(
+            "_($overlayCount NSID(s) handled by overlays — excluded here; " +
+                "see the `overlay-stale` tracking issue.)_",
+        )
+        appendLine()
+    }
 
     appendLine("## New upstream NSIDs (${newNsids.size})")
     appendLine()
@@ -228,13 +253,28 @@ public fun main(args: Array<String>) {
         exitProcess(2)
     }
 
+    // Overlay NSIDs are intentionally absent from lexicons.json (vendored
+    // until resolvable on-network); exclude them so they don't read as drift
+    // forever. Their lifecycle is tracked by the overlay-staleness job.
+    val overlayManifestPath = manifestPath.resolveSibling("overlay-lexicons.json")
+    val overlayNsids = if (overlayManifestPath.exists()) {
+        parseOverlayNsids(Files.readString(overlayManifestPath))
+    } else {
+        emptySet()
+    }
+
     val upstream = parseUpstreamNsids(fetchUpstreamTree(System.getenv("GITHUB_TOKEN")))
     val manifest = parseManifestNsids(Files.readString(manifestPath))
-    val newNsids = upstream - manifest
+    val newNsids = upstream - manifest - overlayNsids
     val removedNsids = manifest - upstream
     val hasDrift = newNsids.isNotEmpty() || removedNsids.isNotEmpty()
     val body =
-        renderReport(newNsids, removedNsids, OffsetDateTime.now(ZoneOffset.UTC))
+        renderReport(
+            newNsids,
+            removedNsids,
+            OffsetDateTime.now(ZoneOffset.UTC),
+            overlayNsids.size,
+        )
 
     println(body)
 

--- a/generator/src/test/kotlin/io/github/kikin81/atproto/generator/tools/DetectStaleOverlaysTest.kt
+++ b/generator/src/test/kotlin/io/github/kikin81/atproto/generator/tools/DetectStaleOverlaysTest.kt
@@ -104,6 +104,36 @@ class DetectStaleOverlaysTest {
     }
 
     @Test
+    fun `pinned overlay (removeWhenPublished=false) is not retired when publishable`() {
+        // Publishable but intentionally pinned → NOT stale (no retire signal).
+        assertFalse(
+            OverlayStatus("a.b.c", publishable = true, DriftStatus.InSync, removeWhenPublished = false).isStale,
+        )
+        // A pinned overlay still surfaces drift (re-vendor), just not retirement.
+        assertTrue(
+            OverlayStatus("a.b.c", publishable = true, DriftStatus.Drifted, removeWhenPublished = false).isStale,
+        )
+    }
+
+    @Test
+    fun `renderReport does not emit RETIRE for a pinned publishable overlay`() {
+        val statuses = listOf(
+            OverlayStatus(
+                "chat.bsky.convo.getConvoMembers",
+                publishable = true,
+                DriftStatus.InSync,
+                removeWhenPublished = false,
+            ),
+        )
+
+        val body = renderReport(statuses, fixedNow)
+
+        assertContains(body, "## Overlays needing attention (0)")
+        assertFalse(body.contains("**RETIRE:**"))
+        assertContains(body, "publishable (pinned: removeWhenPublished=false)")
+    }
+
+    @Test
     fun `renderReport produces the clean body when nothing is stale`() {
         val statuses = listOf(
             OverlayStatus(

--- a/generator/src/test/kotlin/io/github/kikin81/atproto/generator/tools/DetectStaleOverlaysTest.kt
+++ b/generator/src/test/kotlin/io/github/kikin81/atproto/generator/tools/DetectStaleOverlaysTest.kt
@@ -1,0 +1,170 @@
+package io.github.kikin81.atproto.generator.tools
+
+import java.time.OffsetDateTime
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class DetectStaleOverlaysTest {
+
+    private val fixedNow: OffsetDateTime = OffsetDateTime.parse("2026-06-20T12:00:00Z")
+
+    @Test
+    fun `parseOverlayManifest reads nsids and removeWhenPublished`() {
+        val payload = """
+            {
+              "version": 1,
+              "overlays": [
+                {
+                  "nsid": "chat.bsky.convo.getConvoMembers",
+                  "commit": "abc123",
+                  "removeWhenPublished": true
+                }
+              ]
+            }
+        """.trimIndent()
+
+        val manifest = parseOverlayManifest(payload)
+
+        assertEquals(1, manifest.overlays.size)
+        assertEquals("chat.bsky.convo.getConvoMembers", manifest.overlays[0].nsid)
+        assertTrue(manifest.overlays[0].removeWhenPublished)
+    }
+
+    @Test
+    fun `parsePublishableMap parses a nsid-to-bool map`() {
+        val map = parsePublishableMap("""{"a.b.c": true, "d.e.f": false}""")
+
+        assertEquals(true, map["a.b.c"])
+        assertEquals(false, map["d.e.f"])
+    }
+
+    @Test
+    fun `parsePublishableMap returns empty for null or blank`() {
+        assertTrue(parsePublishableMap(null).isEmpty())
+        assertTrue(parsePublishableMap("").isEmpty())
+        assertTrue(parsePublishableMap("   ").isEmpty())
+    }
+
+    @Test
+    fun `nsidToPath converts dotted nsid to a slash path`() {
+        assertEquals(
+            "chat/bsky/convo/getConvoMembers",
+            nsidToPath("chat.bsky.convo.getConvoMembers"),
+        )
+    }
+
+    @Test
+    fun `computeDrift treats key-reordered equivalent JSON as in-sync`() {
+        val vendored = """{"id":"x","lexicon":1,"defs":{"main":{"type":"query"}}}"""
+        val upstream = """{"lexicon":1,"defs":{"main":{"type":"query"}},"id":"x"}"""
+
+        assertEquals(DriftStatus.InSync, computeDrift(vendored, upstream))
+    }
+
+    @Test
+    fun `computeDrift ignores insignificant whitespace`() {
+        val vendored = """{"id":"x","lexicon":1}"""
+        val upstream = "{\n  \"id\": \"x\",\n  \"lexicon\": 1\n}\n"
+
+        assertEquals(DriftStatus.InSync, computeDrift(vendored, upstream))
+    }
+
+    @Test
+    fun `computeDrift flags a semantic difference`() {
+        val vendored = """{"id":"x","lexicon":1}"""
+        val upstream = """{"id":"x","lexicon":2}"""
+
+        assertEquals(DriftStatus.Drifted, computeDrift(vendored, upstream))
+    }
+
+    @Test
+    fun `computeDrift preserves array order as significant`() {
+        val vendored = """{"errors":[{"name":"A"},{"name":"B"}]}"""
+        val upstream = """{"errors":[{"name":"B"},{"name":"A"}]}"""
+
+        assertEquals(DriftStatus.Drifted, computeDrift(vendored, upstream))
+    }
+
+    @Test
+    fun `computeDrift reports UpstreamRemoved when upstream is null`() {
+        assertEquals(DriftStatus.UpstreamRemoved, computeDrift("""{"id":"x"}""", null))
+    }
+
+    @Test
+    fun `OverlayStatus isStale is false only when not publishable and in sync`() {
+        assertFalse(OverlayStatus("a.b.c", publishable = false, DriftStatus.InSync).isStale)
+        assertTrue(OverlayStatus("a.b.c", publishable = true, DriftStatus.InSync).isStale)
+        assertTrue(OverlayStatus("a.b.c", publishable = false, DriftStatus.Drifted).isStale)
+        assertTrue(
+            OverlayStatus("a.b.c", publishable = false, DriftStatus.UpstreamRemoved).isStale,
+        )
+    }
+
+    @Test
+    fun `renderReport produces the clean body when nothing is stale`() {
+        val statuses = listOf(
+            OverlayStatus(
+                "chat.bsky.convo.getConvoMembers",
+                publishable = false,
+                DriftStatus.InSync,
+            ),
+        )
+
+        val body = renderReport(statuses, fixedNow)
+
+        assertContains(body, "_Generated 2026-06-20 12:00 UTC")
+        assertContains(body, "## Overlays needing attention (0)")
+        assertContains(body, "_(none — every overlay is still required and in sync with upstream.)_")
+        assertContains(body, "## All overlays (1)")
+        assertContains(body, "- `chat.bsky.convo.getConvoMembers` — not-yet-publishable, in-sync")
+    }
+
+    @Test
+    fun `renderReport emits a RETIRE line for a publishable overlay`() {
+        val statuses = listOf(
+            OverlayStatus(
+                "chat.bsky.convo.getConvoMembers",
+                publishable = true,
+                DriftStatus.InSync,
+            ),
+        )
+
+        val body = renderReport(statuses, fixedNow)
+
+        assertContains(body, "## Overlays needing attention (1)")
+        assertContains(body, "✅ `chat.bsky.convo.getConvoMembers` — now resolvable on-network")
+        assertContains(body, "**RETIRE:**")
+        assertContains(
+            body,
+            "rm generator/overlay-lexicons/chat/bsky/convo/getConvoMembers.json",
+        )
+    }
+
+    @Test
+    fun `renderReport emits a RE-VENDOR line for a drifted overlay`() {
+        val statuses = listOf(
+            OverlayStatus("app.bsky.feed.fancy", publishable = false, DriftStatus.Drifted),
+        )
+
+        val body = renderReport(statuses, fixedNow)
+
+        assertContains(body, "⚠️ `app.bsky.feed.fancy` — overlay drifted")
+        assertContains(body, "**RE-VENDOR:**")
+        assertContains(body, "generator/overlay-lexicons/app/bsky/feed/fancy.json")
+    }
+
+    @Test
+    fun `renderReport emits a triage line for an upstream-removed overlay`() {
+        val statuses = listOf(
+            OverlayStatus("app.bsky.feed.gone", publishable = false, DriftStatus.UpstreamRemoved),
+        )
+
+        val body = renderReport(statuses, fixedNow)
+
+        assertContains(body, "⚠️ `app.bsky.feed.gone` — upstream removed")
+        assertContains(body, "**TRIAGE:**")
+    }
+}

--- a/models/api/models.api
+++ b/models/api/models.api
@@ -10237,6 +10237,8 @@ public final class io/github/kikin81/atproto/chat/bsky/convo/ConvoService {
 	public static synthetic fun getConvoAvailability$default (Lio/github/kikin81/atproto/chat/bsky/convo/ConvoService;Lio/github/kikin81/atproto/chat/bsky/convo/GetConvoAvailabilityRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun getConvoForMembers (Lio/github/kikin81/atproto/chat/bsky/convo/GetConvoForMembersRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun getConvoForMembers$default (Lio/github/kikin81/atproto/chat/bsky/convo/ConvoService;Lio/github/kikin81/atproto/chat/bsky/convo/GetConvoForMembersRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getConvoMembers (Lio/github/kikin81/atproto/chat/bsky/convo/GetConvoMembersRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getConvoMembers$default (Lio/github/kikin81/atproto/chat/bsky/convo/ConvoService;Lio/github/kikin81/atproto/chat/bsky/convo/GetConvoMembersRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun getLog (Lio/github/kikin81/atproto/chat/bsky/convo/GetLogRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun getLog$default (Lio/github/kikin81/atproto/chat/bsky/convo/ConvoService;Lio/github/kikin81/atproto/chat/bsky/convo/GetLogRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun getMessages (Lio/github/kikin81/atproto/chat/bsky/convo/GetMessagesRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -10268,6 +10270,8 @@ public final class io/github/kikin81/atproto/chat/bsky/convo/ConvoService {
 }
 
 public final class io/github/kikin81/atproto/chat/bsky/convo/ConvoServiceKt {
+	public static final fun convoMembersFlow (Lio/github/kikin81/atproto/chat/bsky/convo/ConvoService;Lio/github/kikin81/atproto/chat/bsky/convo/GetConvoMembersRequest;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun convoMembersPageFlow (Lio/github/kikin81/atproto/chat/bsky/convo/ConvoService;Lio/github/kikin81/atproto/chat/bsky/convo/GetConvoMembersRequest;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun listConvoRequestsFlow (Lio/github/kikin81/atproto/chat/bsky/convo/ConvoService;Lio/github/kikin81/atproto/chat/bsky/convo/ListConvoRequestsRequest;)Lkotlinx/coroutines/flow/Flow;
 	public static synthetic fun listConvoRequestsFlow$default (Lio/github/kikin81/atproto/chat/bsky/convo/ConvoService;Lio/github/kikin81/atproto/chat/bsky/convo/ListConvoRequestsRequest;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun listConvoRequestsPageFlow (Lio/github/kikin81/atproto/chat/bsky/convo/ConvoService;Lio/github/kikin81/atproto/chat/bsky/convo/ListConvoRequestsRequest;)Lkotlinx/coroutines/flow/Flow;
@@ -10638,6 +10642,68 @@ public final synthetic class io/github/kikin81/atproto/chat/bsky/convo/GetConvoF
 }
 
 public final class io/github/kikin81/atproto/chat/bsky/convo/GetConvoForMembersResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/GetConvoMembersRequest {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/GetConvoMembersRequest$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/Long;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;)Lio/github/kikin81/atproto/chat/bsky/convo/GetConvoMembersRequest;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/GetConvoMembersRequest;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/GetConvoMembersRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConvoId ()Ljava/lang/String;
+	public final fun getCursor ()Ljava/lang/String;
+	public final fun getLimit ()Ljava/lang/Long;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/convo/GetConvoMembersRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/GetConvoMembersRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/convo/GetConvoMembersRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/convo/GetConvoMembersRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/GetConvoMembersRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/GetConvoMembersResponse {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/GetConvoMembersResponse$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;)Lio/github/kikin81/atproto/chat/bsky/convo/GetConvoMembersResponse;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/GetConvoMembersResponse;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/GetConvoMembersResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCursor ()Ljava/lang/String;
+	public final fun getMembers ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/convo/GetConvoMembersResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/GetConvoMembersResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/convo/GetConvoMembersResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/convo/GetConvoMembersResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/GetConvoMembersResponse$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 

--- a/models/src/commonTest/kotlin/io/github/kikin81/atproto/chat/bsky/convo/ConvoServiceTest.kt
+++ b/models/src/commonTest/kotlin/io/github/kikin81/atproto/chat/bsky/convo/ConvoServiceTest.kt
@@ -1,0 +1,72 @@
+package io.github.kikin81.atproto.chat.bsky.convo
+
+import io.github.kikin81.atproto.test.MockXrpcFixture
+import io.ktor.http.HttpMethod
+import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class ConvoServiceTest {
+
+    private lateinit var fixture: MockXrpcFixture
+
+    @BeforeTest
+    fun setup() {
+        fixture = MockXrpcFixture()
+    }
+
+    private fun service() = ConvoService(fixture.client)
+
+    private fun assertChatProxyApplied() {
+        // chat.bsky.* services route through the bsky chat appview by default.
+        assertEquals(
+            "did:web:api.bsky.chat#bsky_chat",
+            fixture.capturedHeaders["atproto-proxy"],
+        )
+    }
+
+    @Test
+    fun getConvoMembersIsGetWithPaginatedParamsAndChatProxy() = runTest {
+        fixture.respondWith(
+            """{"cursor":"next","members":[""" +
+                """{"did":"did:plc:alice","handle":"alice.test"},""" +
+                """{"did":"did:plc:bob","handle":"bob.test"}]}""",
+        )
+
+        val response = service().getConvoMembers(
+            GetConvoMembersRequest(convoId = "3kconvo", limit = 25, cursor = "abc"),
+        )
+
+        assertEquals(HttpMethod.Get, fixture.capturedMethod)
+        val url = fixture.capturedUrl
+        assertNotNull(url)
+        assertContains(url, "/xrpc/chat.bsky.convo.getConvoMembers")
+        assertContains(url, "convoId=3kconvo")
+        assertContains(url, "limit=25")
+        assertContains(url, "cursor=abc")
+        assertChatProxyApplied()
+        assertEquals("next", response.cursor)
+        assertEquals(2, response.members.size)
+        assertEquals("did:plc:alice", response.members[0].did.raw)
+        assertEquals("bob.test", response.members[1].handle.raw)
+    }
+
+    @Test
+    fun getConvoMembersOmitsOptionalParamsWhenAbsent() = runTest {
+        fixture.respondWith("""{"members":[]}""")
+
+        val response = service().getConvoMembers(GetConvoMembersRequest(convoId = "3kconvo"))
+
+        assertEquals(HttpMethod.Get, fixture.capturedMethod)
+        val url = fixture.capturedUrl
+        assertNotNull(url)
+        assertContains(url, "/xrpc/chat.bsky.convo.getConvoMembers")
+        assertContains(url, "convoId=3kconvo")
+        assertChatProxyApplied()
+        assertEquals(null, response.cursor)
+        assertEquals(emptyList(), response.members)
+    }
+}


### PR DESCRIPTION
## Why

The SDK codegens from **on-network, CID-pinned** lexicon records (`npx lex install`). But Bluesky's appview serves features for **weeks** before their lexicon schema record is published on-network — e.g. `chat.bsky.convo.getConvoMembers` is in `bluesky-social/atproto` `main` and served in production, yet `getRecord` for its schema returns `RecordNotFound`, so `lex install` can't pull it. That blocks downstream apps (group-chat member lists/counts) with no clean path.

## What

A scoped **overlay-lexicons** escape hatch (the pattern the rest of the AT Proto ecosystem uses — vendored JSON), kept separate from the pinned corpus so reproducibility/`lex install --ci` are untouched.

**1. Overlay mechanism** (`feat(generator)`)
- `generator/overlay-lexicons/` — committed, hand-vendored lexicon JSON (provenance in `generator/overlay-lexicons.json`: upstream source + commit SHA + reason + `removeWhenPublished`).
- `Main.kt` parses the overlay dir alongside the installed corpus and merges by NSID (**overlay-wins**, warns on shadow so a stale overlay is loud once upstream publishes); deduped before codegen to respect `SymbolTable`'s no-duplicates rule.
- `build.gradle.kts` passes the overlay dir as an optional input to `generateModels`.
- Overlays are **never added to `lexicons.json`**, so `npx lex install --ci` (CI gate) never tries to resolve them → stays green by construction.

**2. Vendored `chat.bsky.convo.getConvoMembers`** (from `bluesky-social/atproto@3cb1569`) → generates `ConvoService.getConvoMembers(GetConvoMembersRequest(convoId, limit?, cursor?))` → `GetConvoMembersResponse(members: List<ProfileViewBasic>, cursor?)` + `convoMembersFlow`/`convoMembersPageFlow`. Only dep (`chat.bsky.actor.defs#profileViewBasic`) is already in the corpus.

**3. Staleness cron** (`ci(generator)`) — `:generator:detectStaleOverlays` + `.github/workflows/overlay-staleness.yaml` (weekly), maintaining an `overlay-stale` tracking issue that flags when an overlay is **now resolvable on-network** (retire it) or has **drifted** from upstream (re-vendor) — the inverse of the existing `lexicon-drift` cron. `detectLexiconDrift` now excludes overlay NSIDs from its new-upstream report.

## Tests / verification

- `:generator:test` green (existing golden + 15 new `DetectStaleOverlays` tests); `:models:jvmTest` + `ConvoServiceTest` (new getConvoMembers cases) green; `:models` compiles for JVM + iosSimulatorArm64; `apiDump` updated (`models/api/models.api`).
- `lex install --ci` green (overlay excluded by construction); `detectStaleOverlays` reports the new overlay as in-sync/not-yet-publishable; `detectLexiconDrift` no longer lists getConvoMembers.
- Not run: full iOS `build` link step (environmental — needs full Xcode, not CLT; `:runtime` untouched).

## Retire path

When Bluesky publishes the on-network record, the cron's `overlay-stale` issue fires → `lex install` it into the real corpus, delete the overlay file + manifest entry, regen. The build-time "overlay shadows installed lexicon" WARN is a second signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)