### PR TITLE
chore(lexicons): bump @atproto/lex to 0.1.5

### DIFF
--- a/generator/package-lock.json
+++ b/generator/package-lock.json
@@ -8,20 +8,20 @@
       "name": "kikinlex-atproto-generator-lexicons",
       "version": "0.0.0",
       "dependencies": {
-        "@atproto/lex": "0.1.4"
+        "@atproto/lex": "0.1.5"
       }
     },
     "node_modules/@atproto-labs/did-resolver": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@atproto-labs/did-resolver/-/did-resolver-0.3.2.tgz",
-      "integrity": "sha512-FtUZcVqzdAiYhjQtvT3juNP1cUcsweAnnx5mkz22iM7PnVtK3NGCJ478PuoUrL2F+yhgiO+rSHmXuYxuP3+PAg==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@atproto-labs/did-resolver/-/did-resolver-0.3.3.tgz",
+      "integrity": "sha512-AOzZVvBCaMlmRlYDNfAfIVLIvvsHV97z3yajQkjKngt+G+HDMxsKj+RBPmqpSYz6EzI3g+XH+rGIRjXsBEj6cg==",
       "license": "MIT",
       "dependencies": {
-        "@atproto-labs/fetch": "^0.3.1",
-        "@atproto-labs/pipe": "^0.2.1",
-        "@atproto-labs/simple-store": "^0.4.1",
-        "@atproto-labs/simple-store-memory": "^0.2.1",
-        "@atproto/did": "^0.5.1",
+        "@atproto-labs/fetch": "^0.3.2",
+        "@atproto-labs/pipe": "^0.2.2",
+        "@atproto-labs/simple-store": "^0.4.2",
+        "@atproto-labs/simple-store-memory": "^0.2.2",
+        "@atproto/did": "^0.5.2",
         "zod": "^3.23.8"
       },
       "engines": {
@@ -29,42 +29,42 @@
       }
     },
     "node_modules/@atproto-labs/fetch": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@atproto-labs/fetch/-/fetch-0.3.1.tgz",
-      "integrity": "sha512-L8tq4ssUaK/POMGYembdmvMSH0Dg3PiZIeOf3kptSZTYM1gNxqOVIezkqcnapDbsLTiqQ4nWW7yK3jVVjY40YA==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@atproto-labs/fetch/-/fetch-0.3.2.tgz",
+      "integrity": "sha512-NWNQ+MLNEqXpxsfM9mG14eVo0n5z8oWU7yjz/kCROAw5HG+i8a44tQtic90qXw3rBVxFBrrgE4kMftA7jeOiCw==",
       "license": "MIT",
       "dependencies": {
-        "@atproto-labs/pipe": "^0.2.1"
+        "@atproto-labs/pipe": "^0.2.2"
       },
       "engines": {
         "node": ">=22"
       }
     },
     "node_modules/@atproto-labs/pipe": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@atproto-labs/pipe/-/pipe-0.2.1.tgz",
-      "integrity": "sha512-RmRAwru+/IEz50Q78wlZpVD1Ksx8GkBKjW1sLgTS7ym0EagHtLYD9Jbv6MFDjoafiDOILZ8zDEeQ3E5El9Rg+w==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@atproto-labs/pipe/-/pipe-0.2.2.tgz",
+      "integrity": "sha512-4xCUqB96I7WWGRlJvkJeOi8fpkrbB5pwW471hpJefqgb8Ep0UHP1solF3QOK+fms42cTfwkZCx3ExfGk6xeOuA==",
       "license": "MIT",
       "engines": {
         "node": ">=22"
       }
     },
     "node_modules/@atproto-labs/simple-store": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@atproto-labs/simple-store/-/simple-store-0.4.1.tgz",
-      "integrity": "sha512-ShIqvrsRToBX87ePj5hY+t+BuxcP15g1W49MHSBx5VFkspwzU720LNtWVf0Wi6Lk80DMlKtsC2/fvQJTzRJKZA==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@atproto-labs/simple-store/-/simple-store-0.4.2.tgz",
+      "integrity": "sha512-kWF6GCJBWeG+nwakUInainJi2pb4lukQ4ffkpEpLaavZ7ogKSrbsvA7ZFJWGjVsJNVxcamtXeLEl1NpFufs/4g==",
       "license": "MIT",
       "engines": {
         "node": ">=22"
       }
     },
     "node_modules/@atproto-labs/simple-store-memory": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@atproto-labs/simple-store-memory/-/simple-store-memory-0.2.1.tgz",
-      "integrity": "sha512-NOpv+PRHjMFy+k/726mbNUfO3UKl5XlXi+2olJOvmeft1u7byYXCZcIl3m/LxIuK8W0QWG60MQPbuxeNY+9Djg==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@atproto-labs/simple-store-memory/-/simple-store-memory-0.2.2.tgz",
+      "integrity": "sha512-uhEO3j9I09ksdJxYK0B9hl6X5ZUZ+poUBBq6qpulOjbIlzFPhRG/i23ZnzHhQaeT17LQBeP8xvSPk1QzDsblMA==",
       "license": "MIT",
       "dependencies": {
-        "@atproto-labs/simple-store": "^0.4.1",
+        "@atproto-labs/simple-store": "^0.4.2",
         "lru-cache": "^10.2.0"
       },
       "engines": {
@@ -72,30 +72,30 @@
       }
     },
     "node_modules/@atproto/common": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/@atproto/common/-/common-0.6.3.tgz",
-      "integrity": "sha512-ZkJzz1T0LNmzFWPJ2BSqtHMvbHkhakanDhgW0/xj4jw8bz7ZRLHvMdJ8a3qZxmhgGRCVDis4F0NGsuBkBYPL2w==",
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@atproto/common/-/common-0.6.4.tgz",
+      "integrity": "sha512-o1T96pBvjFFWkfYREazjPYp3UqON6ZngZmJturUihMjO6E1R2H5W0M2WlwDOECpSX6qvXShi5b5K+KJyoije2Q==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/common-web": "^0.5.1",
-        "@atproto/lex-cbor": "^0.1.1",
-        "@atproto/lex-data": "^0.1.2",
+        "@atproto/common-web": "^0.5.2",
+        "@atproto/lex-cbor": "^0.1.2",
+        "@atproto/lex-data": "^0.1.3",
         "multiformats": "^13.0.0",
-        "pino": "^8.21.0"
+        "pino": "^10.3.1"
       },
       "engines": {
         "node": ">=22"
       }
     },
     "node_modules/@atproto/common-web": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@atproto/common-web/-/common-web-0.5.1.tgz",
-      "integrity": "sha512-nru02gLyzjMQn4ZFgms9ry3kIAKwMaCAvjeFhB9mU6h1ABiSho7aRDbGvnU50CC88TROXuZlgRiEkBjnuiHEtA==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@atproto/common-web/-/common-web-0.5.2.tgz",
+      "integrity": "sha512-oO0JEvM7MM7iXMngq6V51IJlzBZFhFJoDjnGnQT75EO94/8Q5hnM/LP+a8KyWjcBcpcSZwQ0bukNv9phZONdGA==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/lex-data": "^0.1.2",
-        "@atproto/lex-json": "^0.1.1",
-        "@atproto/syntax": "^0.6.2",
+        "@atproto/lex-data": "^0.1.3",
+        "@atproto/lex-json": "^0.1.2",
+        "@atproto/syntax": "^0.6.3",
         "zod": "^3.23.8"
       },
       "engines": {
@@ -103,9 +103,9 @@
       }
     },
     "node_modules/@atproto/crypto": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@atproto/crypto/-/crypto-0.5.1.tgz",
-      "integrity": "sha512-szFSBYM8l9HGVMQgCvkCUasvsvMmqNlfQca/Pc7E/X36agQzUMw4lhYh7W7O9z+h+flzhS5ThjW0SzHMIItK2A==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@atproto/crypto/-/crypto-0.5.2.tgz",
+      "integrity": "sha512-WU3FN9mx1tnOcbZjH2zJQcvvI5pTyEuHetEhrZSv/a1eL0dJgrDtWfJnht7p9FrpdcDVL/xgAKewzwD5wVYBXQ==",
       "license": "MIT",
       "dependencies": {
         "@noble/curves": "^1.7.0",
@@ -117,9 +117,9 @@
       }
     },
     "node_modules/@atproto/did": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@atproto/did/-/did-0.5.1.tgz",
-      "integrity": "sha512-lGc9JdP8xAOWT35zE3+qH49wvXAdhyDC0KnLFPj+TI7yTsMQBC3jZ8z7zSM97wTBQFTL0xq4XQkpA4k2Uww28w==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@atproto/did/-/did-0.5.2.tgz",
+      "integrity": "sha512-ilVQ1Nrio6EhL61mt7zPgM0Vnb1N2mOisVP32bUBa+PflGI0wRneflacWyVyyN78RdFJDcPQBmv0dfSNgOcbQA==",
       "license": "MIT",
       "dependencies": {
         "zod": "^3.23.8"
@@ -129,17 +129,17 @@
       }
     },
     "node_modules/@atproto/lex": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@atproto/lex/-/lex-0.1.4.tgz",
-      "integrity": "sha512-UM/GDVTAmzSRTcuynJGCjsGlY7i1kdnaqS2lWfwFtGwSMLPjNE2CFi3OYwcv0gCb8Brc51P7m1QvGGJmUUrUTQ==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@atproto/lex/-/lex-0.1.5.tgz",
+      "integrity": "sha512-9jF83rw9Zk/g8bXCBC7+Nx59rg6mIgntSP4mXbhh1oArgSLViBSTAfLp9U5X0KdHoCOvMdOih8+DlknLjx0xPA==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/lex-builder": "^0.1.3",
-        "@atproto/lex-client": "^0.1.4",
-        "@atproto/lex-data": "^0.1.2",
-        "@atproto/lex-installer": "^0.1.1",
-        "@atproto/lex-json": "^0.1.1",
-        "@atproto/lex-schema": "^0.1.4",
+        "@atproto/lex-builder": "^0.1.4",
+        "@atproto/lex-client": "^0.1.5",
+        "@atproto/lex-data": "^0.1.3",
+        "@atproto/lex-installer": "^0.1.2",
+        "@atproto/lex-json": "^0.1.2",
+        "@atproto/lex-schema": "^0.1.5",
         "tslib": "^2.8.1",
         "yargs": "^18.0.0"
       },
@@ -152,13 +152,13 @@
       }
     },
     "node_modules/@atproto/lex-builder": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@atproto/lex-builder/-/lex-builder-0.1.3.tgz",
-      "integrity": "sha512-z/CbP6Kstl6Ivn64vIqEwEICyJxyuYpocWg+gBQCVtHOpvYGE4IoKoTQaZHQYwrLemrjE/vnPaBPsR1DSjzJ7A==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@atproto/lex-builder/-/lex-builder-0.1.4.tgz",
+      "integrity": "sha512-QClKf7tlUmx6HPez6NQGhh1JlGafM3RRYrR13TstL+Vz0HFCdKQ4HgQzF1/Q4ykDIm/PGhHSWw72bI0W3mwOAQ==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/lex-document": "^0.1.1",
-        "@atproto/lex-schema": "^0.1.4",
+        "@atproto/lex-document": "^0.1.2",
+        "@atproto/lex-schema": "^0.1.5",
         "prettier": "^3.2.5",
         "ts-morph": "^27.0.0",
         "tslib": "^2.8.1"
@@ -168,12 +168,12 @@
       }
     },
     "node_modules/@atproto/lex-cbor": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@atproto/lex-cbor/-/lex-cbor-0.1.1.tgz",
-      "integrity": "sha512-VvCytc6HfsRxT8rVtRc+Z6fEIfBn/4guCE50VoJJN7iWPool47v120XtX5zAWTjW1C+8ksoVDN+Bd8P5t3qDvA==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@atproto/lex-cbor/-/lex-cbor-0.1.2.tgz",
+      "integrity": "sha512-Ccs4nnlzjWXGHiMnb9LB8tOJpqoVf8f3pAA6Qx72U2/DuK4agkONn90YUemYY5wHPLdZKpvz6O4/gCGJGXE+MA==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/lex-data": "^0.1.2",
+        "@atproto/lex-data": "^0.1.3",
         "cborg": "^4.5.8",
         "tslib": "^2.8.1"
       },
@@ -182,14 +182,14 @@
       }
     },
     "node_modules/@atproto/lex-client": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@atproto/lex-client/-/lex-client-0.1.4.tgz",
-      "integrity": "sha512-KUG3ofwTBSS3zSqbvyzQ/AzNfp3jBvTJC78JF5CO9TSaTtvhiqGKEEsnvg1Nso8aZQnHOErNEseYcwtstCqFsQ==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@atproto/lex-client/-/lex-client-0.1.5.tgz",
+      "integrity": "sha512-1Ajx/+m3iVaAmgeZedj4d/mYyrazHQ96EU1d8/Vub7zYk0WaNzKGA68Vi0K74f8u340sxKXqYa3O3233xecLNw==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/lex-data": "^0.1.2",
-        "@atproto/lex-json": "^0.1.1",
-        "@atproto/lex-schema": "^0.1.4",
+        "@atproto/lex-data": "^0.1.3",
+        "@atproto/lex-json": "^0.1.2",
+        "@atproto/lex-schema": "^0.1.5",
         "tslib": "^2.8.1"
       },
       "engines": {
@@ -197,9 +197,9 @@
       }
     },
     "node_modules/@atproto/lex-data": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@atproto/lex-data/-/lex-data-0.1.2.tgz",
-      "integrity": "sha512-NZ4iZvNaqTM6pz+9VRDyEjtozrrf2EDHySNi3Xa8PCzS8gRMCvsnnsvM7r264v4eSqNIDhBB8fr9hfWCHMspXg==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@atproto/lex-data/-/lex-data-0.1.3.tgz",
+      "integrity": "sha512-ysqMYW6cIKce52/+EIbTa+I4pLqZQSBP9aGImN88vAQtd1oZBKPmut6dQk00xSQ8PW9REJRuIHNSFAF4HD+fsw==",
       "license": "MIT",
       "dependencies": {
         "multiformats": "^13.0.0",
@@ -212,12 +212,12 @@
       }
     },
     "node_modules/@atproto/lex-document": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@atproto/lex-document/-/lex-document-0.1.1.tgz",
-      "integrity": "sha512-sUv+Dpy7+tQVr1vDQbqEh3SRZOv1kJpJ2SbSb2P/GPDqi8hvN9LZAertTMT8O6Ui8OJKy4vk5vRECXrgn2mkzw==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@atproto/lex-document/-/lex-document-0.1.2.tgz",
+      "integrity": "sha512-UqTxFbgbbE4AzJ6sO/0yJqUgbmBapswnBUKxwIexn+CiWJGMr3OQtbCLYPd+nQ/Ffkmxrwg3ec8lNeJn/hQX4A==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/lex-schema": "^0.1.4",
+        "@atproto/lex-schema": "^0.1.5",
         "core-js": "^3",
         "tslib": "^2.8.1"
       },
@@ -226,18 +226,18 @@
       }
     },
     "node_modules/@atproto/lex-installer": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@atproto/lex-installer/-/lex-installer-0.1.1.tgz",
-      "integrity": "sha512-LRbXv/pPBdKkxc7buvb0nkRaD4PBPVvVckY6SkeoHF9h1snRqJNMCkrxurpaUheAbw+JBxjCxRN1OBELe5xDLw==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@atproto/lex-installer/-/lex-installer-0.1.2.tgz",
+      "integrity": "sha512-2yfEEypSd2ofPg0Xl7cvGA3NtnKAg4cQJpb/DMLZ+s0eDBNqPaRZmMuvHkiCkB5rcOpPBcM6KVVWhNZh9D+OiA==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/lex-builder": "^0.1.3",
-        "@atproto/lex-cbor": "^0.1.1",
-        "@atproto/lex-data": "^0.1.2",
-        "@atproto/lex-document": "^0.1.1",
-        "@atproto/lex-resolver": "^0.1.1",
-        "@atproto/lex-schema": "^0.1.4",
-        "@atproto/syntax": "^0.6.2",
+        "@atproto/lex-builder": "^0.1.4",
+        "@atproto/lex-cbor": "^0.1.2",
+        "@atproto/lex-data": "^0.1.3",
+        "@atproto/lex-document": "^0.1.2",
+        "@atproto/lex-resolver": "^0.1.2",
+        "@atproto/lex-schema": "^0.1.5",
+        "@atproto/syntax": "^0.6.3",
         "tslib": "^2.8.1"
       },
       "engines": {
@@ -245,12 +245,12 @@
       }
     },
     "node_modules/@atproto/lex-json": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@atproto/lex-json/-/lex-json-0.1.1.tgz",
-      "integrity": "sha512-FC/NsKHm8TDzWikvf/268T3mMAh6+f31yfCApWC3SvrhWc9c06cSYPp7qzpXcdV0OdB+I5dqHScuTB5OC7HrXg==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@atproto/lex-json/-/lex-json-0.1.2.tgz",
+      "integrity": "sha512-58nIjoWX0c8T5fcoPPmIaShxKZgfPMhNmrprtR7GuN4PzyMwm59A3CLlKAzzR+vjI3IidEMU+enpLuwUT8L+Nw==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/lex-data": "^0.1.2",
+        "@atproto/lex-data": "^0.1.3",
         "tslib": "^2.8.1"
       },
       "engines": {
@@ -258,19 +258,19 @@
       }
     },
     "node_modules/@atproto/lex-resolver": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@atproto/lex-resolver/-/lex-resolver-0.1.1.tgz",
-      "integrity": "sha512-K/OiH8xMH21siMFxkD5wzb4dhj1Co6Rbok7pCxPhtlDqWKmomNF2WEK20k36VmiN2NrksXfvox7alsx4SernEA==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@atproto/lex-resolver/-/lex-resolver-0.1.2.tgz",
+      "integrity": "sha512-BOy2zvr0pmLUlzSFzFi8wTc5bZlSUkVa98KSUpSqn6D1xP+Qmqpb2eK2jo0gjNOu3+lB8f3WS6lKw0DpUIN/JQ==",
       "license": "MIT",
       "dependencies": {
-        "@atproto-labs/did-resolver": "^0.3.2",
-        "@atproto/crypto": "^0.5.1",
-        "@atproto/lex-client": "^0.1.4",
-        "@atproto/lex-data": "^0.1.2",
-        "@atproto/lex-document": "^0.1.1",
-        "@atproto/lex-schema": "^0.1.4",
-        "@atproto/repo": "^0.10.1",
-        "@atproto/syntax": "^0.6.2",
+        "@atproto-labs/did-resolver": "^0.3.3",
+        "@atproto/crypto": "^0.5.2",
+        "@atproto/lex-client": "^0.1.5",
+        "@atproto/lex-data": "^0.1.3",
+        "@atproto/lex-document": "^0.1.2",
+        "@atproto/lex-schema": "^0.1.5",
+        "@atproto/repo": "^0.10.2",
+        "@atproto/syntax": "^0.6.3",
         "tslib": "^2.8.1"
       },
       "engines": {
@@ -278,13 +278,13 @@
       }
     },
     "node_modules/@atproto/lex-schema": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@atproto/lex-schema/-/lex-schema-0.1.4.tgz",
-      "integrity": "sha512-v3jZjDzDkK2uDhW6oU9WgYylUbCkKehC1sx+cCS/DXQsdMt3B2ousSYuYZ6EvXmVexu94LOPaOEnLwB7bqs92w==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@atproto/lex-schema/-/lex-schema-0.1.5.tgz",
+      "integrity": "sha512-+4lxSYY+F7/JwJXRdqNfU4U+UhiSzfIlretR+R9JT+BHOKEwl7zbJVV+UROiCAmxZMgxqgM6v9Oho0s59Wyovw==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/lex-data": "^0.1.2",
-        "@atproto/syntax": "^0.6.2",
+        "@atproto/lex-data": "^0.1.3",
+        "@atproto/syntax": "^0.6.3",
         "@standard-schema/spec": "^1.1.0",
         "tslib": "^2.8.1"
       },
@@ -293,17 +293,17 @@
       }
     },
     "node_modules/@atproto/repo": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@atproto/repo/-/repo-0.10.1.tgz",
-      "integrity": "sha512-W7ZF8lI/u4se9aovHz60IKOYXSwEE4OPT7ZQYI2e75SXwP23e2WHmvkLqLsQbqDTLffVpOqSJXFwNRtVTGK9yw==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@atproto/repo/-/repo-0.10.2.tgz",
+      "integrity": "sha512-/0RdKIQ5ty93nqGHxzf3naf+kGHPDWMQRutR2TKpOkf+VSyoDLMJK2fOdgtcUFETfT8L6bekGwm7rJxe77RbeA==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/common": "^0.6.3",
-        "@atproto/common-web": "^0.5.1",
-        "@atproto/crypto": "^0.5.1",
-        "@atproto/lex-cbor": "^0.1.1",
-        "@atproto/lex-data": "^0.1.2",
-        "@atproto/syntax": "^0.6.2",
+        "@atproto/common": "^0.6.4",
+        "@atproto/common-web": "^0.5.2",
+        "@atproto/crypto": "^0.5.2",
+        "@atproto/lex-cbor": "^0.1.2",
+        "@atproto/lex-data": "^0.1.3",
+        "@atproto/syntax": "^0.6.3",
         "varint": "^6.0.0",
         "zod": "^3.23.8"
       },
@@ -312,9 +312,9 @@
       }
     },
     "node_modules/@atproto/syntax": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/@atproto/syntax/-/syntax-0.6.2.tgz",
-      "integrity": "sha512-h3njTNFl/jv5kTbDqfamQGOJfGbulqLDuAiLbasKwVdBhFyQanpRLa6vE2WqTwv1XEFWLYNMH0KCVsYwT2+aww==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/@atproto/syntax/-/syntax-0.6.3.tgz",
+      "integrity": "sha512-io7Ck4o+40iFXhetHYoEtok2gZ8cWcJ1yRftEHe5AmAF0dSGcYmclbx5GatVew59taw+eSG7Ty5D3llop/0BhA==",
       "license": "MIT",
       "dependencies": {
         "iso-datestring-validator": "^2.2.2",
@@ -351,6 +351,12 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@pinojs/redact": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
+      "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
+      "license": "MIT"
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -366,18 +372,6 @@
         "minimatch": "^10.0.1",
         "path-browserify": "^1.0.1",
         "tinyglobby": "^0.2.14"
-      }
-    },
-    "node_modules/abort-controller": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "license": "MIT",
-      "dependencies": {
-        "event-target-shim": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=6.5"
       }
     },
     "node_modules/ansi-regex": {
@@ -422,60 +416,16 @@
         "node": "18 || 20 || >=22"
       }
     },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
         "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
       }
     },
     "node_modules/cborg": {
@@ -533,33 +483,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/event-target-shim": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/events": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.x"
-      }
-    },
-    "node_modules/fast-redact": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.5.0.tgz",
-      "integrity": "sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -597,26 +520,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "BSD-3-Clause"
     },
     "node_modules/iso-datestring-validator": {
       "version": "2.2.2",
@@ -679,47 +582,46 @@
       }
     },
     "node_modules/pino": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-8.21.0.tgz",
-      "integrity": "sha512-ip4qdzjkAyDDZklUaZkcRFb2iA118H9SgRh8yzTkSQK8HilsOJF7rSY8HoW5+I0M46AZgX/pxbprf2vvzQCE0Q==",
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-10.3.1.tgz",
+      "integrity": "sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==",
       "license": "MIT",
       "dependencies": {
+        "@pinojs/redact": "^0.4.0",
         "atomic-sleep": "^1.0.0",
-        "fast-redact": "^3.1.1",
         "on-exit-leak-free": "^2.1.0",
-        "pino-abstract-transport": "^1.2.0",
-        "pino-std-serializers": "^6.0.0",
-        "process-warning": "^3.0.0",
+        "pino-abstract-transport": "^3.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
         "quick-format-unescaped": "^4.0.3",
         "real-require": "^0.2.0",
         "safe-stable-stringify": "^2.3.1",
-        "sonic-boom": "^3.7.0",
-        "thread-stream": "^2.6.0"
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^4.0.0"
       },
       "bin": {
         "pino": "bin.js"
       }
     },
     "node_modules/pino-abstract-transport": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.2.0.tgz",
-      "integrity": "sha512-Guhh8EZfPCfH+PMXAb6rKOjGQEoy0xlAIn+irODG5kgfYV+BQ0rGYYWTIel3P5mmyXqkYkPmdIkywsn6QKUR1Q==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-3.0.0.tgz",
+      "integrity": "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==",
       "license": "MIT",
       "dependencies": {
-        "readable-stream": "^4.0.0",
         "split2": "^4.0.0"
       }
     },
     "node_modules/pino-std-serializers": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.2.2.tgz",
-      "integrity": "sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+      "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
       "license": "MIT"
     },
     "node_modules/prettier": {
-      "version": "3.8.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
-      "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
+      "version": "3.9.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.3.tgz",
+      "integrity": "sha512-HWmu+K+zvHNpaMfSnYeqdqrDbR16cuIXaPx8WoHaviQkDJh1/0BNtOZmHVQI5jc3wXv0H1yXc9wjvFdXh+n3hQ==",
       "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"
@@ -731,19 +633,20 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
-    "node_modules/process": {
-      "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6.0"
-      }
-    },
     "node_modules/process-warning": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-3.0.0.tgz",
-      "integrity": "sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
       "license": "MIT"
     },
     "node_modules/quick-format-unescaped": {
@@ -751,22 +654,6 @@
       "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
       "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
       "license": "MIT"
-    },
-    "node_modules/readable-stream": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
-      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
-      "license": "MIT",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10",
-        "string_decoder": "^1.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
     },
     "node_modules/real-require": {
       "version": "0.2.0",
@@ -776,26 +663,6 @@
       "engines": {
         "node": ">= 12.13.0"
       }
-    },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/safe-stable-stringify": {
       "version": "2.5.0",
@@ -807,9 +674,9 @@
       }
     },
     "node_modules/sonic-boom": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.8.1.tgz",
-      "integrity": "sha512-y4Z8LCDBuum+PBP3lSV7RHrXscqksve/bi0as7mhwVnBW+/wUqKT/2Kb7um8yqcFy0duYbbPxzt89Zy2nOCaxg==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+      "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
       "license": "MIT",
       "dependencies": {
         "atomic-sleep": "^1.0.0"
@@ -822,15 +689,6 @@
       "license": "ISC",
       "engines": {
         "node": ">= 10.x"
-      }
-    },
-    "node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-width": {
@@ -866,13 +724,22 @@
       }
     },
     "node_modules/thread-stream": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-2.7.0.tgz",
-      "integrity": "sha512-qQiRWsU/wvNolI6tbbCKd9iKaTnCXsTwVxhhKM6nctPdujTyztjlbUkUTUymidWcMnZ5pWR0ej4a0tjsW021vw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-4.2.0.tgz",
+      "integrity": "sha512-e2zZ96wSChazBsbENf/Pcm/4swHt2cEKQ92rhUjkL9GCKiTDJIaTBenjE/m9DXi0QBmTMDkFDdOomUy20A1tDQ==",
       "license": "MIT",
       "dependencies": {
-        "real-require": "^0.2.0"
+        "real-require": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
+    },
+    "node_modules/thread-stream/node_modules/real-require": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-1.0.0.tgz",
+      "integrity": "sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g==",
+      "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.17",

--- a/generator/package.json
+++ b/generator/package.json
@@ -4,6 +4,6 @@
   "private": true,
   "description": "Pins the @atproto/lex release whose lexicon JSON is consumed by :generator. Not published.",
   "dependencies": {
-    "@atproto/lex": "0.1.4"
+    "@atproto/lex": "0.1.5"
   }
 }


### PR DESCRIPTION
## Lexicon corpus update

Bumps `@atproto/lex` from `0.1.4` to `0.1.5`.

### lexicons.json changes

**Added** (0):
- _(none)_

**Removed** (0):
- _(none)_

**Updated** (0):
- _(none)_

### What reviewers should check

- [ ] CI passes (generator regeneration, runtime tests, sample APK build)
- [ ] Skim the generator golden-file diff if any generator logic was affected
- [ ] Verify no new lexicon references are missing Kotlin types (compile failure in `:models`)

### Release impact

If this PR merges with only additive changes (new types, new fields), expect a `feat:` release. If it removes or renames anything, expect a `BREAKING CHANGE:` release — update the PR title to `feat!: bump @atproto/lex to <version>` before merging.