### PR TITLE
feat(models): add embed.gallery + getEmbedExternalView via overlays

### DIFF
--- a/docs/superpowers/plans/2026-06-25-embed-gallery-overlays.md
+++ b/docs/superpowers/plans/2026-06-25-embed-gallery-overlays.md
@@ -47,7 +47,7 @@
 - [ ] **Step 1: Capture the current upstream main sha**
 
 ```bash
-cd /Users/francisco/code/atproto-kotlin
+cd <repo-root>
 SHA=$(gh api repos/bluesky-social/atproto/commits/main -q '.sha')
 echo "$SHA"   # record this; used for every manifest `commit` field below
 ```
@@ -56,7 +56,7 @@ Expected: a 40-char sha (e.g. `fdc8ca8...`). Save it as `$SHA` for the rest of t
 - [ ] **Step 2: Vendor the five files verbatim from main**
 
 ```bash
-cd /Users/francisco/code/atproto-kotlin
+cd <repo-root>
 for p in embed/gallery embed/getEmbedExternalView embed/recordWithMedia feed/post feed/defs; do
   dest="generator/overlay-lexicons/app/bsky/$p.json"
   mkdir -p "$(dirname "$dest")"
@@ -70,7 +70,7 @@ Expected: five "wrote …" lines, no errors.
 - [ ] **Step 3: Sanity-check the vendored content**
 
 ```bash
-cd /Users/francisco/code/atproto-kotlin
+cd <repo-root>
 grep -l '"app.bsky.embed.gallery' generator/overlay-lexicons/app/bsky/feed/post.json \
   generator/overlay-lexicons/app/bsky/embed/recordWithMedia.json
 grep -l 'gallery#view' generator/overlay-lexicons/app/bsky/feed/defs.json
@@ -143,7 +143,7 @@ Replace every `<SHA>` with the Step 1 value.
 - [ ] **Step 5: Validate the manifest parses**
 
 ```bash
-cd /Users/francisco/code/atproto-kotlin
+cd <repo-root>
 python3 -c "import json;d=json.load(open('generator/overlay-lexicons.json'));print('overlays:',[o['nsid'] for o in d['overlays']]);assert {o['nsid'] for o in d['overlays']} >= {'app.bsky.embed.gallery','app.bsky.embed.getEmbedExternalView','app.bsky.feed.post','app.bsky.embed.recordWithMedia','app.bsky.feed.defs'};print('OK')"
 ```
 Expected: lists 6 nsids, prints `OK`.
@@ -151,7 +151,7 @@ Expected: lists 6 nsids, prints `OK`.
 - [ ] **Step 6: Regenerate models and verify the wiring**
 
 ```bash
-cd /Users/francisco/code/atproto-kotlin
+cd <repo-root>
 ./gradlew :generator:generateModels
 gen=models/build/generated/source/lexicon/commonMain/kotlin/io/github/kikin81/atproto/app/bsky/embed
 ls $gen/Gallery*.kt
@@ -165,7 +165,7 @@ Expected: `Gallery.kt`/`GalleryView.kt` exist; the two `grep -c` print `1`; the 
 - [ ] **Step 7: Commit**
 
 ```bash
-cd /Users/francisco/code/atproto-kotlin
+cd <repo-root>
 git add generator/overlay-lexicons/ generator/overlay-lexicons.json
 git commit -m "feat(models): vendor embed.gallery + getEmbedExternalView overlays
 
@@ -234,7 +234,7 @@ class EmbedGalleryUnionTest {
 - [ ] **Step 2: Run the test to verify it passes**
 
 ```bash
-cd /Users/francisco/code/atproto-kotlin
+cd <repo-root>
 ./gradlew :models:jvmTest --tests '*EmbedGalleryUnionTest*'
 ```
 Expected: BUILD SUCCESSFUL, 3 tests passed. (If `assertIs<Gallery>` fails or it routes to `RecordWithMediaMediaUnion.Unknown`, the overlay wiring from Task 1 is wrong — fix before continuing.)
@@ -242,7 +242,7 @@ Expected: BUILD SUCCESSFUL, 3 tests passed. (If `assertIs<Gallery>` fails or it 
 - [ ] **Step 3: If `Gallery`/`GalleryView` field names or the encode helper signature differ from generated output, align the test**
 
 ```bash
-cd /Users/francisco/code/atproto-kotlin
+cd <repo-root>
 gen=models/build/generated/source/lexicon/commonMain/kotlin/io/github/kikin81/atproto/app/bsky/embed
 sed -n '1,40p' $gen/Gallery.kt
 ```
@@ -251,7 +251,7 @@ Expected: confirm the class is `data class Gallery(... items: List<...> ...)`. A
 - [ ] **Step 4: Commit**
 
 ```bash
-cd /Users/francisco/code/atproto-kotlin
+cd <repo-root>
 git add models/src/commonTest/kotlin/io/github/kikin81/atproto/app/bsky/embed/EmbedGalleryUnionTest.kt
 git commit -m "test(models): gallery is a typed member of the recordWithMedia unions
 
@@ -268,7 +268,7 @@ Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
 - [ ] **Step 1: Confirm `apiCheck` currently fails (new public API undeclared)**
 
 ```bash
-cd /Users/francisco/code/atproto-kotlin
+cd <repo-root>
 ./gradlew :models:apiCheck
 ```
 Expected: FAIL — the report lists added classes such as `Gallery`, `GalleryView`, `GalleryImage`, `GalleryViewImage`, and the `getEmbedExternalView` types as not present in `models/api/models.api`. (If it unexpectedly PASSES, the new types aren't public/generated — revisit Task 1 Step 6.)
@@ -276,7 +276,7 @@ Expected: FAIL — the report lists added classes such as `Gallery`, `GalleryVie
 - [ ] **Step 2: Regenerate the API dump**
 
 ```bash
-cd /Users/francisco/code/atproto-kotlin
+cd <repo-root>
 ./gradlew apiDump
 git diff --stat models/api/models.api
 grep -E 'Gallery|GetEmbedExternalView' models/api/models.api | head
@@ -286,7 +286,7 @@ Expected: `models/api/models.api` changed; grep shows the new gallery + getEmbed
 - [ ] **Step 3: Verify apiCheck now passes**
 
 ```bash
-cd /Users/francisco/code/atproto-kotlin
+cd <repo-root>
 ./gradlew :models:apiCheck
 ```
 Expected: BUILD SUCCESSFUL.
@@ -294,7 +294,7 @@ Expected: BUILD SUCCESSFUL.
 - [ ] **Step 4: Commit**
 
 ```bash
-cd /Users/francisco/code/atproto-kotlin
+cd <repo-root>
 git add models/api/models.api
 git commit -m "chore(models): apiDump for embed.gallery + getEmbedExternalView
 
@@ -328,7 +328,7 @@ Also update the `## Manifest semantics` line that cites commit `85c25efde14c1d03
 - [ ] **Step 2: Commit**
 
 ```bash
-cd /Users/francisco/code/atproto-kotlin
+cd <repo-root>
 git add docs/superpowers/specs/2026-06-25-embed-gallery-overlays-design.md
 git commit -m "docs: mark overlay-dir open-item resolved in gallery spec
 
@@ -342,7 +342,7 @@ Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
 - [ ] **Step 1: Generator tests (drift/stale + golden) pass**
 
 ```bash
-cd /Users/francisco/code/atproto-kotlin
+cd <repo-root>
 ./gradlew :generator:test
 ```
 Expected: BUILD SUCCESSFUL. `DetectStaleOverlaysTest` and `GoldenFileTest` pass. (Golden fixtures are independent of the real corpus/overlays, so they should be unaffected; if `GoldenFileTest` fails, inspect the diff — it likely indicates an unintended change and should be understood, not blindly `GOLDEN_UPDATE`-ed.)
@@ -350,7 +350,7 @@ Expected: BUILD SUCCESSFUL. `DetectStaleOverlaysTest` and `GoldenFileTest` pass.
 - [ ] **Step 2: Models + runtime compile and test, formatting + API gate clean**
 
 ```bash
-cd /Users/francisco/code/atproto-kotlin
+cd <repo-root>
 ./gradlew :models:jvmTest :runtime:jvmTest spotlessCheck :models:apiCheck
 ```
 Expected: BUILD SUCCESSFUL across all. (Skip iOS sim targets — unavailable on this CLT-only machine per memory `ios-sim-tests-need-xcode`.)
@@ -358,7 +358,7 @@ Expected: BUILD SUCCESSFUL across all. (Skip iOS sim targets — unavailable on 
 - [ ] **Step 3: Push and update the PR**
 
 ```bash
-cd /Users/francisco/code/atproto-kotlin
+cd <repo-root>
 git push
 gh pr ready 150
 ```

--- a/docs/superpowers/plans/2026-06-25-embed-gallery-overlays.md
+++ b/docs/superpowers/plans/2026-06-25-embed-gallery-overlays.md
@@ -1,0 +1,373 @@
+# embed.gallery + getEmbedExternalView Overlays Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add typed Kotlin support for `app.bsky.embed.gallery` (10-image gallery) and `app.bsky.embed.getEmbedExternalView`, fully wired into the three embed unions, via the overlay mechanism.
+
+**Architecture:** Vendor five lexicon JSON files verbatim from `bluesky-social/atproto@main` into `generator/overlay-lexicons/` (two new schemas + three shadowed core files that add gallery to their unions), register them in `generator/overlay-lexicons.json`, regenerate `:models`, and refresh the binary-compat API dump. The generator merges overlays by NSID with overlay-wins semantics.
+
+**Tech Stack:** Kotlin Multiplatform, KotlinPoet codegen, kotlinx.serialization, kotlinx binary-compatibility-validator, JUnit5/kotlin.test, Gradle.
+
+---
+
+## Background (read before starting)
+
+- **Why overlays, not `lexicons.json`:** gallery + getEmbedExternalView are live in the production **data plane** but their `com.atproto.lexicon.schema` **records are unpublished** on-network (`RecordNotFound`), so `npx lex install` can't fetch them. Overlays vendor the schema from GitHub. See `docs/superpowers/specs/2026-06-25-embed-gallery-overlays-design.md` and memory `lexicon-resolution-network-vs-github`.
+- **How codegen consumes overlays:** `generator/src/main/kotlin/.../Main.kt` parses the overlay dir (3rd arg) and merges by `id` with overlay-wins; shadowing a corpus NSID logs a stderr WARN. Generated source lands in `models/build/generated/...` (gitignored — regenerated each build, **not** committed).
+- **How staleness tracking consumes overlays:** `DetectStaleOverlays.kt` reads `overlay-lexicons.json` and the vendored file at `generator/overlay-lexicons/<nsid-with-slashes>.json`. It (a) compares the vendored file to upstream **`main`** via key-sorted JSON canonicalization (drift) and (b) reads a publishable verdict. `isStale = (publishable && removeWhenPublished) || drift != InSync`.
+- **Two retire conditions (drives `removeWhenPublished`):**
+  - New files (`gallery`, `getEmbedExternalView`) → `removeWhenPublished: true` (retire once their schema record publishes on-network).
+  - Shadow files (`feed.post`, `embed.recordWithMedia`, `feed.defs`) → `removeWhenPublished: false`. They are **already publishable** (the older, gallery-less version resolves on-network), so `true` would wrongly flag them for immediate retirement. They stay pinned; drift is the only signal, and final retirement is a manual call once the network's published copy includes gallery.
+- **Vendored file format:** GitHub style — `{"lexicon":1,"id":"...","defs":{...}}`, 2-space indent, **no** `$type` field (the network adds `$type`; GitHub-vendored overlays omit it, matching `generator/overlay-lexicons/chat/bsky/convo/getConvoMembers.json`). Canonicalization makes the `$type` difference irrelevant to drift.
+- **Vendor from current `main`:** upstream `main` moves. Drift compares against `main`, so vendor each file from the current `main` and pin the manifest `commit` to the current `main` sha at vendoring time. Do **not** reuse a stale sha.
+- **API dump:** `:models` is published; CI runs `apiCheck` against `models/api/models.api`. New public classes change the API, so `./gradlew apiDump` and committing the updated `.api` file is mandatory.
+
+## File Structure
+
+| File | Action | Responsibility |
+|---|---|---|
+| `generator/overlay-lexicons/app/bsky/embed/gallery.json` | Create | Vendored gallery schema (new type) |
+| `generator/overlay-lexicons/app/bsky/embed/getEmbedExternalView.json` | Create | Vendored query schema (new type) |
+| `generator/overlay-lexicons/app/bsky/feed/post.json` | Create | Shadow: adds gallery to post embed union |
+| `generator/overlay-lexicons/app/bsky/embed/recordWithMedia.json` | Create | Shadow: adds gallery/gallery#view to media unions |
+| `generator/overlay-lexicons/app/bsky/feed/defs.json` | Create | Shadow: adds gallery#view to postView union |
+| `generator/overlay-lexicons.json` | Modify | Five manifest entries (provenance + retire flags) |
+| `models/api/models.api` | Modify (via `apiDump`) | Refreshed public-API signatures |
+| `models/src/commonTest/kotlin/io/github/kikin81/atproto/app/bsky/embed/EmbedGalleryUnionTest.kt` | Create | Round-trip proof that gallery is a typed union member |
+| `docs/superpowers/specs/2026-06-25-embed-gallery-overlays-design.md` | Modify | Correct stale open-item + commit sha |
+
+---
+
+## Task 1: Vendor overlay files and register them in the manifest
+
+**Files:**
+- Create: the five files under `generator/overlay-lexicons/...` (see table)
+- Modify: `generator/overlay-lexicons.json`
+
+- [ ] **Step 1: Capture the current upstream main sha**
+
+```bash
+cd /Users/francisco/code/atproto-kotlin
+SHA=$(gh api repos/bluesky-social/atproto/commits/main -q '.sha')
+echo "$SHA"   # record this; used for every manifest `commit` field below
+```
+Expected: a 40-char sha (e.g. `fdc8ca8...`). Save it as `$SHA` for the rest of this task.
+
+- [ ] **Step 2: Vendor the five files verbatim from main**
+
+```bash
+cd /Users/francisco/code/atproto-kotlin
+for p in embed/gallery embed/getEmbedExternalView embed/recordWithMedia feed/post feed/defs; do
+  dest="generator/overlay-lexicons/app/bsky/$p.json"
+  mkdir -p "$(dirname "$dest")"
+  gh api "repos/bluesky-social/atproto/contents/lexicons/app/bsky/$p.json?ref=$SHA" \
+    -q '.content' | base64 -d > "$dest"
+  echo "wrote $dest"
+done
+```
+Expected: five "wrote …" lines, no errors.
+
+- [ ] **Step 3: Sanity-check the vendored content**
+
+```bash
+cd /Users/francisco/code/atproto-kotlin
+grep -l '"app.bsky.embed.gallery' generator/overlay-lexicons/app/bsky/feed/post.json \
+  generator/overlay-lexicons/app/bsky/embed/recordWithMedia.json
+grep -l 'gallery#view' generator/overlay-lexicons/app/bsky/feed/defs.json
+python3 -c "import json,glob; [json.load(open(f)) for f in glob.glob('generator/overlay-lexicons/app/bsky/**/*.json',recursive=True)]; print('all parse OK')"
+grep -L '\$type' generator/overlay-lexicons/app/bsky/embed/gallery.json   # should print the path (no \$type)
+```
+Expected: `post.json` + `recordWithMedia.json` contain `app.bsky.embed.gallery`; `defs.json` contains `gallery#view`; "all parse OK"; gallery.json has no `$type`.
+
+- [ ] **Step 4: Add the five manifest entries**
+
+Replace the `overlays` array in `generator/overlay-lexicons.json` so it contains the existing `getConvoMembers` entry plus the five below. Set every `commit` to the `$SHA` from Step 1 and `vendoredAt` to today (`2026-06-25`). Note the differing `removeWhenPublished` values and `reason` text.
+
+```json
+{
+  "version": 1,
+  "overlays": [
+    {
+      "nsid": "chat.bsky.convo.getConvoMembers",
+      "source": "https://github.com/bluesky-social/atproto/blob/3cb156907a15f3f22a1be734f82b3b0c855b4da0/lexicons/chat/bsky/convo/getConvoMembers.json",
+      "commit": "3cb156907a15f3f22a1be734f82b3b0c855b4da0",
+      "vendoredAt": "2026-06-20",
+      "reason": "Served by appview + present in bluesky-social/atproto main, but not yet published on-network (npx lex install -> RecordNotFound). Retire once publishable.",
+      "removeWhenPublished": true
+    },
+    {
+      "nsid": "app.bsky.embed.gallery",
+      "source": "https://github.com/bluesky-social/atproto/blob/<SHA>/lexicons/app/bsky/embed/gallery.json",
+      "commit": "<SHA>",
+      "vendoredAt": "2026-06-25",
+      "reason": "10-image gallery embed. Live in the production data plane but its com.atproto.lexicon.schema record is unpublished on-network (npx lex install -> RecordNotFound). Retire once publishable.",
+      "removeWhenPublished": true
+    },
+    {
+      "nsid": "app.bsky.embed.getEmbedExternalView",
+      "source": "https://github.com/bluesky-social/atproto/blob/<SHA>/lexicons/app/bsky/embed/getEmbedExternalView.json",
+      "commit": "<SHA>",
+      "vendoredAt": "2026-06-25",
+      "reason": "Enhanced external-embed resolver query. Present in bluesky-social/atproto main but its schema record is unpublished on-network (npx lex install -> RecordNotFound). Retire once publishable.",
+      "removeWhenPublished": true
+    },
+    {
+      "nsid": "app.bsky.feed.post",
+      "source": "https://github.com/bluesky-social/atproto/blob/<SHA>/lexicons/app/bsky/feed/post.json",
+      "commit": "<SHA>",
+      "vendoredAt": "2026-06-25",
+      "reason": "PINNED shadow (removeWhenPublished=false). This NSID is already published on-network, so it will never read as not-yet-publishable; we vendor it only to add app.bsky.embed.gallery to the embed union ahead of the network publishing that change. RE-VENDOR on drift; retire MANUALLY once the on-network post.json includes gallery.",
+      "removeWhenPublished": false
+    },
+    {
+      "nsid": "app.bsky.embed.recordWithMedia",
+      "source": "https://github.com/bluesky-social/atproto/blob/<SHA>/lexicons/app/bsky/embed/recordWithMedia.json",
+      "commit": "<SHA>",
+      "vendoredAt": "2026-06-25",
+      "reason": "PINNED shadow (removeWhenPublished=false). Already published on-network; vendored only to add app.bsky.embed.gallery / gallery#view to the media unions ahead of the network. RE-VENDOR on drift; retire MANUALLY once the on-network copy includes gallery.",
+      "removeWhenPublished": false
+    },
+    {
+      "nsid": "app.bsky.feed.defs",
+      "source": "https://github.com/bluesky-social/atproto/blob/<SHA>/lexicons/app/bsky/feed/defs.json",
+      "commit": "<SHA>",
+      "vendoredAt": "2026-06-25",
+      "reason": "PINNED shadow (removeWhenPublished=false). Already published on-network; vendored only to add app.bsky.embed.gallery#view to the postView embed union ahead of the network. RE-VENDOR on drift; retire MANUALLY once the on-network copy includes gallery#view.",
+      "removeWhenPublished": false
+    }
+  ]
+}
+```
+Replace every `<SHA>` with the Step 1 value.
+
+- [ ] **Step 5: Validate the manifest parses**
+
+```bash
+cd /Users/francisco/code/atproto-kotlin
+python3 -c "import json;d=json.load(open('generator/overlay-lexicons.json'));print('overlays:',[o['nsid'] for o in d['overlays']]);assert {o['nsid'] for o in d['overlays']} >= {'app.bsky.embed.gallery','app.bsky.embed.getEmbedExternalView','app.bsky.feed.post','app.bsky.embed.recordWithMedia','app.bsky.feed.defs'};print('OK')"
+```
+Expected: lists 6 nsids, prints `OK`.
+
+- [ ] **Step 6: Regenerate models and verify the wiring**
+
+```bash
+cd /Users/francisco/code/atproto-kotlin
+./gradlew :generator:generateModels
+gen=models/build/generated/source/lexicon/commonMain/kotlin/io/github/kikin81/atproto/app/bsky/embed
+ls $gen/Gallery*.kt
+grep -c '"app.bsky.embed.gallery" -> Gallery.serializer()' $gen/RecordWithMediaMediaUnion.kt
+grep -rc '"app.bsky.embed.gallery#view" -> GalleryView.serializer()' $gen/RecordWithMediaViewMediaUnion.kt
+grep -rl 'gallery' models/build/generated/source/lexicon/commonMain/kotlin/io/github/kikin81/atproto/app/bsky/feed/ | head
+find models/build/generated -iname "*GetEmbedExternalView*"
+```
+Expected: `Gallery.kt`/`GalleryView.kt` exist; the two `grep -c` print `1`; the feed package references gallery in its post embed union; a `getEmbedExternalView` artifact exists. The generator log should show a `WARN overlay shadows installed lexicon` line for `app.bsky.feed.post`, `app.bsky.embed.recordWithMedia`, and `app.bsky.feed.defs` (expected — those are the intentional shadows).
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /Users/francisco/code/atproto-kotlin
+git add generator/overlay-lexicons/ generator/overlay-lexicons.json
+git commit -m "feat(models): vendor embed.gallery + getEmbedExternalView overlays
+
+Add gallery (10-image) + getEmbedExternalView schemas plus pinned shadows of
+feed.post/embed.recordWithMedia/feed.defs to wire gallery into all three embed
+unions. Schemas are live in the data plane but unpublished on-network, so the
+overlay mechanism bridges the gap. Shadows use removeWhenPublished=false.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Round-trip test proving gallery is a typed union member
+
+**Files:**
+- Create: `models/src/commonTest/kotlin/io/github/kikin81/atproto/app/bsky/embed/EmbedGalleryUnionTest.kt`
+
+- [ ] **Step 1: Write the test**
+
+```kotlin
+package io.github.kikin81.atproto.app.bsky.embed
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * Proves the gallery overlay wired `app.bsky.embed.gallery` into the
+ * recordWithMedia media unions as a *typed* member (not the Unknown fallback).
+ */
+class EmbedGalleryUnionTest {
+    // Mirror the generator-emitted Json config (see runtime OpenUnionTest).
+    private val json = Json {
+        ignoreUnknownKeys = true
+        encodeDefaults = true
+    }
+
+    @Test
+    fun authoringUnion_decodesGalleryAsTypedMember() {
+        val wire = """{"${'$'}type":"app.bsky.embed.gallery","items":[]}"""
+        val decoded = json.decodeFromString<RecordWithMediaMediaUnion>(wire)
+        assertIs<Gallery>(decoded)
+    }
+
+    @Test
+    fun viewUnion_decodesGalleryViewAsTypedMember() {
+        val wire = """{"${'$'}type":"app.bsky.embed.gallery#view","items":[]}"""
+        val decoded = json.decodeFromString<RecordWithMediaViewMediaUnion>(wire)
+        assertIs<GalleryView>(decoded)
+    }
+
+    @Test
+    fun authoringUnion_encodesGalleryWithNsidDollarType() {
+        val value: RecordWithMediaMediaUnion = Gallery(items = emptyList())
+        val encoded = json.encodeToString(value)
+        val type = json.parseToJsonElement(encoded).jsonObject["${'$'}type"]!!.jsonPrimitive.content
+        assertEquals("app.bsky.embed.gallery", type)
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it passes**
+
+```bash
+cd /Users/francisco/code/atproto-kotlin
+./gradlew :models:jvmTest --tests '*EmbedGalleryUnionTest*'
+```
+Expected: BUILD SUCCESSFUL, 3 tests passed. (If `assertIs<Gallery>` fails or it routes to `RecordWithMediaMediaUnion.Unknown`, the overlay wiring from Task 1 is wrong — fix before continuing.)
+
+- [ ] **Step 3: If `Gallery`/`GalleryView` field names or the encode helper signature differ from generated output, align the test**
+
+```bash
+cd /Users/francisco/code/atproto-kotlin
+gen=models/build/generated/source/lexicon/commonMain/kotlin/io/github/kikin81/atproto/app/bsky/embed
+sed -n '1,40p' $gen/Gallery.kt
+```
+Expected: confirm the class is `data class Gallery(... items: List<...> ...)`. Adjust the test's constructor/encode call only if the generated signature differs; do not change the assertions.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/francisco/code/atproto-kotlin
+git add models/src/commonTest/kotlin/io/github/kikin81/atproto/app/bsky/embed/EmbedGalleryUnionTest.kt
+git commit -m "test(models): gallery is a typed member of the recordWithMedia unions
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Refresh the binary-compat API dump
+
+**Files:**
+- Modify: `models/api/models.api`
+
+- [ ] **Step 1: Confirm `apiCheck` currently fails (new public API undeclared)**
+
+```bash
+cd /Users/francisco/code/atproto-kotlin
+./gradlew :models:apiCheck
+```
+Expected: FAIL — the report lists added classes such as `Gallery`, `GalleryView`, `GalleryImage`, `GalleryViewImage`, and the `getEmbedExternalView` types as not present in `models/api/models.api`. (If it unexpectedly PASSES, the new types aren't public/generated — revisit Task 1 Step 6.)
+
+- [ ] **Step 2: Regenerate the API dump**
+
+```bash
+cd /Users/francisco/code/atproto-kotlin
+./gradlew apiDump
+git diff --stat models/api/models.api
+grep -E 'Gallery|GetEmbedExternalView' models/api/models.api | head
+```
+Expected: `models/api/models.api` changed; grep shows the new gallery + getEmbedExternalView symbols.
+
+- [ ] **Step 3: Verify apiCheck now passes**
+
+```bash
+cd /Users/francisco/code/atproto-kotlin
+./gradlew :models:apiCheck
+```
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/francisco/code/atproto-kotlin
+git add models/api/models.api
+git commit -m "chore(models): apiDump for embed.gallery + getEmbedExternalView
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Correct the design doc's resolved open-item
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-06-25-embed-gallery-overlays-design.md`
+
+- [ ] **Step 1: Replace the stale "Open item" section**
+
+In the spec, replace the `## Open item to resolve during implementation` section body with the resolved finding:
+
+```markdown
+## Resolved during planning
+
+The `generator/overlay-lexicons/` directory **does exist** (it already holds
+`chat/bsky/convo/getConvoMembers.json`); codegen reads the directory while the
+`overlay-lexicons.json` manifest drives drift/staleness tracking. New overlay
+files live at `generator/overlay-lexicons/<nsid-with-slashes>.json`. The three
+shadow entries use `removeWhenPublished: false` so the staleness tool keeps
+them pinned (they are already publishable on-network in their gallery-less form).
+```
+
+Also update the `## Manifest semantics` line that cites commit `85c25efde14c1d0383f32bba21b21bdad2ae2619` to read "the upstream `main` sha captured at vendoring time (see `overlay-lexicons.json`)".
+
+- [ ] **Step 2: Commit**
+
+```bash
+cd /Users/francisco/code/atproto-kotlin
+git add docs/superpowers/specs/2026-06-25-embed-gallery-overlays-design.md
+git commit -m "docs: mark overlay-dir open-item resolved in gallery spec
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Full verification
+
+- [ ] **Step 1: Generator tests (drift/stale + golden) pass**
+
+```bash
+cd /Users/francisco/code/atproto-kotlin
+./gradlew :generator:test
+```
+Expected: BUILD SUCCESSFUL. `DetectStaleOverlaysTest` and `GoldenFileTest` pass. (Golden fixtures are independent of the real corpus/overlays, so they should be unaffected; if `GoldenFileTest` fails, inspect the diff — it likely indicates an unintended change and should be understood, not blindly `GOLDEN_UPDATE`-ed.)
+
+- [ ] **Step 2: Models + runtime compile and test, formatting + API gate clean**
+
+```bash
+cd /Users/francisco/code/atproto-kotlin
+./gradlew :models:jvmTest :runtime:jvmTest spotlessCheck :models:apiCheck
+```
+Expected: BUILD SUCCESSFUL across all. (Skip iOS sim targets — unavailable on this CLT-only machine per memory `ios-sim-tests-need-xcode`.)
+
+- [ ] **Step 3: Push and update the PR**
+
+```bash
+cd /Users/francisco/code/atproto-kotlin
+git push
+gh pr ready 150
+```
+Expected: branch pushed; PR #150 flipped out of draft. Optionally tick the PR body checklist.
+
+---
+
+## Self-Review (completed by plan author)
+
+- **Spec coverage:** vendor 5 files (T1) ✓; manifest with two retire conditions (T1 Step 4) ✓; union wiring verified (T1 Step 6) ✓; typed-member behavior (T2) ✓; API dump (T3) ✓; drift/golden/test verification (T5) ✓; drift-report side effect is automatic once overlay-handled. All spec sections map to a task.
+- **Placeholder scan:** `<SHA>` is an explicit, instructed substitution (captured in T1 Step 1), not a TODO. No "add error handling" / "similar to" placeholders; all code and commands are concrete.
+- **Type consistency:** test references `RecordWithMediaMediaUnion`, `RecordWithMediaViewMediaUnion`, `Gallery`, `GalleryView` — matching the generated names verified against existing `RecordWithMediaMediaUnion.kt` and the `Images`/`ImagesView` short-name convention. T1 Step 6 and T2 Step 3 include guards to confirm exact generated signatures before relying on them.

--- a/docs/superpowers/specs/2026-06-25-embed-gallery-overlays-design.md
+++ b/docs/superpowers/specs/2026-06-25-embed-gallery-overlays-design.md
@@ -89,20 +89,20 @@ keys off a per-overlay publishable verdict:
    "exists." The `reason` field must state this explicitly so the overlay isn't mis-flagged
    as stale and whoever retires later knows the real condition.
 
-Each entry pins `source` + `commit` (`85c25efde14c1d0383f32bba21b21bdad2ae2619`) +
+Each entry pins `source` + `commit` (the upstream `main` sha captured at vendoring time (recorded in `overlay-lexicons.json`; the vendored commit was `fdc8ca8`)) +
 `vendoredAt: 2026-06-25`.
 
 New files are overlay-only — they do **not** need entries in `lexicons.json` (confirmed by the
 `getConvoMembers` precedent, which is overlay-only).
 
-## Open item to resolve during implementation
+## Resolved during planning
 
-The `generator/overlay-lexicons/` **directory does not currently exist on disk**, yet
-`overlay-lexicons.json` already lists `getConvoMembers`. The generator treats a missing
-overlay dir as an empty overlay set (`takeIf { it.exists() }`), so overlays are presently a
-no-op. Implementation must determine whether the `getConvoMembers` vendored file is expected
-to exist (and is simply missing/retired) or whether the dir is created fresh by this change —
-and ensure we don't accidentally resurrect or orphan it.
+The `generator/overlay-lexicons/` directory **does exist** (it already holds
+`chat/bsky/convo/getConvoMembers.json`); codegen reads the directory while the
+`overlay-lexicons.json` manifest drives drift/staleness tracking. New overlay
+files live at `generator/overlay-lexicons/<nsid-with-slashes>.json`. The three
+shadow entries use `removeWhenPublished: false` so the staleness tool keeps
+them pinned (they are already publishable on-network in their gallery-less form).
 
 ## Testing / verification
 

--- a/docs/superpowers/specs/2026-06-25-embed-gallery-overlays-design.md
+++ b/docs/superpowers/specs/2026-06-25-embed-gallery-overlays-design.md
@@ -29,7 +29,7 @@ delta is only these two NSIDs.
 ## Goal
 
 Emit typed, fully-wired Kotlin support for gallery and getEmbedExternalView:
-- `EmbedGallery` / `EmbedGalleryView` model classes.
+- `Gallery` / `GalleryView` model classes.
 - `gallery` as a **typed member** of every union that accepts it (so authoring and reading a
   gallery post is typesafe, not relegated to the `Unknown` open-union fallback).
 - The `getEmbedExternalView` XRPC query method on the embed service.
@@ -44,7 +44,7 @@ overridden in place.
 
 | Overlay file | Role | Effect on generated code |
 |---|---|---|
-| `app/bsky/embed/gallery.json` | **new** standalone type | emits `EmbedGallery`, `EmbedGalleryView` |
+| `app/bsky/embed/gallery.json` | **new** standalone type | emits `Gallery`, `GalleryView` |
 | `app/bsky/embed/getEmbedExternalView.json` | **new** query | emits XRPC query method on the embed service |
 | `app/bsky/feed/post.json` | **shadow** | `+ gallery` in post embed authoring union |
 | `app/bsky/embed/recordWithMedia.json` | **shadow** | `+ gallery` / `gallery#view` in both media unions |
@@ -74,7 +74,7 @@ Concretely, each generated open-union serializer gains a typed branch, e.g. in
 ```kotlin
 "app.bsky.embed.gallery" -> Gallery.serializer()   // was: else -> null (Unknown fallback)
 ```
-and `EmbedGallery` comes to implement the union interface.
+and `Gallery` comes to implement the union interface.
 
 ## Manifest semantics (two retire conditions)
 
@@ -107,7 +107,7 @@ and ensure we don't accidentally resurrect or orphan it.
 ## Testing / verification
 
 - Run `:generator:generateModels`; confirm the three union serializers gain a typed `gallery`
-  branch, `EmbedGallery`/`EmbedGalleryView` are emitted, and the `getEmbedExternalView` query
+  branch, `Gallery`/`GalleryView` are emitted, and the `getEmbedExternalView` query
   method appears on the embed service. Confirm only the expected files change.
 - Regenerate golden files if any golden fixture covers these embeds
   (`GOLDEN_UPDATE=1 ./gradlew :generator:test --tests '*GoldenFileTest*'`).

--- a/docs/superpowers/specs/2026-06-25-embed-gallery-overlays-design.md
+++ b/docs/superpowers/specs/2026-06-25-embed-gallery-overlays-design.md
@@ -1,0 +1,132 @@
+# Design: Add `app.bsky.embed.gallery` + `getEmbedExternalView` via fully-wired overlays
+
+**Date:** 2026-06-25
+**Status:** Proposed — awaiting review
+**Approach:** B (additive overlays + union wiring)
+
+## Problem
+
+Bluesky has shipped the **10-image gallery** embed (`app.bsky.embed.gallery`) and the
+`app.bsky.embed.getEmbedExternalView` query to production. Real posts carry gallery embeds
+today and the official app + third-party iOS clients render them — the **data plane is live**.
+
+However, neither schema is published as a `com.atproto.lexicon.schema` **record** on the
+authority DID (`did:plc:4v4y5r3lwsbtmsxhile2ljac`). Verified 2026-06-25: that DID hosts 167
+schema records; its `app.bsky.embed.*` set is exactly
+`{defs, external, images, record, recordWithMedia, video}` — gallery and getEmbedExternalView
+are absent. Because our SDK's codegen input comes from `npx lex install` (which resolves those
+schema *records*, not GitHub), the normal path returns `RecordNotFound` and cannot generate
+these types. See memory `lexicon-resolution-network-vs-github`.
+
+This is precisely the gap the `overlay-lexicons.json` mechanism exists for: vendor a schema
+from a pinned GitHub commit so codegen can emit typed support that matches live network data,
+flagged for retirement once the schema record is published.
+
+The drift issue (#128) listed these under `app.bsky.embed.* (7)`, but that report compares
+against GitHub `main` (not the network) and over-lists types we already generate; the true
+delta is only these two NSIDs.
+
+## Goal
+
+Emit typed, fully-wired Kotlin support for gallery and getEmbedExternalView:
+- `EmbedGallery` / `EmbedGalleryView` model classes.
+- `gallery` as a **typed member** of every union that accepts it (so authoring and reading a
+  gallery post is typesafe, not relegated to the `Unknown` open-union fallback).
+- The `getEmbedExternalView` XRPC query method on the embed service.
+
+## Approach: B — additive overlays + union wiring
+
+Vendor five files into `generator/overlay-lexicons/` **verbatim** from a single pinned
+`bluesky-social/atproto@main` commit, with five matching entries in
+`generator/overlay-lexicons.json`. Overlays merge into the corpus by NSID with **overlay-wins**
+semantics (shadowing an installed NSID logs a stderr WARN), so the three core files are
+overridden in place.
+
+| Overlay file | Role | Effect on generated code |
+|---|---|---|
+| `app/bsky/embed/gallery.json` | **new** standalone type | emits `EmbedGallery`, `EmbedGalleryView` |
+| `app/bsky/embed/getEmbedExternalView.json` | **new** query | emits XRPC query method on the embed service |
+| `app/bsky/feed/post.json` | **shadow** | `+ gallery` in post embed authoring union |
+| `app/bsky/embed/recordWithMedia.json` | **shadow** | `+ gallery` / `gallery#view` in both media unions |
+| `app/bsky/feed/defs.json` | **shadow** | `+ gallery#view` in postView embed union |
+
+### Why full-verbatim vendoring is safe here
+
+Diff of our network-resolved copies vs upstream (2026-06-25) shows the three shadow files
+differ from ours by **only** the gallery union members, plus a `$type` field the network adds
+that GitHub-vendored overlays correctly omit (matching the existing `getConvoMembers`
+precedent). So vendoring verbatim changes generated code by exactly "gallery added to three
+unions" — no unrelated churn.
+
+Ref-resolution check (2026-06-25): the only refs in the three upstream files absent from our
+corpus are the gallery ones, which the gallery overlay supplies. Nothing dangles.
+
+### Union sites wired
+
+| Site | Authoring union | View union |
+|---|---|---|
+| `app.bsky.feed.post` | `+ app.bsky.embed.gallery` | — |
+| `app.bsky.embed.recordWithMedia` | `+ app.bsky.embed.gallery` | `+ app.bsky.embed.gallery#view` |
+| `app.bsky.feed.defs` (postView) | — | `+ app.bsky.embed.gallery#view` |
+
+Concretely, each generated open-union serializer gains a typed branch, e.g. in
+`RecordWithMediaMediaUnion`:
+```kotlin
+"app.bsky.embed.gallery" -> Gallery.serializer()   // was: else -> null (Unknown fallback)
+```
+and `EmbedGallery` comes to implement the union interface.
+
+## Manifest semantics (two retire conditions)
+
+`overlay-lexicons.json` entries must distinguish two cases, because `DetectStaleOverlays`
+keys off a per-overlay publishable verdict:
+
+1. **New files** (`gallery.json`, `getEmbedExternalView.json`) — classic
+   `removeWhenPublished: true`; retire when the NSID's schema record appears on-network.
+2. **Shadow files** (`post.json`, `recordWithMedia.json`, `feed/defs.json`) — these are
+   **already published** on-network (the older, gallery-less version); they will never go
+   `RecordNotFound`. Their retire trigger is "on-network version **includes gallery**," not
+   "exists." The `reason` field must state this explicitly so the overlay isn't mis-flagged
+   as stale and whoever retires later knows the real condition.
+
+Each entry pins `source` + `commit` (`85c25efde14c1d0383f32bba21b21bdad2ae2619`) +
+`vendoredAt: 2026-06-25`.
+
+New files are overlay-only — they do **not** need entries in `lexicons.json` (confirmed by the
+`getConvoMembers` precedent, which is overlay-only).
+
+## Open item to resolve during implementation
+
+The `generator/overlay-lexicons/` **directory does not currently exist on disk**, yet
+`overlay-lexicons.json` already lists `getConvoMembers`. The generator treats a missing
+overlay dir as an empty overlay set (`takeIf { it.exists() }`), so overlays are presently a
+no-op. Implementation must determine whether the `getConvoMembers` vendored file is expected
+to exist (and is simply missing/retired) or whether the dir is created fresh by this change —
+and ensure we don't accidentally resurrect or orphan it.
+
+## Testing / verification
+
+- Run `:generator:generateModels`; confirm the three union serializers gain a typed `gallery`
+  branch, `EmbedGallery`/`EmbedGalleryView` are emitted, and the `getEmbedExternalView` query
+  method appears on the embed service. Confirm only the expected files change.
+- Regenerate golden files if any golden fixture covers these embeds
+  (`GOLDEN_UPDATE=1 ./gradlew :generator:test --tests '*GoldenFileTest*'`).
+- Confirm `DetectStaleOverlaysTest` passes; extend it if it asserts on manifest contents.
+- Build `:models` and run `:runtime:jvmTest` to confirm compilation and open-union round-trip.
+- Note iOS sim test-link is unavailable on this machine (CLT-only); use targeted JVM
+  verification (memory `ios-sim-tests-need-xcode`).
+
+## Side effects
+
+Once vendored, the drift detector excludes overlay-handled NSIDs, so gallery and
+getEmbedExternalView drop off issue #128's list.
+
+## Rejected alternatives
+
+- **A — additive overlays only (no union wiring):** emits the model classes but leaves gallery
+  in the `Unknown` fallback for all unions; can't author a typed gallery post. Rejected because
+  gallery is live in production *now* and typed authoring is the whole point.
+- **C — getEmbedExternalView only:** skips gallery; doesn't meet the goal.
+- **D — wait for network publication:** zero maintenance, but blocks typed gallery support
+  indefinitely while real gallery posts already flow through production. Rejected for the same
+  reason as A.

--- a/generator/overlay-lexicons.json
+++ b/generator/overlay-lexicons.json
@@ -8,6 +8,46 @@
       "vendoredAt": "2026-06-20",
       "reason": "Served by appview + present in bluesky-social/atproto main, but not yet published on-network (npx lex install -> RecordNotFound). Retire once publishable.",
       "removeWhenPublished": true
+    },
+    {
+      "nsid": "app.bsky.embed.gallery",
+      "source": "https://github.com/bluesky-social/atproto/blob/fdc8ca8ba690b4e051fd23fe2c914eb3fd61306e/lexicons/app/bsky/embed/gallery.json",
+      "commit": "fdc8ca8ba690b4e051fd23fe2c914eb3fd61306e",
+      "vendoredAt": "2026-06-25",
+      "reason": "10-image gallery embed. Live in the production data plane but its com.atproto.lexicon.schema record is unpublished on-network (npx lex install -> RecordNotFound). Retire once publishable.",
+      "removeWhenPublished": true
+    },
+    {
+      "nsid": "app.bsky.embed.getEmbedExternalView",
+      "source": "https://github.com/bluesky-social/atproto/blob/fdc8ca8ba690b4e051fd23fe2c914eb3fd61306e/lexicons/app/bsky/embed/getEmbedExternalView.json",
+      "commit": "fdc8ca8ba690b4e051fd23fe2c914eb3fd61306e",
+      "vendoredAt": "2026-06-25",
+      "reason": "Enhanced external-embed resolver query. Present in bluesky-social/atproto main but its schema record is unpublished on-network (npx lex install -> RecordNotFound). Retire once publishable.",
+      "removeWhenPublished": true
+    },
+    {
+      "nsid": "app.bsky.feed.post",
+      "source": "https://github.com/bluesky-social/atproto/blob/fdc8ca8ba690b4e051fd23fe2c914eb3fd61306e/lexicons/app/bsky/feed/post.json",
+      "commit": "fdc8ca8ba690b4e051fd23fe2c914eb3fd61306e",
+      "vendoredAt": "2026-06-25",
+      "reason": "PINNED shadow (removeWhenPublished=false). This NSID is already published on-network, so it will never read as not-yet-publishable; we vendor it only to add app.bsky.embed.gallery to the embed union ahead of the network publishing that change. RE-VENDOR on drift; retire MANUALLY once the on-network post.json includes gallery.",
+      "removeWhenPublished": false
+    },
+    {
+      "nsid": "app.bsky.embed.recordWithMedia",
+      "source": "https://github.com/bluesky-social/atproto/blob/fdc8ca8ba690b4e051fd23fe2c914eb3fd61306e/lexicons/app/bsky/embed/recordWithMedia.json",
+      "commit": "fdc8ca8ba690b4e051fd23fe2c914eb3fd61306e",
+      "vendoredAt": "2026-06-25",
+      "reason": "PINNED shadow (removeWhenPublished=false). Already published on-network; vendored only to add app.bsky.embed.gallery / gallery#view to the media unions ahead of the network. RE-VENDOR on drift; retire MANUALLY once the on-network copy includes gallery.",
+      "removeWhenPublished": false
+    },
+    {
+      "nsid": "app.bsky.feed.defs",
+      "source": "https://github.com/bluesky-social/atproto/blob/fdc8ca8ba690b4e051fd23fe2c914eb3fd61306e/lexicons/app/bsky/feed/defs.json",
+      "commit": "fdc8ca8ba690b4e051fd23fe2c914eb3fd61306e",
+      "vendoredAt": "2026-06-25",
+      "reason": "PINNED shadow (removeWhenPublished=false). Already published on-network; vendored only to add app.bsky.embed.gallery#view to the postView embed union ahead of the network. RE-VENDOR on drift; retire MANUALLY once the on-network copy includes gallery#view.",
+      "removeWhenPublished": false
     }
   ]
 }

--- a/generator/overlay-lexicons/app/bsky/embed/gallery.json
+++ b/generator/overlay-lexicons/app/bsky/embed/gallery.json
@@ -1,0 +1,79 @@
+{
+  "lexicon": 1,
+  "id": "app.bsky.embed.gallery",
+  "description": "An assortment of media embedded in a Bluesky record (eg, a post).",
+  "defs": {
+    "main": {
+      "type": "object",
+      "required": ["items"],
+      "properties": {
+        "items": {
+          "type": "array",
+          "maxLength": 20,
+          "description": "The schema-level maxLength of 20 is a future-proof ceiling. Clients should currently enforce a soft limit of 10 items in authoring UIs.",
+          "items": {
+            "type": "union",
+            "refs": ["#image"],
+            "description": "The media items in the gallery. Each item may be of a different type, but all types must be supported by the client."
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": ["image", "alt", "aspectRatio"],
+      "properties": {
+        "image": {
+          "type": "blob",
+          "accept": ["image/*"],
+          "maxSize": 2000000
+        },
+        "alt": {
+          "type": "string",
+          "description": "Alt text description of the image, for accessibility."
+        },
+        "aspectRatio": {
+          "type": "ref",
+          "ref": "app.bsky.embed.defs#aspectRatio"
+        }
+      }
+    },
+    "view": {
+      "type": "object",
+      "required": ["items"],
+      "properties": {
+        "items": {
+          "type": "array",
+          "items": {
+            "type": "union",
+            "refs": ["#viewImage"]
+          }
+        }
+      }
+    },
+    "viewImage": {
+      "type": "object",
+      "required": ["thumbnail", "fullsize", "alt", "aspectRatio"],
+      "properties": {
+        "thumbnail": {
+          "type": "string",
+          "format": "uri",
+          "description": "Fully-qualified URL where a thumbnail of the image can be fetched. For example, CDN location provided by the App View."
+        },
+        "fullsize": {
+          "type": "string",
+          "format": "uri",
+          "description": "Fully-qualified URL where a large version of the image can be fetched. May or may not be the exact original blob. For example, CDN location provided by the App View."
+        },
+        "alt": {
+          "type": "string",
+          "description": "Alt text description of the image, for accessibility."
+        },
+        "aspectRatio": {
+          "type": "ref",
+          "ref": "app.bsky.embed.defs#aspectRatio"
+        }
+      }
+    }
+  }
+}

--- a/generator/overlay-lexicons/app/bsky/embed/getEmbedExternalView.json
+++ b/generator/overlay-lexicons/app/bsky/embed/getEmbedExternalView.json
@@ -1,0 +1,55 @@
+{
+  "lexicon": 1,
+  "id": "app.bsky.embed.getEmbedExternalView",
+  "defs": {
+    "main": {
+      "type": "query",
+      "description": "Resolve one or more AT-URIs into the data needed to render an enhanced external embed. Returns `associatedRefs` (strongRefs to embed into a post's external.associatedRefs), the raw `associatedRecords`, and a hydrated `view`. The response is empty (`{}`) when no records were resolvable, or when validation determined the resolved records don't actually back the requested URL; clients should fall back to their own link-card rendering in that case and skip writing strongRefs to the post.",
+      "parameters": {
+        "type": "params",
+        "required": ["url", "uris"],
+        "properties": {
+          "url": {
+            "type": "string",
+            "format": "uri",
+            "description": "The canonical web URL the embed represents (typically the URL the user pasted into the composer). Used as the returned view's `uri`. May be used for validation in the future."
+          },
+          "uris": {
+            "type": "array",
+            "description": "AT-URIs of any Atmosphere records that can be resolved and used to construct #externalView views. Example: a site.standard.document and optionally its associated site.standard.publication.",
+            "items": { "type": "string", "format": "at-uri" },
+            "maxLength": 4
+          }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "view": {
+              "type": "ref",
+              "ref": "app.bsky.embed.external#view",
+              "description": "Hydrated view of the embed. Present only when the resolved records back the requested URL and supply enough information to populate the required `viewExternal` fields. Omitted alongside the rest of the response when no records resolved or validation failed."
+            },
+            "associatedRefs": {
+              "type": "array",
+              "items": {
+                "type": "ref",
+                "ref": "com.atproto.repo.strongRef"
+              },
+              "description": "StrongRefs (URI+CID) of the Atmosphere records that backed this view, suitable for embedding into a post's external.associatedRefs."
+            },
+            "associatedRecords": {
+              "type": "array",
+              "items": {
+                "type": "unknown",
+                "description": "The raw record data of the Atmosphere records that backed this view. This is returned for convenience, to avoid the need for the client to separately fetch the record data for the associatedRefs. Example: the site.standard.document and site.standard.publication records that backed this view."
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/generator/overlay-lexicons/app/bsky/embed/recordWithMedia.json
+++ b/generator/overlay-lexicons/app/bsky/embed/recordWithMedia.json
@@ -1,0 +1,45 @@
+{
+  "lexicon": 1,
+  "id": "app.bsky.embed.recordWithMedia",
+  "description": "A representation of a record embedded in a Bluesky record (eg, a post), alongside other compatible embeds. For example, a quote post and image, or a quote post and external URL card.",
+  "defs": {
+    "main": {
+      "type": "object",
+      "required": ["record", "media"],
+      "properties": {
+        "record": {
+          "type": "ref",
+          "ref": "app.bsky.embed.record"
+        },
+        "media": {
+          "type": "union",
+          "refs": [
+            "app.bsky.embed.images",
+            "app.bsky.embed.video",
+            "app.bsky.embed.gallery",
+            "app.bsky.embed.external"
+          ]
+        }
+      }
+    },
+    "view": {
+      "type": "object",
+      "required": ["record", "media"],
+      "properties": {
+        "record": {
+          "type": "ref",
+          "ref": "app.bsky.embed.record#view"
+        },
+        "media": {
+          "type": "union",
+          "refs": [
+            "app.bsky.embed.images#view",
+            "app.bsky.embed.video#view",
+            "app.bsky.embed.gallery#view",
+            "app.bsky.embed.external#view"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/generator/overlay-lexicons/app/bsky/feed/defs.json
+++ b/generator/overlay-lexicons/app/bsky/feed/defs.json
@@ -1,0 +1,332 @@
+{
+  "lexicon": 1,
+  "id": "app.bsky.feed.defs",
+  "defs": {
+    "postView": {
+      "type": "object",
+      "required": ["uri", "cid", "author", "record", "indexedAt"],
+      "properties": {
+        "uri": { "type": "string", "format": "at-uri" },
+        "cid": { "type": "string", "format": "cid" },
+        "author": {
+          "type": "ref",
+          "ref": "app.bsky.actor.defs#profileViewBasic"
+        },
+        "record": { "type": "unknown" },
+        "embed": {
+          "type": "union",
+          "refs": [
+            "app.bsky.embed.images#view",
+            "app.bsky.embed.video#view",
+            "app.bsky.embed.gallery#view",
+            "app.bsky.embed.external#view",
+            "app.bsky.embed.record#view",
+            "app.bsky.embed.recordWithMedia#view"
+          ]
+        },
+        "bookmarkCount": { "type": "integer" },
+        "replyCount": { "type": "integer" },
+        "repostCount": { "type": "integer" },
+        "likeCount": { "type": "integer" },
+        "quoteCount": { "type": "integer" },
+        "indexedAt": { "type": "string", "format": "datetime" },
+        "viewer": { "type": "ref", "ref": "#viewerState" },
+        "labels": {
+          "type": "array",
+          "items": { "type": "ref", "ref": "com.atproto.label.defs#label" }
+        },
+        "threadgate": { "type": "ref", "ref": "#threadgateView" },
+        "debug": {
+          "type": "unknown",
+          "description": "Debug information for internal development"
+        }
+      }
+    },
+    "viewerState": {
+      "type": "object",
+      "description": "Metadata about the requesting account's relationship with the subject content. Only has meaningful content for authed requests.",
+      "properties": {
+        "repost": { "type": "string", "format": "at-uri" },
+        "like": { "type": "string", "format": "at-uri" },
+        "bookmarked": { "type": "boolean" },
+        "threadMuted": { "type": "boolean" },
+        "replyDisabled": { "type": "boolean" },
+        "embeddingDisabled": { "type": "boolean" },
+        "pinned": { "type": "boolean" }
+      }
+    },
+    "threadContext": {
+      "type": "object",
+      "description": "Metadata about this post within the context of the thread it is in.",
+      "properties": {
+        "rootAuthorLike": { "type": "string", "format": "at-uri" }
+      }
+    },
+    "feedViewPost": {
+      "type": "object",
+      "required": ["post"],
+      "properties": {
+        "post": { "type": "ref", "ref": "#postView" },
+        "reply": { "type": "ref", "ref": "#replyRef" },
+        "reason": { "type": "union", "refs": ["#reasonRepost", "#reasonPin"] },
+        "feedContext": {
+          "type": "string",
+          "description": "Context provided by feed generator that may be passed back alongside interactions.",
+          "maxLength": 2000
+        },
+        "reqId": {
+          "type": "string",
+          "description": "Unique identifier per request that may be passed back alongside interactions.",
+          "maxLength": 100
+        }
+      }
+    },
+    "replyRef": {
+      "type": "object",
+      "required": ["root", "parent"],
+      "properties": {
+        "root": {
+          "type": "union",
+          "refs": ["#postView", "#notFoundPost", "#blockedPost"]
+        },
+        "parent": {
+          "type": "union",
+          "refs": ["#postView", "#notFoundPost", "#blockedPost"]
+        },
+        "grandparentAuthor": {
+          "type": "ref",
+          "ref": "app.bsky.actor.defs#profileViewBasic",
+          "description": "When parent is a reply to another post, this is the author of that post."
+        }
+      }
+    },
+    "reasonRepost": {
+      "type": "object",
+      "required": ["by", "indexedAt"],
+      "properties": {
+        "by": { "type": "ref", "ref": "app.bsky.actor.defs#profileViewBasic" },
+        "uri": { "type": "string", "format": "at-uri" },
+        "cid": { "type": "string", "format": "cid" },
+        "indexedAt": { "type": "string", "format": "datetime" }
+      }
+    },
+    "reasonPin": {
+      "type": "object",
+      "properties": {}
+    },
+    "threadViewPost": {
+      "type": "object",
+      "required": ["post"],
+      "properties": {
+        "post": { "type": "ref", "ref": "#postView" },
+        "parent": {
+          "type": "union",
+          "refs": ["#threadViewPost", "#notFoundPost", "#blockedPost"]
+        },
+        "replies": {
+          "type": "array",
+          "items": {
+            "type": "union",
+            "refs": ["#threadViewPost", "#notFoundPost", "#blockedPost"]
+          }
+        },
+        "threadContext": { "type": "ref", "ref": "#threadContext" }
+      }
+    },
+    "notFoundPost": {
+      "type": "object",
+      "required": ["uri", "notFound"],
+      "properties": {
+        "uri": { "type": "string", "format": "at-uri" },
+        "notFound": { "type": "boolean", "const": true }
+      }
+    },
+    "blockedPost": {
+      "type": "object",
+      "required": ["uri", "blocked", "author"],
+      "properties": {
+        "uri": { "type": "string", "format": "at-uri" },
+        "blocked": { "type": "boolean", "const": true },
+        "author": { "type": "ref", "ref": "#blockedAuthor" }
+      }
+    },
+    "blockedAuthor": {
+      "type": "object",
+      "required": ["did"],
+      "properties": {
+        "did": { "type": "string", "format": "did" },
+        "viewer": { "type": "ref", "ref": "app.bsky.actor.defs#viewerState" }
+      }
+    },
+    "generatorView": {
+      "type": "object",
+      "required": ["uri", "cid", "did", "creator", "displayName", "indexedAt"],
+      "properties": {
+        "uri": { "type": "string", "format": "at-uri" },
+        "cid": { "type": "string", "format": "cid" },
+        "did": { "type": "string", "format": "did" },
+        "creator": { "type": "ref", "ref": "app.bsky.actor.defs#profileView" },
+        "displayName": { "type": "string" },
+        "description": {
+          "type": "string",
+          "maxGraphemes": 300,
+          "maxLength": 3000
+        },
+        "descriptionFacets": {
+          "type": "array",
+          "items": { "type": "ref", "ref": "app.bsky.richtext.facet" }
+        },
+        "avatar": { "type": "string", "format": "uri" },
+        "likeCount": { "type": "integer", "minimum": 0 },
+        "acceptsInteractions": { "type": "boolean" },
+        "labels": {
+          "type": "array",
+          "items": { "type": "ref", "ref": "com.atproto.label.defs#label" }
+        },
+        "viewer": { "type": "ref", "ref": "#generatorViewerState" },
+        "contentMode": {
+          "type": "string",
+          "knownValues": [
+            "app.bsky.feed.defs#contentModeUnspecified",
+            "app.bsky.feed.defs#contentModeVideo"
+          ]
+        },
+        "indexedAt": { "type": "string", "format": "datetime" }
+      }
+    },
+    "generatorViewerState": {
+      "type": "object",
+      "properties": {
+        "like": { "type": "string", "format": "at-uri" }
+      }
+    },
+    "skeletonFeedPost": {
+      "type": "object",
+      "required": ["post"],
+      "properties": {
+        "post": { "type": "string", "format": "at-uri" },
+        "reason": {
+          "type": "union",
+          "refs": ["#skeletonReasonRepost", "#skeletonReasonPin"]
+        },
+        "feedContext": {
+          "type": "string",
+          "description": "Context that will be passed through to client and may be passed to feed generator back alongside interactions.",
+          "maxLength": 2000
+        }
+      }
+    },
+    "skeletonReasonRepost": {
+      "type": "object",
+      "required": ["repost"],
+      "properties": {
+        "repost": { "type": "string", "format": "at-uri" }
+      }
+    },
+    "skeletonReasonPin": {
+      "type": "object",
+      "properties": {}
+    },
+    "threadgateView": {
+      "type": "object",
+      "properties": {
+        "uri": { "type": "string", "format": "at-uri" },
+        "cid": { "type": "string", "format": "cid" },
+        "record": { "type": "unknown" },
+        "lists": {
+          "type": "array",
+          "items": { "type": "ref", "ref": "app.bsky.graph.defs#listViewBasic" }
+        }
+      }
+    },
+    "interaction": {
+      "type": "object",
+      "properties": {
+        "item": { "type": "string", "format": "at-uri" },
+        "event": {
+          "type": "string",
+          "knownValues": [
+            "app.bsky.feed.defs#requestLess",
+            "app.bsky.feed.defs#requestMore",
+            "app.bsky.feed.defs#clickthroughItem",
+            "app.bsky.feed.defs#clickthroughAuthor",
+            "app.bsky.feed.defs#clickthroughReposter",
+            "app.bsky.feed.defs#clickthroughEmbed",
+            "app.bsky.feed.defs#interactionSeen",
+            "app.bsky.feed.defs#interactionLike",
+            "app.bsky.feed.defs#interactionRepost",
+            "app.bsky.feed.defs#interactionReply",
+            "app.bsky.feed.defs#interactionQuote",
+            "app.bsky.feed.defs#interactionShare"
+          ]
+        },
+        "feedContext": {
+          "type": "string",
+          "description": "Context on a feed item that was originally supplied by the feed generator on getFeedSkeleton.",
+          "maxLength": 2000
+        },
+        "reqId": {
+          "type": "string",
+          "description": "Unique identifier per request that may be passed back alongside interactions.",
+          "maxLength": 100
+        }
+      }
+    },
+    "requestLess": {
+      "type": "token",
+      "description": "Request that less content like the given feed item be shown in the feed"
+    },
+    "requestMore": {
+      "type": "token",
+      "description": "Request that more content like the given feed item be shown in the feed"
+    },
+    "clickthroughItem": {
+      "type": "token",
+      "description": "User clicked through to the feed item"
+    },
+    "clickthroughAuthor": {
+      "type": "token",
+      "description": "User clicked through to the author of the feed item"
+    },
+    "clickthroughReposter": {
+      "type": "token",
+      "description": "User clicked through to the reposter of the feed item"
+    },
+    "clickthroughEmbed": {
+      "type": "token",
+      "description": "User clicked through to the embedded content of the feed item"
+    },
+    "contentModeUnspecified": {
+      "type": "token",
+      "description": "Declares the feed generator returns any types of posts."
+    },
+    "contentModeVideo": {
+      "type": "token",
+      "description": "Declares the feed generator returns posts containing app.bsky.embed.video embeds."
+    },
+    "interactionSeen": {
+      "type": "token",
+      "description": "Feed item was seen by user"
+    },
+    "interactionLike": {
+      "type": "token",
+      "description": "User liked the feed item"
+    },
+    "interactionRepost": {
+      "type": "token",
+      "description": "User reposted the feed item"
+    },
+    "interactionReply": {
+      "type": "token",
+      "description": "User replied to the feed item"
+    },
+    "interactionQuote": {
+      "type": "token",
+      "description": "User quoted the feed item"
+    },
+    "interactionShare": {
+      "type": "token",
+      "description": "User shared the feed item"
+    }
+  }
+}

--- a/generator/overlay-lexicons/app/bsky/feed/post.json
+++ b/generator/overlay-lexicons/app/bsky/feed/post.json
@@ -1,0 +1,97 @@
+{
+  "lexicon": 1,
+  "id": "app.bsky.feed.post",
+  "defs": {
+    "main": {
+      "type": "record",
+      "description": "Record containing a Bluesky post.",
+      "key": "tid",
+      "record": {
+        "type": "object",
+        "required": ["text", "createdAt"],
+        "properties": {
+          "text": {
+            "type": "string",
+            "maxLength": 3000,
+            "maxGraphemes": 300,
+            "description": "The primary post content. May be an empty string, if there are embeds."
+          },
+          "entities": {
+            "type": "array",
+            "description": "DEPRECATED: replaced by app.bsky.richtext.facet.",
+            "items": { "type": "ref", "ref": "#entity" }
+          },
+          "facets": {
+            "type": "array",
+            "description": "Annotations of text (mentions, URLs, hashtags, etc)",
+            "items": { "type": "ref", "ref": "app.bsky.richtext.facet" }
+          },
+          "reply": { "type": "ref", "ref": "#replyRef" },
+          "embed": {
+            "type": "union",
+            "refs": [
+              "app.bsky.embed.images",
+              "app.bsky.embed.video",
+              "app.bsky.embed.gallery",
+              "app.bsky.embed.external",
+              "app.bsky.embed.record",
+              "app.bsky.embed.recordWithMedia"
+            ]
+          },
+          "langs": {
+            "type": "array",
+            "description": "Indicates human language of post primary text content.",
+            "maxLength": 3,
+            "items": { "type": "string", "format": "language" }
+          },
+          "labels": {
+            "type": "union",
+            "description": "Self-label values for this post. Effectively content warnings.",
+            "refs": ["com.atproto.label.defs#selfLabels"]
+          },
+          "tags": {
+            "type": "array",
+            "description": "Additional hashtags, in addition to any included in post text and facets.",
+            "maxLength": 8,
+            "items": { "type": "string", "maxLength": 640, "maxGraphemes": 64 }
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "datetime",
+            "description": "Client-declared timestamp when this post was originally created."
+          }
+        }
+      }
+    },
+    "replyRef": {
+      "type": "object",
+      "required": ["root", "parent"],
+      "properties": {
+        "root": { "type": "ref", "ref": "com.atproto.repo.strongRef" },
+        "parent": { "type": "ref", "ref": "com.atproto.repo.strongRef" }
+      }
+    },
+    "entity": {
+      "type": "object",
+      "description": "Deprecated: use facets instead.",
+      "required": ["index", "type", "value"],
+      "properties": {
+        "index": { "type": "ref", "ref": "#textSlice" },
+        "type": {
+          "type": "string",
+          "description": "Expected values are 'mention' and 'link'."
+        },
+        "value": { "type": "string" }
+      }
+    },
+    "textSlice": {
+      "type": "object",
+      "description": "Deprecated. Use app.bsky.richtext instead -- A text segment. Start is inclusive, end is exclusive. Indices are for utf16-encoded strings.",
+      "required": ["start", "end"],
+      "properties": {
+        "start": { "type": "integer", "minimum": 0 },
+        "end": { "type": "integer", "minimum": 0 }
+      }
+    }
+  }
+}

--- a/models/api/models.api
+++ b/models/api/models.api
@@ -2863,6 +2863,12 @@ public final class io/github/kikin81/atproto/app/bsky/embed/AspectRatio$Companio
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class io/github/kikin81/atproto/app/bsky/embed/EmbedService {
+	public fun <init> (Lio/github/kikin81/atproto/runtime/XrpcClient;)V
+	public final fun getEmbedExternalView (Lio/github/kikin81/atproto/app/bsky/embed/GetEmbedExternalViewRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getEmbedExternalView$default (Lio/github/kikin81/atproto/app/bsky/embed/EmbedService;Lio/github/kikin81/atproto/app/bsky/embed/GetEmbedExternalViewRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
 public final class io/github/kikin81/atproto/app/bsky/embed/External : io/github/kikin81/atproto/app/bsky/actor/StatusEmbedUnion, io/github/kikin81/atproto/app/bsky/embed/RecordWithMediaMediaUnion, io/github/kikin81/atproto/app/bsky/feed/PostEmbedUnion {
 	public static final field Companion Lio/github/kikin81/atproto/app/bsky/embed/External$Companion;
 	public fun <init> (Lio/github/kikin81/atproto/app/bsky/embed/ExternalExternal;)V
@@ -2982,6 +2988,266 @@ public final synthetic class io/github/kikin81/atproto/app/bsky/embed/ExternalVi
 }
 
 public final class io/github/kikin81/atproto/app/bsky/embed/ExternalViewExternal$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/Gallery : io/github/kikin81/atproto/app/bsky/embed/RecordWithMediaMediaUnion, io/github/kikin81/atproto/app/bsky/feed/PostEmbedUnion {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/embed/Gallery$Companion;
+	public fun <init> (Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lio/github/kikin81/atproto/app/bsky/embed/Gallery;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/embed/Gallery;Ljava/util/List;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/embed/Gallery;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getItems ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/embed/Gallery$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/embed/Gallery$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/embed/Gallery;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/embed/Gallery;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/Gallery$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/GalleryImage : io/github/kikin81/atproto/app/bsky/embed/GalleryItemsUnion {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/embed/GalleryImage$Companion;
+	public fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/embed/AspectRatio;Lio/github/kikin81/atproto/runtime/Blob;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/github/kikin81/atproto/app/bsky/embed/AspectRatio;
+	public final fun component3 ()Lio/github/kikin81/atproto/runtime/Blob;
+	public final fun copy (Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/embed/AspectRatio;Lio/github/kikin81/atproto/runtime/Blob;)Lio/github/kikin81/atproto/app/bsky/embed/GalleryImage;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/embed/GalleryImage;Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/embed/AspectRatio;Lio/github/kikin81/atproto/runtime/Blob;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/embed/GalleryImage;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAlt ()Ljava/lang/String;
+	public final fun getAspectRatio ()Lio/github/kikin81/atproto/app/bsky/embed/AspectRatio;
+	public final fun getImage ()Lio/github/kikin81/atproto/runtime/Blob;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/embed/GalleryImage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/embed/GalleryImage$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/embed/GalleryImage;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/embed/GalleryImage;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/GalleryImage$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class io/github/kikin81/atproto/app/bsky/embed/GalleryItemsUnion : io/github/kikin81/atproto/runtime/OpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/embed/GalleryItemsUnion$Companion;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/GalleryItemsUnion$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/GalleryItemsUnion$Unknown : io/github/kikin81/atproto/app/bsky/embed/GalleryItemsUnion, io/github/kikin81/atproto/runtime/UnknownOpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/embed/GalleryItemsUnion$Unknown$Companion;
+	public fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/app/bsky/embed/GalleryItemsUnion$Unknown;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/embed/GalleryItemsUnion$Unknown;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/embed/GalleryItemsUnion$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getRaw ()Lkotlinx/serialization/json/JsonObject;
+	public fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/GalleryItemsUnion$Unknown$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/GalleryItemsUnionSerializer : io/github/kikin81/atproto/runtime/OpenUnionSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/embed/GalleryItemsUnionSerializer;
+	public fun selectKnownDeserializer (Ljava/lang/String;)Lkotlinx/serialization/KSerializer;
+	public fun selectKnownSerializer (Lio/github/kikin81/atproto/app/bsky/embed/GalleryItemsUnion;)Lkotlinx/serialization/KSerializer;
+	public synthetic fun selectKnownSerializer (Lio/github/kikin81/atproto/runtime/OpenUnionMember;)Lkotlinx/serialization/KSerializer;
+	public fun unknownSerializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/GalleryItemsUnionUnknownSerializer : io/github/kikin81/atproto/runtime/UnknownMemberSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/embed/GalleryItemsUnionUnknownSerializer;
+	public fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/app/bsky/embed/GalleryItemsUnion$Unknown;
+	public synthetic fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/runtime/UnknownOpenUnionMember;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/GalleryView : io/github/kikin81/atproto/app/bsky/embed/RecordWithMediaViewMediaUnion, io/github/kikin81/atproto/app/bsky/feed/PostViewEmbedUnion {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/embed/GalleryView$Companion;
+	public fun <init> (Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lio/github/kikin81/atproto/app/bsky/embed/GalleryView;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/embed/GalleryView;Ljava/util/List;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/embed/GalleryView;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getItems ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/embed/GalleryView$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/embed/GalleryView$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/embed/GalleryView;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/embed/GalleryView;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/GalleryView$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/GalleryViewImage : io/github/kikin81/atproto/app/bsky/embed/GalleryViewItemsUnion {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/embed/GalleryViewImage$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/embed/AspectRatio;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/github/kikin81/atproto/app/bsky/embed/AspectRatio;
+	public final fun component3-jMNtXP8 ()Ljava/lang/String;
+	public final fun component4-jMNtXP8 ()Ljava/lang/String;
+	public final fun copy-1pRRTy0 (Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/embed/AspectRatio;Ljava/lang/String;Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/embed/GalleryViewImage;
+	public static synthetic fun copy-1pRRTy0$default (Lio/github/kikin81/atproto/app/bsky/embed/GalleryViewImage;Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/embed/AspectRatio;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/embed/GalleryViewImage;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAlt ()Ljava/lang/String;
+	public final fun getAspectRatio ()Lio/github/kikin81/atproto/app/bsky/embed/AspectRatio;
+	public final fun getFullsize-jMNtXP8 ()Ljava/lang/String;
+	public final fun getThumbnail-jMNtXP8 ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/embed/GalleryViewImage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/embed/GalleryViewImage$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/embed/GalleryViewImage;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/embed/GalleryViewImage;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/GalleryViewImage$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class io/github/kikin81/atproto/app/bsky/embed/GalleryViewItemsUnion : io/github/kikin81/atproto/runtime/OpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/embed/GalleryViewItemsUnion$Companion;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/GalleryViewItemsUnion$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/GalleryViewItemsUnion$Unknown : io/github/kikin81/atproto/app/bsky/embed/GalleryViewItemsUnion, io/github/kikin81/atproto/runtime/UnknownOpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/embed/GalleryViewItemsUnion$Unknown$Companion;
+	public fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/app/bsky/embed/GalleryViewItemsUnion$Unknown;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/embed/GalleryViewItemsUnion$Unknown;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/embed/GalleryViewItemsUnion$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getRaw ()Lkotlinx/serialization/json/JsonObject;
+	public fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/GalleryViewItemsUnion$Unknown$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/GalleryViewItemsUnionSerializer : io/github/kikin81/atproto/runtime/OpenUnionSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/embed/GalleryViewItemsUnionSerializer;
+	public fun selectKnownDeserializer (Ljava/lang/String;)Lkotlinx/serialization/KSerializer;
+	public fun selectKnownSerializer (Lio/github/kikin81/atproto/app/bsky/embed/GalleryViewItemsUnion;)Lkotlinx/serialization/KSerializer;
+	public synthetic fun selectKnownSerializer (Lio/github/kikin81/atproto/runtime/OpenUnionMember;)Lkotlinx/serialization/KSerializer;
+	public fun unknownSerializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/GalleryViewItemsUnionUnknownSerializer : io/github/kikin81/atproto/runtime/UnknownMemberSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/embed/GalleryViewItemsUnionUnknownSerializer;
+	public fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/app/bsky/embed/GalleryViewItemsUnion$Unknown;
+	public synthetic fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/runtime/UnknownOpenUnionMember;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/GetEmbedExternalViewRequest {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/embed/GetEmbedExternalViewRequest$Companion;
+	public synthetic fun <init> (Ljava/util/List;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2-jMNtXP8 ()Ljava/lang/String;
+	public final fun copy-eM3CBdQ (Ljava/util/List;Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/embed/GetEmbedExternalViewRequest;
+	public static synthetic fun copy-eM3CBdQ$default (Lio/github/kikin81/atproto/app/bsky/embed/GetEmbedExternalViewRequest;Ljava/util/List;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/embed/GetEmbedExternalViewRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUris ()Ljava/util/List;
+	public final fun getUrl-jMNtXP8 ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/embed/GetEmbedExternalViewRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/embed/GetEmbedExternalViewRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/embed/GetEmbedExternalViewRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/embed/GetEmbedExternalViewRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/GetEmbedExternalViewRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/GetEmbedExternalViewResponse {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/embed/GetEmbedExternalViewResponse$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;Ljava/util/List;Lio/github/kikin81/atproto/app/bsky/embed/ExternalView;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;Lio/github/kikin81/atproto/app/bsky/embed/ExternalView;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Lio/github/kikin81/atproto/app/bsky/embed/ExternalView;
+	public final fun copy (Ljava/util/List;Ljava/util/List;Lio/github/kikin81/atproto/app/bsky/embed/ExternalView;)Lio/github/kikin81/atproto/app/bsky/embed/GetEmbedExternalViewResponse;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/embed/GetEmbedExternalViewResponse;Ljava/util/List;Ljava/util/List;Lio/github/kikin81/atproto/app/bsky/embed/ExternalView;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/embed/GetEmbedExternalViewResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAssociatedRecords ()Ljava/util/List;
+	public final fun getAssociatedRefs ()Ljava/util/List;
+	public final fun getView ()Lio/github/kikin81/atproto/app/bsky/embed/ExternalView;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/embed/GetEmbedExternalViewResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/embed/GetEmbedExternalViewResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/embed/GetEmbedExternalViewResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/embed/GetEmbedExternalViewResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/GetEmbedExternalViewResponse$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 

--- a/models/src/commonTest/kotlin/io/github/kikin81/atproto/app/bsky/embed/EmbedGalleryUnionTest.kt
+++ b/models/src/commonTest/kotlin/io/github/kikin81/atproto/app/bsky/embed/EmbedGalleryUnionTest.kt
@@ -27,9 +27,19 @@ class EmbedGalleryUnionTest {
 
     @Test
     fun viewUnion_decodesGalleryViewAsTypedMember() {
+        // `#view` is not `#main`, so normalizeDollarType preserves the fragment; the
+        // union's when-clause matches "app.bsky.embed.gallery#view" verbatim.
         val wire = """{"${'$'}type":"app.bsky.embed.gallery#view","items":[]}"""
         val decoded = json.decodeFromString<RecordWithMediaViewMediaUnion>(wire)
         assertIs<GalleryView>(decoded)
+    }
+
+    @Test
+    fun viewUnion_encodesGalleryViewWithNsidFragment() {
+        val value: RecordWithMediaViewMediaUnion = GalleryView(items = emptyList())
+        val encoded = json.encodeToString(value)
+        val type = json.parseToJsonElement(encoded).jsonObject["${'$'}type"]!!.jsonPrimitive.content
+        assertEquals("app.bsky.embed.gallery#view", type)
     }
 
     @Test

--- a/models/src/commonTest/kotlin/io/github/kikin81/atproto/app/bsky/embed/EmbedGalleryUnionTest.kt
+++ b/models/src/commonTest/kotlin/io/github/kikin81/atproto/app/bsky/embed/EmbedGalleryUnionTest.kt
@@ -1,0 +1,42 @@
+package io.github.kikin81.atproto.app.bsky.embed
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+/**
+ * Proves the gallery overlay wired `app.bsky.embed.gallery` into the
+ * recordWithMedia media unions as a *typed* member (not the Unknown fallback).
+ */
+class EmbedGalleryUnionTest {
+    // Mirror the generator-emitted Json config (see runtime OpenUnionTest).
+    private val json = Json {
+        ignoreUnknownKeys = true
+        encodeDefaults = true
+    }
+
+    @Test
+    fun authoringUnion_decodesGalleryAsTypedMember() {
+        val wire = """{"${'$'}type":"app.bsky.embed.gallery","items":[]}"""
+        val decoded = json.decodeFromString<RecordWithMediaMediaUnion>(wire)
+        assertIs<Gallery>(decoded)
+    }
+
+    @Test
+    fun viewUnion_decodesGalleryViewAsTypedMember() {
+        val wire = """{"${'$'}type":"app.bsky.embed.gallery#view","items":[]}"""
+        val decoded = json.decodeFromString<RecordWithMediaViewMediaUnion>(wire)
+        assertIs<GalleryView>(decoded)
+    }
+
+    @Test
+    fun authoringUnion_encodesGalleryWithNsidDollarType() {
+        val value: RecordWithMediaMediaUnion = Gallery(items = emptyList())
+        val encoded = json.encodeToString(value)
+        val type = json.parseToJsonElement(encoded).jsonObject["${'$'}type"]!!.jsonPrimitive.content
+        assertEquals("app.bsky.embed.gallery", type)
+    }
+}


### PR DESCRIPTION
## Summary

Adds typed Kotlin support for the new Bluesky embed types **`app.bsky.embed.gallery`** (the 10-image gallery, 4→10 images) and **`app.bsky.embed.getEmbedExternalView`** (query) via the overlay mechanism.

These features are **live in the production data plane** (the official app + third-party clients render gallery posts today), but their `com.atproto.lexicon.schema` records are **not yet published on-network** — `lex install` returns `RecordNotFound`. The overlay mechanism vendors the schemas from a pinned `bluesky-social/atproto@main` commit (`85c25ef`) so codegen can emit support matching live network data, flagged for retirement once the schema records publish.

Approach B (fully-wired): vendor the two new schemas plus shadow `feed/post`, `embed/recordWithMedia`, and `feed/defs` to add `gallery`/`gallery#view` as **typed members** of all three embed unions (not just the `Unknown` fallback).

## Status

🚧 **Draft — design only so far.** This PR currently contains the design spec; the overlay implementation will follow on this branch.

- [x] Design spec (`docs/superpowers/specs/2026-06-25-embed-gallery-overlays-design.md`)
- [ ] Vendor 5 overlay files into `generator/overlay-lexicons/`
- [ ] Add 5 manifest entries to `overlay-lexicons.json` (two retire conditions: new vs shadow)
- [ ] Regenerate models + golden files
- [ ] Verify `:models` compiles, `:runtime:jvmTest` passes, `DetectStaleOverlaysTest` passes

## Notes

- Diffs verified surgical: shadow files differ from our network copies by **only** the gallery union members; no dangling refs.
- Side effect: these NSIDs drop off the drift report (#128) once overlay-handled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)