### PR TITLE
fix(runtime): degrade an incompatible known union variant to Unknown

### DIFF
--- a/runtime/src/commonMain/kotlin/io/github/kikin81/atproto/runtime/OpenUnion.kt
+++ b/runtime/src/commonMain/kotlin/io/github/kikin81/atproto/runtime/OpenUnion.kt
@@ -178,9 +178,29 @@ public abstract class OpenUnionSerializer<T : OpenUnionMember>(
         val raw = element.jsonObject[DOLLAR_TYPE]?.jsonPrimitive?.content.orEmpty()
         val normalized = normalizeDollarType(raw)
 
+        // Resolve the known member serializer for this `$type`, falling back to
+        // the Unknown member when the discriminator is unrecognized.
         @Suppress("UNCHECKED_CAST")
-        val serializer = (selectKnownDeserializer(normalized) ?: unknownSerializer()) as KSerializer<T>
-        return jsonDecoder.json.decodeFromJsonElement(serializer, element)
+        val known = selectKnownDeserializer(normalized) as KSerializer<T>?
+        if (known == null) {
+            @Suppress("UNCHECKED_CAST")
+            return jsonDecoder.json.decodeFromJsonElement(unknownSerializer() as KSerializer<T>, element)
+        }
+        return try {
+            jsonDecoder.json.decodeFromJsonElement(known, element)
+        } catch (e: SerializationException) {
+            // Open-union resilience: a recognized `$type` whose wire shape no
+            // longer matches the generated model — e.g. an "under active
+            // development" lexicon the server emits with absent/renamed required
+            // fields, or a field whose ref type the server sends in a reduced
+            // shape — must NOT hard-fail the whole enclosing object. Degrade to
+            // the Unknown member (which preserves the raw JsonObject verbatim
+            // for lossless round-trip), exactly as for an unrecognized `$type`.
+            // This keeps a single drifted event from failing an entire
+            // `getLog`/list response. See OpenUnionSerializerTest.
+            @Suppress("UNCHECKED_CAST")
+            jsonDecoder.json.decodeFromJsonElement(unknownSerializer() as KSerializer<T>, element)
+        }
     }
 
     override fun serialize(encoder: Encoder, value: T) {

--- a/runtime/src/commonMain/kotlin/io/github/kikin81/atproto/runtime/OpenUnion.kt
+++ b/runtime/src/commonMain/kotlin/io/github/kikin81/atproto/runtime/OpenUnion.kt
@@ -178,28 +178,28 @@ public abstract class OpenUnionSerializer<T : OpenUnionMember>(
         val raw = element.jsonObject[DOLLAR_TYPE]?.jsonPrimitive?.content.orEmpty()
         val normalized = normalizeDollarType(raw)
 
-        // Resolve the known member serializer for this `$type`, falling back to
-        // the Unknown member when the discriminator is unrecognized.
+        @Suppress("UNCHECKED_CAST")
+        val unknown = unknownSerializer() as KSerializer<T>
+
         @Suppress("UNCHECKED_CAST")
         val known = selectKnownDeserializer(normalized) as KSerializer<T>?
+
+        // Unrecognized `$type` → Unknown member (preserves the raw JsonObject).
         if (known == null) {
-            @Suppress("UNCHECKED_CAST")
-            return jsonDecoder.json.decodeFromJsonElement(unknownSerializer() as KSerializer<T>, element)
+            return jsonDecoder.json.decodeFromJsonElement(unknown, element)
         }
+        // Recognized `$type`, but a known variant whose wire shape no longer
+        // matches the generated model — e.g. an "under active development"
+        // lexicon the server emits with absent/renamed required fields, or a
+        // field whose ref type the server sends in a reduced shape — must NOT
+        // hard-fail the whole enclosing object. Degrade to the Unknown member
+        // (which preserves the raw JsonObject verbatim for lossless round-trip),
+        // exactly as for an unrecognized `$type`, so a single drifted event
+        // can't fail an entire `getLog`/list response. See OpenUnionTest.
         return try {
             jsonDecoder.json.decodeFromJsonElement(known, element)
         } catch (e: SerializationException) {
-            // Open-union resilience: a recognized `$type` whose wire shape no
-            // longer matches the generated model — e.g. an "under active
-            // development" lexicon the server emits with absent/renamed required
-            // fields, or a field whose ref type the server sends in a reduced
-            // shape — must NOT hard-fail the whole enclosing object. Degrade to
-            // the Unknown member (which preserves the raw JsonObject verbatim
-            // for lossless round-trip), exactly as for an unrecognized `$type`.
-            // This keeps a single drifted event from failing an entire
-            // `getLog`/list response. See OpenUnionSerializerTest.
-            @Suppress("UNCHECKED_CAST")
-            jsonDecoder.json.decodeFromJsonElement(unknownSerializer() as KSerializer<T>, element)
+            jsonDecoder.json.decodeFromJsonElement(unknown, element)
         }
     }
 

--- a/runtime/src/commonTest/kotlin/io/github/kikin81/atproto/runtime/OpenUnionTest.kt
+++ b/runtime/src/commonTest/kotlin/io/github/kikin81/atproto/runtime/OpenUnionTest.kt
@@ -162,4 +162,42 @@ class OpenUnionTest {
         val decoded = json.decodeFromString(FakeMediaUnknownSerializer, encoded)
         assertEquals(member, decoded)
     }
+
+    @Test
+    fun decode_knownType_withMissingRequiredField_degradesToUnknown() {
+        // Open-union resilience: a recognized `$type` whose payload no longer
+        // matches the generated model (here `app.bsky.embed.images` missing its
+        // required `count`) must degrade to the Unknown member instead of
+        // throwing — so a single drifted event can't fail an entire enclosing
+        // response. Regression for the chat `getLog` crash where the server
+        // emitted a reduced `systemMessageDataAddMember` shape and one bad
+        // event hard-failed deserialization of the whole logs array.
+        val wire = """{"${'$'}type":"app.bsky.embed.images","unexpected":"x"}"""
+        val decoded = json.decodeFromString(FakeMediaSerializer, wire)
+        assertIs<FakeMedia.Unknown>(decoded)
+        assertEquals("app.bsky.embed.images", decoded.type)
+        assertTrue("unexpected" in decoded.raw)
+    }
+
+    @Test
+    fun decode_knownType_withWrongFieldType_degradesToUnknown() {
+        // Mirrors the real drift: a ref-typed field arriving in an incompatible
+        // shape (here `count`, an Int, arrives as a String). Must degrade, not
+        // throw.
+        val wire = """{"${'$'}type":"app.bsky.embed.images","count":"not-an-int"}"""
+        val decoded = json.decodeFromString(FakeMediaSerializer, wire)
+        assertIs<FakeMedia.Unknown>(decoded)
+        assertEquals("app.bsky.embed.images", decoded.type)
+    }
+
+    @Test
+    fun degradedKnownType_roundTripIsLossless() {
+        // The degraded Unknown carries the raw JsonObject verbatim, so a known
+        // type that failed to decode still round-trips byte-for-byte.
+        val wire = """{"${'$'}type":"app.bsky.embed.images","count":"bad","extra":42}"""
+        val decoded = json.decodeFromString(FakeMediaSerializer, wire)
+        assertIs<FakeMedia.Unknown>(decoded)
+        val reencoded = json.encodeToString(FakeMediaSerializer, decoded)
+        assertEquals(json.parseToJsonElement(wire), json.parseToJsonElement(reencoded))
+    }
 }


### PR DESCRIPTION
## Problem

`OpenUnionSerializer.deserialize` matched a `\$type` to its generated member serializer and **hard-decoded** it. When the server emits a *recognized* type in a shape the generated model can't parse — an "under active development" lexicon with absent/renamed required fields, or a ref-typed field sent in a reduced shape — kotlinx throws a `SerializationException` that propagates out of the **enclosing** object, failing the entire response.

### Real-world impact: `chat.bsky.convo.getLog` hard-crash

A single `logAddMember` event carried a `systemMessageDataAddMember` whose `member`/`addedBy` arrived as **bare `{"did":"…"}`** objects (not full `profileViewBasic`):

```json
{ "$type":"chat.bsky.convo.defs#logAddMember",
  "message": { "data": {
    "member":  {"did":"did:plc:…"},
    "addedBy": {"did":"did:plc:…"},
    "role":"standard",
    "$type":"chat.bsky.convo.defs#systemMessageDataAddMember" }}}
```

That one event in `logs[]` failed deserialization of the **whole** getLog response, so a downstream background DM-notification poller never advanced its cursor and **never notified** (root-caused + verified on a physical device).

## Fix

Wrap the known-variant decode in `try/catch`; on `SerializationException`, **degrade to the `Unknown` member** — exactly as for an unrecognized `\$type`. `Unknown` preserves the raw `JsonObject`, so:
- the event round-trips **losslessly**, and
- consumers that ignore it (e.g. a notifier that only cares about `createMessage` events) simply skip it.

A single drifted event can no longer fail an entire list / `getLog` response. This is the correct semantics for an *open* union.

## Tests

`OpenUnionTest` gains: missing-required-field → Unknown, wrong-field-type → Unknown, and lossless round-trip of a degraded known variant. All existing tests still pass.

## Note on observability

The degrade is intentionally silent in the runtime (no logging dependency in a KMP SDK). Lexicon drift is already surfaced separately by `lexicon-drift-detect`; consumers can additionally inspect `Unknown` members (which retain `\$type` + raw JSON) if they want a per-event signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)