### PR TITLE
feat(generator): field-default overrides — non-null handle.invalid fallback for chat profileViewBasic

### DIFF
--- a/generator/build.gradle.kts
+++ b/generator/build.gradle.kts
@@ -33,6 +33,7 @@ tasks.test {
  */
 val lexiconsDir = layout.projectDirectory.dir("lexicons")
 val overlayDir = layout.projectDirectory.dir("overlay-lexicons")
+val fieldDefaultsFile = layout.projectDirectory.file("field-default-overrides.json")
 val generatedModelsDir = project(":models")
     .layout.buildDirectory.dir("generated/source/lexicon/commonMain/kotlin")
 
@@ -52,6 +53,7 @@ tasks.register<JavaExec>("generateModels") {
         lexiconsDirFile.absolutePath,
         generatedModelsDirFile.absolutePath,
         overlayDir.asFile.absolutePath,
+        fieldDefaultsFile.asFile.absolutePath,
     )
 
     inputs.dir(lexiconsDir)
@@ -61,6 +63,10 @@ tasks.register<JavaExec>("generateModels") {
     inputs.dir(overlayDir)
         .withPathSensitivity(PathSensitivity.RELATIVE)
         .withPropertyName("overlayLexicons")
+        .optional()
+    inputs.file(fieldDefaultsFile)
+        .withPathSensitivity(PathSensitivity.RELATIVE)
+        .withPropertyName("fieldDefaultOverrides")
         .optional()
     outputs.dir(generatedModelsDir).withPropertyName("generatedSources")
 

--- a/generator/field-default-overrides.json
+++ b/generator/field-default-overrides.json
@@ -1,0 +1,10 @@
+{
+  "version": 1,
+  "overrides": [
+    {
+      "def": "chat.bsky.actor.defs#profileViewBasic",
+      "defaults": { "handle": "handle.invalid" },
+      "reason": "Bluesky's chat service returns a profileViewBasic with no `handle` for departed/deactivated members embedded in `#memberJoin` system messages, even though the published lexicon marks `handle` required. Without a fallback chat.bsky.convo.getMessages hard-fails deserialization (MissingFieldException) and group threads won't open. Default to `handle.invalid` — the same sentinel app.bsky returns for invalid handles — so `handle` stays non-null and consumers need no null-checks."
+    }
+  ]
+}

--- a/generator/src/main/kotlin/io/github/kikin81/atproto/generator/Main.kt
+++ b/generator/src/main/kotlin/io/github/kikin81/atproto/generator/Main.kt
@@ -3,12 +3,17 @@ package io.github.kikin81.atproto.generator
 import io.github.kikin81.atproto.generator.emit.CodeGenerator
 import io.github.kikin81.atproto.generator.ir.LexiconDocument
 import io.github.kikin81.atproto.generator.parser.LexiconParser
+import io.github.kikin81.atproto.generator.tools.applyFieldDefaultOverrides
+import io.github.kikin81.atproto.generator.tools.parseFieldDefaultOverrides
 import java.nio.file.Path
 import kotlin.io.path.exists
+import kotlin.io.path.isRegularFile
+import kotlin.io.path.readText
 import kotlin.system.exitProcess
 
 /**
- * CLI entry point: `java -jar generator.jar <lexiconsDir> <outputDir> [overlayDir]`.
+ * CLI entry point:
+ * `java -jar generator.jar <lexiconsDir> <outputDir> [overlayDir] [optionalOverridesFile]`.
  *
  * Parses every `*.json` under [lexiconsDir] and writes Kotlin source files
  * mirroring the AT Protocol lexicon corpus under [outputDir]. Used by the
@@ -18,10 +23,14 @@ import kotlin.system.exitProcess
  * lexicon JSON (for methods Bluesky serves but hasn't published on-network yet).
  * Overlay docs are parsed and merged into the installed corpus by NSID with
  * overlay-wins semantics; shadowing an installed NSID logs a stderr WARN.
+ *
+ * An optional fourth argument points at a field-default-overrides manifest
+ * (see [parseFieldDefaultOverrides]): deliberate, permanent fallbacks for
+ * over-strict `required` fields whose servers violate the published lexicon.
  */
 public fun main(args: Array<String>) {
-    if (args.size !in 2..3) {
-        System.err.println("Usage: <lexiconsDir> <outputDir> [overlayDir]")
+    if (args.size !in 2..4) {
+        System.err.println("Usage: <lexiconsDir> <outputDir> [overlayDir] [fieldDefaultsFile]")
         exitProcess(2)
     }
     val lexiconsDir = Path.of(args[0])
@@ -53,7 +62,14 @@ public fun main(args: Array<String>) {
             )
         }
     }
-    val docs = byId.values.toList()
+    val merged = byId.values.toList()
+    // Deliberate, permanent fallbacks for over-strict `required` fields (see
+    // FieldDefaultOverrides) — applied after overlay merge so they win.
+    val overridesFile = args.getOrNull(3)?.let(Path::of)?.takeIf { it.isRegularFile() }
+    val docs =
+        overridesFile
+            ?.let { applyFieldDefaultOverrides(merged, parseFieldDefaultOverrides(it.readText())) }
+            ?: merged
     CodeGenerator().writeTo(docs, outputDir)
     println("generated lexicon sources for ${docs.size} documents into $outputDir")
 }

--- a/generator/src/main/kotlin/io/github/kikin81/atproto/generator/emit/ModelGenerator.kt
+++ b/generator/src/main/kotlin/io/github/kikin81/atproto/generator/emit/ModelGenerator.kt
@@ -8,6 +8,7 @@ import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.ParameterSpec
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.PropertySpec
+import com.squareup.kotlinpoet.STRING
 import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.TypeSpec
 import io.github.kikin81.atproto.generator.ir.FieldType
@@ -16,6 +17,7 @@ import io.github.kikin81.atproto.generator.ir.ObjectType
 import io.github.kikin81.atproto.generator.ir.ParamsDefTopLevel
 import io.github.kikin81.atproto.generator.ir.ParamsType
 import io.github.kikin81.atproto.generator.ir.RecordDef
+import io.github.kikin81.atproto.generator.ir.StringType
 import io.github.kikin81.atproto.generator.resolved.DefKey
 import io.github.kikin81.atproto.generator.resolved.Nsid
 import io.github.kikin81.atproto.generator.resolved.UsageContext
@@ -163,7 +165,8 @@ public class ModelGenerator(
             val baseType = typeResolver.resolve(ft, origin, fqName, name)
             val isRequired = name in required
             val (propType, defaultCode, extraAnnotations) =
-                fieldShape(baseType, isRequired, shape)
+                injectedDefaultShape(baseType, ft, shape)
+                    ?: fieldShape(baseType, isRequired, shape)
 
             val param = ParameterSpec.builder(name, propType)
             if (defaultCode != null) param.defaultValue(defaultCode)
@@ -192,6 +195,27 @@ public class ModelGenerator(
 
         builder.primaryConstructor(ctor.build())
         return builder.build()
+    }
+
+    /**
+     * A field-default override ([io.github.kikin81.atproto.generator.tools.applyFieldDefaultOverrides])
+     * injects a fallback so a server that omits an over-strict required field still
+     * decodes. Emit the read-side field as its non-null base type defaulted to the
+     * injected value — a property with a Kotlin default is optional to kotlinx, so
+     * there's no `MissingFieldException` and no consumer null-checks. Returns null
+     * (defer to [fieldShape]) for non-string fields, fields without an injected
+     * default, or mutation inputs (which keep their `AtField` three-state).
+     */
+    private fun injectedDefaultShape(
+        baseType: TypeName,
+        ft: FieldType,
+        shape: Shape,
+    ): Triple<TypeName, CodeBlock?, List<AnnotationSpec>>? {
+        if (shape != Shape.ReadShape) return null
+        val value = (ft as? StringType)?.injectedDefault ?: return null
+        // Value classes (e.g. Handle for format=handle) wrap the literal; plain strings don't.
+        val default = if (baseType == STRING) CodeBlock.of("%S", value) else CodeBlock.of("%T(%S)", baseType, value)
+        return Triple(baseType, default, emptyList())
     }
 
     private fun fieldShape(

--- a/generator/src/main/kotlin/io/github/kikin81/atproto/generator/ir/FieldType.kt
+++ b/generator/src/main/kotlin/io/github/kikin81/atproto/generator/ir/FieldType.kt
@@ -2,6 +2,7 @@ package io.github.kikin81.atproto.generator.ir
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonPrimitive
@@ -71,6 +72,14 @@ public data class StringType(
     public val enum: List<String>? = null,
     public val default: String? = null,
     public val const: String? = null,
+    /**
+     * A fallback value injected by a field-default override (not from the Lexicon
+     * JSON), used when a server omits a field its own published lexicon marks
+     * required. When set, the generator emits this string field as a non-null
+     * property defaulted to this value, so kotlinx tolerates the missing field
+     * without forcing every consumer to null-check. See FieldDefaultOverrides.
+     */
+    @Transient public val injectedDefault: String? = null,
 ) : FieldType {
     override val deprecated: Boolean get() = _deprecated != null && _deprecated !is JsonNull
     override val deprecatedMessage: String? get() = (_deprecated as? JsonPrimitive)?.takeIf { it.isString }?.content

--- a/generator/src/main/kotlin/io/github/kikin81/atproto/generator/tools/FieldDefaultOverrides.kt
+++ b/generator/src/main/kotlin/io/github/kikin81/atproto/generator/tools/FieldDefaultOverrides.kt
@@ -1,0 +1,91 @@
+package io.github.kikin81.atproto.generator.tools
+
+import io.github.kikin81.atproto.generator.ir.LexiconDocument
+import io.github.kikin81.atproto.generator.ir.ObjectDef
+import io.github.kikin81.atproto.generator.ir.StringType
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+/**
+ * Deliberate, permanent fallbacks for over-strict `required` fields in the
+ * upstream Lexicon corpus.
+ *
+ * Some Bluesky services return objects that violate their own published lexicon.
+ * For example `chat.bsky.convo.getMessages` embeds a `profileViewBasic` for a
+ * departed/deactivated member that carries no `handle`, even though
+ * `chat.bsky.actor.defs#profileViewBasic` marks `handle` required — so a strict
+ * client throws `MissingFieldException` and the whole response fails to decode.
+ *
+ * Rather than make the field nullable (which pushes a null-check onto every
+ * consumer), an override injects a **fallback default**: the generator emits the
+ * field as its non-null type defaulted to the given value (e.g. `handle.invalid`,
+ * which is exactly what `app.bsky` itself returns for invalid handles). A Kotlin
+ * property with a default is optional to kotlinx, so the missing field decodes to
+ * the fallback and consumers see a normal non-null value.
+ *
+ * This is distinct from [overlay-lexicons][parseOverlayManifest]: an overlay
+ * temporarily vendors a lexicon not yet published on-network and is retired once
+ * it is; a field-default override is a *deliberate, lasting* deviation from a
+ * published lexicon. The injected value is carried on [StringType.injectedDefault]
+ * (a non-Lexicon, `@Transient` marker), so the four real Lexicon string `default`s
+ * in the corpus keep their existing nullable emission untouched.
+ */
+@Serializable
+internal data class FieldDefaultOverride(
+    /** Target def, `nsid#def` (e.g. `chat.bsky.actor.defs#profileViewBasic`). */
+    val def: String,
+    /** Property name → fallback value to default a missing required string field to. */
+    val defaults: Map<String, String>,
+    /** Why the deviation exists; documentation only. */
+    val reason: String = "",
+)
+
+@Serializable
+internal data class FieldDefaultOverrideManifest(
+    val version: Int = 1,
+    val overrides: List<FieldDefaultOverride> = emptyList(),
+)
+
+private val overrideJson = Json { ignoreUnknownKeys = true }
+
+internal fun parseFieldDefaultOverrides(manifestJson: String): FieldDefaultOverrideManifest = overrideJson.decodeFromString(manifestJson)
+
+/**
+ * Returns [docs] with every [manifest] override applied: each named property's
+ * [StringType.injectedDefault] is set (the property stays required so it emits
+ * non-null). Fails fast on a malformed id, an unknown lexicon/def, or a property
+ * that isn't a string, so a typo can't silently leave the strict schema in place.
+ * Document/def ordering is preserved.
+ */
+internal fun applyFieldDefaultOverrides(
+    docs: List<LexiconDocument>,
+    manifest: FieldDefaultOverrideManifest,
+): List<LexiconDocument> {
+    if (manifest.overrides.isEmpty()) return docs
+    val byId = LinkedHashMap<String, LexiconDocument>()
+    docs.forEach { byId[it.id] = it }
+    for (override in manifest.overrides) {
+        val nsid = override.def.substringBefore('#')
+        val defName = override.def.substringAfter('#', missingDelimiterValue = "")
+        require(nsid.isNotEmpty() && defName.isNotEmpty()) {
+            "field-default override '${override.def}' must be of the form 'nsid#def'"
+        }
+        val doc = requireNotNull(byId[nsid]) { "field-default override targets unknown lexicon '$nsid'" }
+        val def = doc.defs[defName]
+        require(def is ObjectDef) {
+            "field-default override '${override.def}' does not resolve to an object def" +
+                if (def == null) " (no such def)" else " (found ${def::class.simpleName})"
+        }
+        var properties = def.properties
+        for ((field, value) in override.defaults) {
+            val ft = properties[field]
+            require(ft is StringType) {
+                "field-default override '${override.def}' property '$field' is not a string field" +
+                    if (ft == null) " (no such property)" else " (found ${ft::class.simpleName})"
+            }
+            properties = properties + (field to ft.copy(injectedDefault = value))
+        }
+        byId[nsid] = doc.copy(defs = doc.defs + (defName to def.copy(properties = properties)))
+    }
+    return byId.values.toList()
+}

--- a/generator/src/test/kotlin/io/github/kikin81/atproto/generator/tools/FieldDefaultOverridesTest.kt
+++ b/generator/src/test/kotlin/io/github/kikin81/atproto/generator/tools/FieldDefaultOverridesTest.kt
@@ -1,0 +1,160 @@
+package io.github.kikin81.atproto.generator.tools
+
+import io.github.kikin81.atproto.generator.emit.CodeGenerator
+import io.github.kikin81.atproto.generator.ir.LexiconDocument
+import io.github.kikin81.atproto.generator.ir.ObjectDef
+import io.github.kikin81.atproto.generator.ir.StringType
+import io.github.kikin81.atproto.generator.parser.LexiconParser
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class FieldDefaultOverridesTest {
+    private val parser = LexiconParser()
+
+    /** A minimal chat.bsky.actor.defs with profileViewBasic requiring did + handle. */
+    private val profileDocs =
+        listOf(
+            parser.parse(
+                """
+                {
+                  "lexicon": 1,
+                  "id": "chat.bsky.actor.defs",
+                  "defs": {
+                    "profileViewBasic": {
+                      "type": "object",
+                      "required": ["did", "handle"],
+                      "properties": {
+                        "did": { "type": "string", "format": "did" },
+                        "handle": { "type": "string", "format": "handle" },
+                        "displayName": { "type": "string" }
+                      }
+                    }
+                  }
+                }
+                """.trimIndent(),
+            ),
+        )
+
+    private fun objectDef(
+        docs: List<LexiconDocument>,
+        nsid: String,
+        def: String,
+    ): ObjectDef = docs.single { it.id == nsid }.defs.getValue(def) as ObjectDef
+
+    @Test
+    fun `parse reads def, defaults, and reason`() {
+        val manifest =
+            parseFieldDefaultOverrides(
+                """
+                {
+                  "version": 1,
+                  "overrides": [
+                    { "def": "chat.bsky.actor.defs#profileViewBasic", "defaults": { "handle": "handle.invalid" }, "reason": "server omits it" }
+                  ]
+                }
+                """.trimIndent(),
+            )
+        assertEquals(1, manifest.overrides.size)
+        assertEquals("chat.bsky.actor.defs#profileViewBasic", manifest.overrides[0].def)
+        assertEquals(mapOf("handle" to "handle.invalid"), manifest.overrides[0].defaults)
+        assertEquals("server omits it", manifest.overrides[0].reason)
+    }
+
+    @Test
+    fun `apply sets injectedDefault and keeps the field required and present`() {
+        val manifest =
+            FieldDefaultOverrideManifest(
+                overrides = listOf(FieldDefaultOverride("chat.bsky.actor.defs#profileViewBasic", mapOf("handle" to "handle.invalid"))),
+            )
+
+        val result = applyFieldDefaultOverrides(profileDocs, manifest)
+
+        val def = objectDef(result, "chat.bsky.actor.defs", "profileViewBasic")
+        // required is untouched (the field stays non-null; the default makes it optional to kotlinx).
+        assertEquals(listOf("did", "handle"), def.required)
+        assertEquals("handle.invalid", (def.properties.getValue("handle") as StringType).injectedDefault)
+    }
+
+    @Test
+    fun `the generator emits the field non-null defaulted to the injected value`() {
+        val overridden =
+            applyFieldDefaultOverrides(
+                profileDocs,
+                FieldDefaultOverrideManifest(
+                    overrides = listOf(FieldDefaultOverride("chat.bsky.actor.defs#profileViewBasic", mapOf("handle" to "handle.invalid"))),
+                ),
+            )
+
+        val source = CodeGenerator().generate(overridden).single { it.name == "ProfileViewBasic" }.toString()
+
+        // Non-null, defaulted to the value-class-wrapped sentinel — not nullable.
+        assertTrue("""public val handle: Handle = Handle("handle.invalid")""" in source, source)
+        assertFalse("handle: Handle?" in source, "handle must not be nullable")
+    }
+
+    @Test
+    fun `apply with no overrides returns the docs unchanged`() {
+        val result = applyFieldDefaultOverrides(profileDocs, FieldDefaultOverrideManifest())
+        assertEquals(null, (objectDef(result, "chat.bsky.actor.defs", "profileViewBasic").properties.getValue("handle") as StringType).injectedDefault)
+    }
+
+    @Test
+    fun `apply fails fast on an unknown lexicon`() {
+        val manifest =
+            FieldDefaultOverrideManifest(overrides = listOf(FieldDefaultOverride("does.not.exist#x", mapOf("y" to "z"))))
+        assertFailsWith<IllegalArgumentException> { applyFieldDefaultOverrides(profileDocs, manifest) }
+    }
+
+    @Test
+    fun `apply fails fast on an unknown def`() {
+        val manifest =
+            FieldDefaultOverrideManifest(
+                overrides = listOf(FieldDefaultOverride("chat.bsky.actor.defs#nope", mapOf("handle" to "x"))),
+            )
+        assertFailsWith<IllegalArgumentException> { applyFieldDefaultOverrides(profileDocs, manifest) }
+    }
+
+    @Test
+    fun `apply fails fast on a property that is not a string`() {
+        // 'did' is a string-format field, so use a non-string by adding an object property.
+        val docs =
+            listOf(
+                parser.parse(
+                    """
+                    {
+                      "lexicon": 1,
+                      "id": "x.y.z",
+                      "defs": {
+                        "main": {
+                          "type": "object",
+                          "required": ["count"],
+                          "properties": { "count": { "type": "integer" } }
+                        }
+                      }
+                    }
+                    """.trimIndent(),
+                ),
+            )
+        val manifest = FieldDefaultOverrideManifest(overrides = listOf(FieldDefaultOverride("x.y.z#main", mapOf("count" to "0"))))
+        assertFailsWith<IllegalArgumentException> { applyFieldDefaultOverrides(docs, manifest) }
+    }
+
+    @Test
+    fun `apply fails fast on an unknown property`() {
+        val manifest =
+            FieldDefaultOverrideManifest(
+                overrides = listOf(FieldDefaultOverride("chat.bsky.actor.defs#profileViewBasic", mapOf("nonexistent" to "x"))),
+            )
+        assertFailsWith<IllegalArgumentException> { applyFieldDefaultOverrides(profileDocs, manifest) }
+    }
+
+    @Test
+    fun `apply fails fast on a malformed id without a def fragment`() {
+        val manifest =
+            FieldDefaultOverrideManifest(overrides = listOf(FieldDefaultOverride("chat.bsky.actor.defs", mapOf("handle" to "x"))))
+        assertFailsWith<IllegalArgumentException> { applyFieldDefaultOverrides(profileDocs, manifest) }
+    }
+}


### PR DESCRIPTION
## Problem

`chat.bsky.convo.getMessages` hard-fails deserialization when a group's history contains a **member-join system message** whose embedded `chat.bsky.actor.defs#profileViewBasic` has **no `handle`** — which Bluesky's chat service returns for departed/deactivated members. The lexicon marks `handle` required, so:

```
kotlinx.serialization.MissingFieldException: Field 'handle' is required ... but it was missing
```

The whole page fails to decode, so group threads won't open (observed in Nubecita; logcat pinned it to this `MissingFieldException`).

## Fix

A **field-default-overrides** manifest (`generator/field-default-overrides.json`) the generator applies after parsing. Each entry injects a fallback onto a required string field; the model emitter renders it as its **non-null type defaulted to the value**:

```kotlin
public val handle: Handle = Handle("handle.invalid")
```

A Kotlin property with a default is optional to kotlinx, so a missing `handle` decodes to the fallback — **no `MissingFieldException`, and consumers keep a plain non-null `Handle`** (no null-checks pushed downstream). `handle.invalid` is the same sentinel `app.bsky` returns for invalid handles, so it already flows through clients cleanly.

Seeded with:
```json
{ "def": "chat.bsky.actor.defs#profileViewBasic", "defaults": { "handle": "handle.invalid" } }
```

### Scoping (no churn)

The injected value rides on `StringType.injectedDefault` — a `@Transient`, non-Lexicon marker — so the **four real Lexicon string `default`s** in the corpus (e.g. `getAuthorFeed` filter, `searchPosts` sort) keep their existing emission. `app.bsky`'s `profileViewBasic` is untouched. GoldenFileTest is green (zero diff to existing output).

### Why not an overlay / nullable?

- **Overlay**: overlays temporarily vendor lexicons not yet published on-network and retire once published; this is a *permanent* deviation from a *published* lexicon (an overlay would be flagged `DRIFTED` forever).
- **Nullable** (`Handle?`): pushes a null-check onto every consumer (7+ sites in Nubecita alone). The non-null sentinel keeps consumers clean.

The applier fails fast on a malformed id (`nsid#def`), or an unknown lexicon / def / non-string field.

## Tests

- `FieldDefaultOverridesTest`: parse, apply (sets `injectedDefault`, keeps field required), an end-to-end emit assertion (`val handle: Handle = Handle("handle.invalid")`, not nullable), and fail-fast cases.
- Full `:generator:test` incl. `GoldenFileTest` green; `:models:compileKotlinJvm` green.

## Downstream

Consumers need only the version bump — no source changes (`handle` stays non-null). Tracked under `nubecita-yvod`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)