### PR TITLE
chore(lexicons): bump @atproto/lex to 0.1.4

### DIFF
--- a/generator/package-lock.json
+++ b/generator/package-lock.json
@@ -8,20 +8,20 @@
       "name": "kikinlex-atproto-generator-lexicons",
       "version": "0.0.0",
       "dependencies": {
-        "@atproto/lex": "0.1.3"
+        "@atproto/lex": "0.1.4"
       }
     },
     "node_modules/@atproto-labs/did-resolver": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@atproto-labs/did-resolver/-/did-resolver-0.3.0.tgz",
-      "integrity": "sha512-6w8UxJQVj40TqKJm+D5s6pcH45eWH/KvfAR+gYC6KOux/mM7ZI3IKOhI1Gq7GIte1eOp9WXwASN1RQAFYZ4MFw==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@atproto-labs/did-resolver/-/did-resolver-0.3.2.tgz",
+      "integrity": "sha512-FtUZcVqzdAiYhjQtvT3juNP1cUcsweAnnx5mkz22iM7PnVtK3NGCJ478PuoUrL2F+yhgiO+rSHmXuYxuP3+PAg==",
       "license": "MIT",
       "dependencies": {
-        "@atproto-labs/fetch": "^0.3.0",
-        "@atproto-labs/pipe": "^0.2.0",
-        "@atproto-labs/simple-store": "^0.4.0",
-        "@atproto-labs/simple-store-memory": "^0.2.0",
-        "@atproto/did": "^0.4.0",
+        "@atproto-labs/fetch": "^0.3.1",
+        "@atproto-labs/pipe": "^0.2.1",
+        "@atproto-labs/simple-store": "^0.4.1",
+        "@atproto-labs/simple-store-memory": "^0.2.1",
+        "@atproto/did": "^0.5.1",
         "zod": "^3.23.8"
       },
       "engines": {
@@ -29,42 +29,42 @@
       }
     },
     "node_modules/@atproto-labs/fetch": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@atproto-labs/fetch/-/fetch-0.3.0.tgz",
-      "integrity": "sha512-yZhNsRZyqhjmzHlXmE9k6XU0f6+ynfNyrHhB4FlEyUjkBvf5vNLjdJyBq+Jp7ISGMigA1fn2lAgaE/qkrVo9iw==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@atproto-labs/fetch/-/fetch-0.3.1.tgz",
+      "integrity": "sha512-L8tq4ssUaK/POMGYembdmvMSH0Dg3PiZIeOf3kptSZTYM1gNxqOVIezkqcnapDbsLTiqQ4nWW7yK3jVVjY40YA==",
       "license": "MIT",
       "dependencies": {
-        "@atproto-labs/pipe": "^0.2.0"
+        "@atproto-labs/pipe": "^0.2.1"
       },
       "engines": {
         "node": ">=22"
       }
     },
     "node_modules/@atproto-labs/pipe": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@atproto-labs/pipe/-/pipe-0.2.0.tgz",
-      "integrity": "sha512-89X6gv+8/SiZYwJ4+Hw8iaU1WymbElZO6LsMgHd+c1XFs/78KhsIL4xp0RCs7/W8izK9BxaTEnYN5csRmwQ99Q==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@atproto-labs/pipe/-/pipe-0.2.1.tgz",
+      "integrity": "sha512-RmRAwru+/IEz50Q78wlZpVD1Ksx8GkBKjW1sLgTS7ym0EagHtLYD9Jbv6MFDjoafiDOILZ8zDEeQ3E5El9Rg+w==",
       "license": "MIT",
       "engines": {
         "node": ">=22"
       }
     },
     "node_modules/@atproto-labs/simple-store": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@atproto-labs/simple-store/-/simple-store-0.4.0.tgz",
-      "integrity": "sha512-sbPEju2QXzN6lGWfr5p2Kg82ZeaG1UyVFOrMQc4eCjUvxGOjIxuYOVIiTuPTFOC5Rsvsb8jMOmLjLi8FR/CMYw==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@atproto-labs/simple-store/-/simple-store-0.4.1.tgz",
+      "integrity": "sha512-ShIqvrsRToBX87ePj5hY+t+BuxcP15g1W49MHSBx5VFkspwzU720LNtWVf0Wi6Lk80DMlKtsC2/fvQJTzRJKZA==",
       "license": "MIT",
       "engines": {
         "node": ">=22"
       }
     },
     "node_modules/@atproto-labs/simple-store-memory": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@atproto-labs/simple-store-memory/-/simple-store-memory-0.2.0.tgz",
-      "integrity": "sha512-nDZIS6vOBvR8NqObGmj0GFSdz3N6gyQ7ny3l/uiezwuCWShsxtA9OkYcjaQ7Kw3hydXTe4iEGu/BDOACncnxDg==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@atproto-labs/simple-store-memory/-/simple-store-memory-0.2.1.tgz",
+      "integrity": "sha512-NOpv+PRHjMFy+k/726mbNUfO3UKl5XlXi+2olJOvmeft1u7byYXCZcIl3m/LxIuK8W0QWG60MQPbuxeNY+9Djg==",
       "license": "MIT",
       "dependencies": {
-        "@atproto-labs/simple-store": "^0.4.0",
+        "@atproto-labs/simple-store": "^0.4.1",
         "lru-cache": "^10.2.0"
       },
       "engines": {
@@ -72,14 +72,14 @@
       }
     },
     "node_modules/@atproto/common": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@atproto/common/-/common-0.6.1.tgz",
-      "integrity": "sha512-mXR4R8nYFgs4gncFXNyIcxMcjuvpeCn3spu4pIlfWsri+MxXPr4jHWkjyv+b2JIvI+nns3L3ElFKWPEO4GlZdA==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/@atproto/common/-/common-0.6.3.tgz",
+      "integrity": "sha512-ZkJzz1T0LNmzFWPJ2BSqtHMvbHkhakanDhgW0/xj4jw8bz7ZRLHvMdJ8a3qZxmhgGRCVDis4F0NGsuBkBYPL2w==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/common-web": "^0.5.0",
-        "@atproto/lex-cbor": "^0.1.0",
-        "@atproto/lex-data": "^0.1.1",
+        "@atproto/common-web": "^0.5.1",
+        "@atproto/lex-cbor": "^0.1.1",
+        "@atproto/lex-data": "^0.1.2",
         "multiformats": "^13.0.0",
         "pino": "^8.21.0"
       },
@@ -88,14 +88,14 @@
       }
     },
     "node_modules/@atproto/common-web": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@atproto/common-web/-/common-web-0.5.0.tgz",
-      "integrity": "sha512-ReWnkuZdDU/74/I47gaI26uxQjHmpq4edp41NnZZQ5vIIKGb7Ei6pZHzDTUD9JURo109SKrPx9RMP2IQm0fOKA==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@atproto/common-web/-/common-web-0.5.1.tgz",
+      "integrity": "sha512-nru02gLyzjMQn4ZFgms9ry3kIAKwMaCAvjeFhB9mU6h1ABiSho7aRDbGvnU50CC88TROXuZlgRiEkBjnuiHEtA==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/lex-data": "^0.1.0",
-        "@atproto/lex-json": "^0.1.0",
-        "@atproto/syntax": "^0.6.0",
+        "@atproto/lex-data": "^0.1.2",
+        "@atproto/lex-json": "^0.1.1",
+        "@atproto/syntax": "^0.6.2",
         "zod": "^3.23.8"
       },
       "engines": {
@@ -103,9 +103,9 @@
       }
     },
     "node_modules/@atproto/crypto": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@atproto/crypto/-/crypto-0.5.0.tgz",
-      "integrity": "sha512-HBfq6z+tzkiBzPhHOvRFkQU3inTQIUJAkb1UEyGx+pdPTnFFtnfIoo9Kr1ZV/FzMIgnHOA8H2UJC3dxxFl1eVg==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@atproto/crypto/-/crypto-0.5.1.tgz",
+      "integrity": "sha512-szFSBYM8l9HGVMQgCvkCUasvsvMmqNlfQca/Pc7E/X36agQzUMw4lhYh7W7O9z+h+flzhS5ThjW0SzHMIItK2A==",
       "license": "MIT",
       "dependencies": {
         "@noble/curves": "^1.7.0",
@@ -117,9 +117,9 @@
       }
     },
     "node_modules/@atproto/did": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@atproto/did/-/did-0.4.0.tgz",
-      "integrity": "sha512-OADX1NXCkScMkNJmSQnTUfPoDJ2IoOUTtqVfuY4z+a8//JDIsY6FDygv3GR8Sh2laz5qodlCA7XM+u6XVine3g==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@atproto/did/-/did-0.5.1.tgz",
+      "integrity": "sha512-lGc9JdP8xAOWT35zE3+qH49wvXAdhyDC0KnLFPj+TI7yTsMQBC3jZ8z7zSM97wTBQFTL0xq4XQkpA4k2Uww28w==",
       "license": "MIT",
       "dependencies": {
         "zod": "^3.23.8"
@@ -129,17 +129,17 @@
       }
     },
     "node_modules/@atproto/lex": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@atproto/lex/-/lex-0.1.3.tgz",
-      "integrity": "sha512-sT2EvdB+I3Kml1z5oirIBgTQjTOJp3DRD5P391ll40Q5X6ghjCEvC449vwRbpk+f2f6svI7KGSONWg/TDj3Zjg==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@atproto/lex/-/lex-0.1.4.tgz",
+      "integrity": "sha512-UM/GDVTAmzSRTcuynJGCjsGlY7i1kdnaqS2lWfwFtGwSMLPjNE2CFi3OYwcv0gCb8Brc51P7m1QvGGJmUUrUTQ==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/lex-builder": "^0.1.2",
-        "@atproto/lex-client": "^0.1.3",
-        "@atproto/lex-data": "^0.1.1",
-        "@atproto/lex-installer": "^0.1.0",
-        "@atproto/lex-json": "^0.1.0",
-        "@atproto/lex-schema": "^0.1.2",
+        "@atproto/lex-builder": "^0.1.3",
+        "@atproto/lex-client": "^0.1.4",
+        "@atproto/lex-data": "^0.1.2",
+        "@atproto/lex-installer": "^0.1.1",
+        "@atproto/lex-json": "^0.1.1",
+        "@atproto/lex-schema": "^0.1.4",
         "tslib": "^2.8.1",
         "yargs": "^18.0.0"
       },
@@ -152,13 +152,13 @@
       }
     },
     "node_modules/@atproto/lex-builder": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@atproto/lex-builder/-/lex-builder-0.1.2.tgz",
-      "integrity": "sha512-cBkuJiBkiIO6KzO2AGTc/0EOJKRfBxWwAQbmy4WYnNO3ewC/8BztQuAxY99mAf/NWuksEKXL+UY6J/ZEKLK1pA==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@atproto/lex-builder/-/lex-builder-0.1.3.tgz",
+      "integrity": "sha512-z/CbP6Kstl6Ivn64vIqEwEICyJxyuYpocWg+gBQCVtHOpvYGE4IoKoTQaZHQYwrLemrjE/vnPaBPsR1DSjzJ7A==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/lex-document": "^0.1.0",
-        "@atproto/lex-schema": "^0.1.1",
+        "@atproto/lex-document": "^0.1.1",
+        "@atproto/lex-schema": "^0.1.4",
         "prettier": "^3.2.5",
         "ts-morph": "^27.0.0",
         "tslib": "^2.8.1"
@@ -168,12 +168,12 @@
       }
     },
     "node_modules/@atproto/lex-cbor": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@atproto/lex-cbor/-/lex-cbor-0.1.0.tgz",
-      "integrity": "sha512-SGL7BHPYN0OmvtnVixieYWyh2ghxI7iHADTLfz52Xp5zR+BZY3QggIKJ32KfyYN9Ss2tduaqsY5aclEki2Aq0A==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@atproto/lex-cbor/-/lex-cbor-0.1.1.tgz",
+      "integrity": "sha512-VvCytc6HfsRxT8rVtRc+Z6fEIfBn/4guCE50VoJJN7iWPool47v120XtX5zAWTjW1C+8ksoVDN+Bd8P5t3qDvA==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/lex-data": "^0.1.0",
+        "@atproto/lex-data": "^0.1.2",
         "cborg": "^4.5.8",
         "tslib": "^2.8.1"
       },
@@ -182,14 +182,14 @@
       }
     },
     "node_modules/@atproto/lex-client": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@atproto/lex-client/-/lex-client-0.1.3.tgz",
-      "integrity": "sha512-uvijUgULTW3aLg0akJWg35yKWfUz7eqLtXw2azpVQtaJ9f0qycoiaQ1LRHetiLrS34KT7i1O/vVd5kryHHW4CA==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@atproto/lex-client/-/lex-client-0.1.4.tgz",
+      "integrity": "sha512-KUG3ofwTBSS3zSqbvyzQ/AzNfp3jBvTJC78JF5CO9TSaTtvhiqGKEEsnvg1Nso8aZQnHOErNEseYcwtstCqFsQ==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/lex-data": "^0.1.1",
-        "@atproto/lex-json": "^0.1.0",
-        "@atproto/lex-schema": "^0.1.2",
+        "@atproto/lex-data": "^0.1.2",
+        "@atproto/lex-json": "^0.1.1",
+        "@atproto/lex-schema": "^0.1.4",
         "tslib": "^2.8.1"
       },
       "engines": {
@@ -197,9 +197,9 @@
       }
     },
     "node_modules/@atproto/lex-data": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@atproto/lex-data/-/lex-data-0.1.1.tgz",
-      "integrity": "sha512-/xza8nU/YhtzhETnHL3QKKofaJ28/0NCzhT7LaYoUkm8EgypWp5ykEtmW52yLhQM2JF6fVa25g1soQmNTGqtSg==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@atproto/lex-data/-/lex-data-0.1.2.tgz",
+      "integrity": "sha512-NZ4iZvNaqTM6pz+9VRDyEjtozrrf2EDHySNi3Xa8PCzS8gRMCvsnnsvM7r264v4eSqNIDhBB8fr9hfWCHMspXg==",
       "license": "MIT",
       "dependencies": {
         "multiformats": "^13.0.0",
@@ -212,12 +212,12 @@
       }
     },
     "node_modules/@atproto/lex-document": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@atproto/lex-document/-/lex-document-0.1.0.tgz",
-      "integrity": "sha512-I2q2iwK8RnSHkBeAj5xdJNYdHiUQqlkbbleBSJKJXlYOYy5y86dWRo9IfE0l9E3qZ3/zvy1ydlEZmZupEt0FGg==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@atproto/lex-document/-/lex-document-0.1.1.tgz",
+      "integrity": "sha512-sUv+Dpy7+tQVr1vDQbqEh3SRZOv1kJpJ2SbSb2P/GPDqi8hvN9LZAertTMT8O6Ui8OJKy4vk5vRECXrgn2mkzw==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/lex-schema": "^0.1.0",
+        "@atproto/lex-schema": "^0.1.4",
         "core-js": "^3",
         "tslib": "^2.8.1"
       },
@@ -226,18 +226,18 @@
       }
     },
     "node_modules/@atproto/lex-installer": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@atproto/lex-installer/-/lex-installer-0.1.0.tgz",
-      "integrity": "sha512-NXrJNe2qY4YreC82VgPE7stXnzSnI+xMeNXvgJDiMZj4MeSQeQn5ElFVd1yzRRV9sZREf6Y/HE+y1ffb2uewXA==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@atproto/lex-installer/-/lex-installer-0.1.1.tgz",
+      "integrity": "sha512-LRbXv/pPBdKkxc7buvb0nkRaD4PBPVvVckY6SkeoHF9h1snRqJNMCkrxurpaUheAbw+JBxjCxRN1OBELe5xDLw==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/lex-builder": "^0.1.0",
-        "@atproto/lex-cbor": "^0.1.0",
-        "@atproto/lex-data": "^0.1.0",
-        "@atproto/lex-document": "^0.1.0",
-        "@atproto/lex-resolver": "^0.1.0",
-        "@atproto/lex-schema": "^0.1.0",
-        "@atproto/syntax": "^0.6.0",
+        "@atproto/lex-builder": "^0.1.3",
+        "@atproto/lex-cbor": "^0.1.1",
+        "@atproto/lex-data": "^0.1.2",
+        "@atproto/lex-document": "^0.1.1",
+        "@atproto/lex-resolver": "^0.1.1",
+        "@atproto/lex-schema": "^0.1.4",
+        "@atproto/syntax": "^0.6.2",
         "tslib": "^2.8.1"
       },
       "engines": {
@@ -245,12 +245,12 @@
       }
     },
     "node_modules/@atproto/lex-json": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@atproto/lex-json/-/lex-json-0.1.0.tgz",
-      "integrity": "sha512-oWUrRMwFyWpmi/5k1Se3xBTbP06XdxBS5iFuUz9LmqItaPXwrWRD87a9ldPvINQ/A2/mn7J6/qug8sDVlhD+vQ==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@atproto/lex-json/-/lex-json-0.1.1.tgz",
+      "integrity": "sha512-FC/NsKHm8TDzWikvf/268T3mMAh6+f31yfCApWC3SvrhWc9c06cSYPp7qzpXcdV0OdB+I5dqHScuTB5OC7HrXg==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/lex-data": "^0.1.0",
+        "@atproto/lex-data": "^0.1.2",
         "tslib": "^2.8.1"
       },
       "engines": {
@@ -258,19 +258,19 @@
       }
     },
     "node_modules/@atproto/lex-resolver": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@atproto/lex-resolver/-/lex-resolver-0.1.0.tgz",
-      "integrity": "sha512-zliMiRW4ttSNFreKxyvSpaYQjeWrKpV/lutnXI9BNE8Ysgnw8Rltm0bR7kG/y0OlyClxhhU/vAG+OR8NpjhU1Q==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@atproto/lex-resolver/-/lex-resolver-0.1.1.tgz",
+      "integrity": "sha512-K/OiH8xMH21siMFxkD5wzb4dhj1Co6Rbok7pCxPhtlDqWKmomNF2WEK20k36VmiN2NrksXfvox7alsx4SernEA==",
       "license": "MIT",
       "dependencies": {
-        "@atproto-labs/did-resolver": "^0.3.0",
-        "@atproto/crypto": "^0.5.0",
-        "@atproto/lex-client": "^0.1.0",
-        "@atproto/lex-data": "^0.1.0",
-        "@atproto/lex-document": "^0.1.0",
-        "@atproto/lex-schema": "^0.1.0",
-        "@atproto/repo": "^0.10.0",
-        "@atproto/syntax": "^0.6.0",
+        "@atproto-labs/did-resolver": "^0.3.2",
+        "@atproto/crypto": "^0.5.1",
+        "@atproto/lex-client": "^0.1.4",
+        "@atproto/lex-data": "^0.1.2",
+        "@atproto/lex-document": "^0.1.1",
+        "@atproto/lex-schema": "^0.1.4",
+        "@atproto/repo": "^0.10.1",
+        "@atproto/syntax": "^0.6.2",
         "tslib": "^2.8.1"
       },
       "engines": {
@@ -278,13 +278,13 @@
       }
     },
     "node_modules/@atproto/lex-schema": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@atproto/lex-schema/-/lex-schema-0.1.2.tgz",
-      "integrity": "sha512-1O/WmV+0JCZ9U7Lto2h6IxYLesakXKRZXNjugf6B0Vsti254umtLQzmz0rWgkkFugGaLQDbfDMXJoexwTOU+5w==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@atproto/lex-schema/-/lex-schema-0.1.4.tgz",
+      "integrity": "sha512-v3jZjDzDkK2uDhW6oU9WgYylUbCkKehC1sx+cCS/DXQsdMt3B2ousSYuYZ6EvXmVexu94LOPaOEnLwB7bqs92w==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/lex-data": "^0.1.1",
-        "@atproto/syntax": "^0.6.1",
+        "@atproto/lex-data": "^0.1.2",
+        "@atproto/syntax": "^0.6.2",
         "@standard-schema/spec": "^1.1.0",
         "tslib": "^2.8.1"
       },
@@ -293,17 +293,17 @@
       }
     },
     "node_modules/@atproto/repo": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@atproto/repo/-/repo-0.10.0.tgz",
-      "integrity": "sha512-dGnU3R+geXepOZFIn3YUu6WaXLuT1NxqNvusR/JmAqPjjT6dT4tjouZeDPrumSnZm2f5Z8xMeDfVxpMWQ4stFw==",
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@atproto/repo/-/repo-0.10.1.tgz",
+      "integrity": "sha512-W7ZF8lI/u4se9aovHz60IKOYXSwEE4OPT7ZQYI2e75SXwP23e2WHmvkLqLsQbqDTLffVpOqSJXFwNRtVTGK9yw==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/common": "^0.6.0",
-        "@atproto/common-web": "^0.5.0",
-        "@atproto/crypto": "^0.5.0",
-        "@atproto/lex-cbor": "^0.1.0",
-        "@atproto/lex-data": "^0.1.0",
-        "@atproto/syntax": "^0.6.0",
+        "@atproto/common": "^0.6.3",
+        "@atproto/common-web": "^0.5.1",
+        "@atproto/crypto": "^0.5.1",
+        "@atproto/lex-cbor": "^0.1.1",
+        "@atproto/lex-data": "^0.1.2",
+        "@atproto/syntax": "^0.6.2",
         "varint": "^6.0.0",
         "zod": "^3.23.8"
       },
@@ -312,9 +312,9 @@
       }
     },
     "node_modules/@atproto/syntax": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@atproto/syntax/-/syntax-0.6.1.tgz",
-      "integrity": "sha512-kA4dQDoMPpWCH8N0Q4KoSq024u5MkVfDVa8DdhyLjGA72z/khbOf1jXKPv7NIL2oEc9aj7geKELdvqyf4ogopA==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@atproto/syntax/-/syntax-0.6.2.tgz",
+      "integrity": "sha512-h3njTNFl/jv5kTbDqfamQGOJfGbulqLDuAiLbasKwVdBhFyQanpRLa6vE2WqTwv1XEFWLYNMH0KCVsYwT2+aww==",
       "license": "MIT",
       "dependencies": {
         "iso-datestring-validator": "^2.2.2",
@@ -717,9 +717,9 @@
       "license": "MIT"
     },
     "node_modules/prettier": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
-      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
+      "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
       "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"
@@ -875,9 +875,9 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",

--- a/generator/package.json
+++ b/generator/package.json
@@ -4,6 +4,6 @@
   "private": true,
   "description": "Pins the @atproto/lex release whose lexicon JSON is consumed by :generator. Not published.",
   "dependencies": {
-    "@atproto/lex": "0.1.3"
+    "@atproto/lex": "0.1.4"
   }
 }


### PR DESCRIPTION
## Lexicon corpus update

Bumps `@atproto/lex` from `0.1.3` to `0.1.4`.

### lexicons.json changes

**Added** (0):
- _(none)_

**Removed** (0):
- _(none)_

**Updated** (0):
- _(none)_

### What reviewers should check

- [ ] CI passes (generator regeneration, runtime tests, sample APK build)
- [ ] Skim the generator golden-file diff if any generator logic was affected
- [ ] Verify no new lexicon references are missing Kotlin types (compile failure in `:models`)

### Release impact

If this PR merges with only additive changes (new types, new fields), expect a `feat:` release. If it removes or renames anything, expect a `BREAKING CHANGE:` release — update the PR title to `feat!: bump @atproto/lex to <version>` before merging.