### PR TITLE
feat(models): add chat.bsky.convo message replies via overlays

### DIFF
--- a/generator/overlay-lexicons.json
+++ b/generator/overlay-lexicons.json
@@ -48,6 +48,30 @@
       "vendoredAt": "2026-06-25",
       "reason": "PINNED shadow (removeWhenPublished=false). Already published on-network; vendored only to add app.bsky.embed.gallery#view to the postView embed union ahead of the network. RE-VENDOR on drift; retire MANUALLY once the on-network copy includes gallery#view.",
       "removeWhenPublished": false
+    },
+    {
+      "nsid": "chat.bsky.convo.defs",
+      "source": "https://github.com/bluesky-social/atproto/blob/4f1e20387bb2a212e263590ac7a3458e8f939091/lexicons/chat/bsky/convo/defs.json",
+      "commit": "4f1e20387bb2a212e263590ac7a3458e8f939091",
+      "vendoredAt": "2026-07-01",
+      "reason": "PINNED shadow (removeWhenPublished=false). Already published on-network; vendored to add message replies (messageInput/messageView.replyTo, #replyRef, #messageBeforeUserJoinedGroupView) ahead of the network. RE-VENDOR on drift; retire MANUALLY once the on-network convo.defs includes replyTo.",
+      "removeWhenPublished": false
+    },
+    {
+      "nsid": "chat.bsky.convo.sendMessage",
+      "source": "https://github.com/bluesky-social/atproto/blob/4f1e20387bb2a212e263590ac7a3458e8f939091/lexicons/chat/bsky/convo/sendMessage.json",
+      "commit": "4f1e20387bb2a212e263590ac7a3458e8f939091",
+      "vendoredAt": "2026-07-01",
+      "reason": "PINNED shadow (removeWhenPublished=false). Already published on-network; vendored for the ReplyTargetNotFound error that pairs with messageInput.replyTo (see chat.bsky.convo.defs). RE-VENDOR on drift; retire MANUALLY once the on-network sendMessage includes it.",
+      "removeWhenPublished": false
+    },
+    {
+      "nsid": "chat.bsky.convo.sendMessageBatch",
+      "source": "https://github.com/bluesky-social/atproto/blob/4f1e20387bb2a212e263590ac7a3458e8f939091/lexicons/chat/bsky/convo/sendMessageBatch.json",
+      "commit": "4f1e20387bb2a212e263590ac7a3458e8f939091",
+      "vendoredAt": "2026-07-01",
+      "reason": "PINNED shadow (removeWhenPublished=false). Already published on-network; vendored for the ReplyTargetNotFound error that pairs with the batch reply input. RE-VENDOR on drift; retire MANUALLY once the on-network sendMessageBatch includes it.",
+      "removeWhenPublished": false
     }
   ]
 }

--- a/generator/overlay-lexicons/chat/bsky/convo/defs.json
+++ b/generator/overlay-lexicons/chat/bsky/convo/defs.json
@@ -1,0 +1,1104 @@
+{
+  "id": "chat.bsky.convo.defs",
+  "defs": {
+    "convoKind": {
+      "type": "string",
+      "knownValues": [
+        "direct",
+        "group"
+      ]
+    },
+    "convoView": {
+      "type": "object",
+      "required": [
+        "id",
+        "rev",
+        "members",
+        "muted",
+        "unreadCount"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "rev": {
+          "type": "string"
+        },
+        "kind": {
+          "refs": [
+            "#directConvo",
+            "#groupConvo"
+          ],
+          "type": "union",
+          "description": "Union field that has data specific to different kinds of convos."
+        },
+        "muted": {
+          "type": "boolean"
+        },
+        "status": {
+          "ref": "#convoStatus",
+          "type": "ref",
+          "description": "Convo status for the viewer member (not the convo itself)."
+        },
+        "members": {
+          "type": "array",
+          "items": {
+            "ref": "chat.bsky.actor.defs#profileViewBasic",
+            "type": "ref"
+          },
+          "description": "Members of this conversation. For direct convos, it will be an immutable list of the 2 members. For group convos, it will a list of important members (the first few members, the viewer, the member who invited the viewer, the member who sent the last message, the member who sent the last reaction), but will not contain the full list of members. NOTE: TBD an endpoint to list all members."
+        },
+        "lastMessage": {
+          "refs": [
+            "#messageView",
+            "#deletedMessageView",
+            "#systemMessageView"
+          ],
+          "type": "union"
+        },
+        "unreadCount": {
+          "type": "integer"
+        },
+        "lastReaction": {
+          "refs": [
+            "#messageAndReactionView"
+          ],
+          "type": "union"
+        }
+      }
+    },
+    "groupConvo": {
+      "type": "object",
+      "required": [
+        "name",
+        "lockStatus"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "maxLength": 1280,
+          "description": "The display name of the group conversation.",
+          "maxGraphemes": 128
+        },
+        "joinLink": {
+          "ref": "chat.bsky.group.defs#joinLinkView",
+          "type": "ref"
+        },
+        "lockStatus": {
+          "ref": "#convoLockStatus",
+          "type": "ref",
+          "description": "The lock status of the conversation."
+        }
+      },
+      "description": "[NOTE: This is under active development and should be considered unstable while this note is here]."
+    },
+    "messageRef": {
+      "type": "object",
+      "required": [
+        "did",
+        "messageId",
+        "convoId"
+      ],
+      "properties": {
+        "did": {
+          "type": "string",
+          "format": "did"
+        },
+        "convoId": {
+          "type": "string"
+        },
+        "messageId": {
+          "type": "string"
+        }
+      }
+    },
+    "convoStatus": {
+      "type": "string",
+      "knownValues": [
+        "request",
+        "accepted"
+      ]
+    },
+    "directConvo": {
+      "type": "object",
+      "properties": {},
+      "description": "[NOTE: This is under active development and should be considered unstable while this note is here]."
+    },
+    "messageView": {
+      "type": "object",
+      "required": [
+        "id",
+        "rev",
+        "text",
+        "sender",
+        "sentAt"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "rev": {
+          "type": "string"
+        },
+        "text": {
+          "type": "string",
+          "maxLength": 10000,
+          "maxGraphemes": 1000
+        },
+        "embed": {
+          "refs": [
+            "app.bsky.embed.record#view"
+          ],
+          "type": "union"
+        },
+        "facets": {
+          "type": "array",
+          "items": {
+            "ref": "app.bsky.richtext.facet",
+            "type": "ref"
+          },
+          "description": "Annotations of text (mentions, URLs, hashtags, etc)"
+        },
+        "sender": {
+          "ref": "#messageViewSender",
+          "type": "ref"
+        },
+        "sentAt": {
+          "type": "string",
+          "format": "datetime"
+        },
+        "reactions": {
+          "type": "array",
+          "items": {
+            "ref": "#reactionView",
+            "type": "ref"
+          },
+          "description": "Reactions to this message, in ascending order of creation time."
+        },
+        "replyTo": {
+          "description": "If set, the message this message is replying to. The full view of the referenced message is embedded so the client can render it inline. Only a single level is embedded: the embedded message will not itself have a populated 'replyTo' field even if it was also a reply.",
+          "type": "union",
+          "refs": [
+            "#messageView",
+            "#deletedMessageView",
+            "#messageBeforeUserJoinedGroupView"
+          ]
+        }
+      }
+    },
+    "logAddMember": {
+      "type": "object",
+      "required": [
+        "rev",
+        "convoId",
+        "message"
+      ],
+      "properties": {
+        "rev": {
+          "type": "string"
+        },
+        "convoId": {
+          "type": "string"
+        },
+        "message": {
+          "ref": "#systemMessageDataAddMember",
+          "type": "ref"
+        }
+      },
+      "description": "[NOTE: This is under active development and should be considered unstable while this note is here]. Event indicating a member was added to a group convo. The member who was added gets a logBeginConvo (to create the convo) but also a logAddMember (to show the system message as the first message the user sees)."
+    },
+    "logEditGroup": {
+      "type": "object",
+      "required": [
+        "rev",
+        "convoId",
+        "message"
+      ],
+      "properties": {
+        "rev": {
+          "type": "string"
+        },
+        "convoId": {
+          "type": "string"
+        },
+        "message": {
+          "ref": "#systemMessageDataEditGroup",
+          "type": "ref"
+        }
+      },
+      "description": "[NOTE: This is under active development and should be considered unstable while this note is here]. Event indicating info about group convo was edited."
+    },
+    "logLockConvo": {
+      "type": "object",
+      "required": [
+        "rev",
+        "convoId",
+        "message"
+      ],
+      "properties": {
+        "rev": {
+          "type": "string"
+        },
+        "convoId": {
+          "type": "string"
+        },
+        "message": {
+          "ref": "#systemMessageDataLockConvo",
+          "type": "ref"
+        }
+      },
+      "description": "[NOTE: This is under active development and should be considered unstable while this note is here]. Event indicating a group convo was locked."
+    },
+    "logMuteConvo": {
+      "type": "object",
+      "required": [
+        "rev",
+        "convoId"
+      ],
+      "properties": {
+        "rev": {
+          "type": "string"
+        },
+        "convoId": {
+          "type": "string"
+        }
+      },
+      "description": "Event indicating the viewer muted a convo. Can be direct or group."
+    },
+    "logReadConvo": {
+      "type": "object",
+      "required": [
+        "rev",
+        "convoId",
+        "message"
+      ],
+      "properties": {
+        "rev": {
+          "type": "string"
+        },
+        "convoId": {
+          "type": "string"
+        },
+        "message": {
+          "refs": [
+            "#messageView",
+            "#deletedMessageView",
+            "#systemMessageView"
+          ],
+          "type": "union"
+        }
+      },
+      "description": "[NOTE: This is under active development and should be considered unstable while this note is here]. Event indicating a convo was read up to a certain message."
+    },
+    "messageInput": {
+      "type": "object",
+      "required": [
+        "text"
+      ],
+      "properties": {
+        "text": {
+          "type": "string",
+          "maxLength": 10000,
+          "maxGraphemes": 1000
+        },
+        "embed": {
+          "refs": [
+            "app.bsky.embed.record"
+          ],
+          "type": "union"
+        },
+        "facets": {
+          "type": "array",
+          "items": {
+            "ref": "app.bsky.richtext.facet",
+            "type": "ref"
+          },
+          "description": "Annotations of text (mentions, URLs, hashtags, etc)"
+        },
+        "replyTo": {
+          "description": "If set, the message this message is replying to. The referenced message must be in the same convo.",
+          "type": "ref",
+          "ref": "#replyRef"
+        }
+      }
+    },
+    "reactionView": {
+      "type": "object",
+      "required": [
+        "value",
+        "sender",
+        "createdAt"
+      ],
+      "properties": {
+        "value": {
+          "type": "string"
+        },
+        "sender": {
+          "ref": "#reactionViewSender",
+          "type": "ref"
+        },
+        "createdAt": {
+          "type": "string",
+          "format": "datetime"
+        }
+      }
+    },
+    "logBeginConvo": {
+      "type": "object",
+      "required": [
+        "rev",
+        "convoId"
+      ],
+      "properties": {
+        "rev": {
+          "type": "string"
+        },
+        "convoId": {
+          "type": "string"
+        }
+      },
+      "description": "Event indicating a convo containing the viewer was started. Can be direct or group. When a member is added to a group convo, they also get this event."
+    },
+    "logLeaveConvo": {
+      "type": "object",
+      "required": [
+        "rev",
+        "convoId"
+      ],
+      "properties": {
+        "rev": {
+          "type": "string"
+        },
+        "convoId": {
+          "type": "string"
+        }
+      },
+      "description": "Event indicating the viewer left a convo. Can be direct or group."
+    },
+    "logMemberJoin": {
+      "type": "object",
+      "required": [
+        "rev",
+        "convoId",
+        "message"
+      ],
+      "properties": {
+        "rev": {
+          "type": "string"
+        },
+        "convoId": {
+          "type": "string"
+        },
+        "message": {
+          "ref": "#systemMessageDataMemberJoin",
+          "type": "ref"
+        }
+      },
+      "description": "[NOTE: This is under active development and should be considered unstable while this note is here]. Event indicating a member joined a group convo via join link. The member who was added gets a logBeginConvo (to create the convo) but also a logMemberJoin (to show the system message as the first message the user sees)."
+    },
+    "logAcceptConvo": {
+      "type": "object",
+      "required": [
+        "rev",
+        "convoId"
+      ],
+      "properties": {
+        "rev": {
+          "type": "string"
+        },
+        "convoId": {
+          "type": "string"
+        }
+      },
+      "description": "Event indicating the viewer accepted a convo, and it can be moved out of the request inbox. Can be direct or group."
+    },
+    "logAddReaction": {
+      "type": "object",
+      "required": [
+        "rev",
+        "convoId",
+        "message",
+        "reaction"
+      ],
+      "properties": {
+        "rev": {
+          "type": "string"
+        },
+        "convoId": {
+          "type": "string"
+        },
+        "message": {
+          "refs": [
+            "#messageView",
+            "#deletedMessageView"
+          ],
+          "type": "union"
+        },
+        "reaction": {
+          "ref": "#reactionView",
+          "type": "ref"
+        }
+      },
+      "description": "Event indicating a reaction was added to a message."
+    },
+    "logMemberLeave": {
+      "type": "object",
+      "required": [
+        "rev",
+        "convoId",
+        "message"
+      ],
+      "properties": {
+        "rev": {
+          "type": "string"
+        },
+        "convoId": {
+          "type": "string"
+        },
+        "message": {
+          "ref": "#systemMessageDataMemberLeave",
+          "type": "ref"
+        }
+      },
+      "description": "[NOTE: This is under active development and should be considered unstable while this note is here]. Event indicating a member voluntarily left a group convo. The member who was removed gets a logLeaveConvo (to leave the convo) but not a logMemberLeave (because they already left, so can't see the system message)."
+    },
+    "logReadMessage": {
+      "type": "object",
+      "required": [
+        "rev",
+        "convoId",
+        "message"
+      ],
+      "properties": {
+        "rev": {
+          "type": "string"
+        },
+        "convoId": {
+          "type": "string"
+        },
+        "message": {
+          "refs": [
+            "#messageView",
+            "#deletedMessageView",
+            "#systemMessageView"
+          ],
+          "type": "union"
+        }
+      },
+      "description": "DEPRECATED: use logReadConvo instead. Event indicating a convo was read up to a certain message."
+    },
+    "logUnlockConvo": {
+      "type": "object",
+      "required": [
+        "rev",
+        "convoId",
+        "message"
+      ],
+      "properties": {
+        "rev": {
+          "type": "string"
+        },
+        "convoId": {
+          "type": "string"
+        },
+        "message": {
+          "ref": "#systemMessageDataUnlockConvo",
+          "type": "ref"
+        }
+      },
+      "description": "[NOTE: This is under active development and should be considered unstable while this note is here]. Event indicating a group convo was unlocked."
+    },
+    "logUnmuteConvo": {
+      "type": "object",
+      "required": [
+        "rev",
+        "convoId"
+      ],
+      "properties": {
+        "rev": {
+          "type": "string"
+        },
+        "convoId": {
+          "type": "string"
+        }
+      },
+      "description": "Event indicating the viewer unmuted a convo. Can be direct or group."
+    },
+    "convoLockStatus": {
+      "type": "string",
+      "knownValues": [
+        "unlocked",
+        "locked",
+        "locked-permanently"
+      ]
+    },
+    "logEditJoinLink": {
+      "type": "object",
+      "required": [
+        "rev",
+        "convoId",
+        "message"
+      ],
+      "properties": {
+        "rev": {
+          "type": "string"
+        },
+        "convoId": {
+          "type": "string"
+        },
+        "message": {
+          "ref": "#systemMessageDataEditJoinLink",
+          "type": "ref"
+        }
+      },
+      "description": "[NOTE: This is under active development and should be considered unstable while this note is here]. Event indicating a settings about a join link for a group convo were edited."
+    },
+    "logRemoveMember": {
+      "type": "object",
+      "required": [
+        "rev",
+        "convoId",
+        "message"
+      ],
+      "properties": {
+        "rev": {
+          "type": "string"
+        },
+        "convoId": {
+          "type": "string"
+        },
+        "message": {
+          "ref": "#systemMessageDataRemoveMember",
+          "type": "ref"
+        }
+      },
+      "description": "[NOTE: This is under active development and should be considered unstable while this note is here]. Event indicating a member was removed from a group convo. The member who was removed gets a logLeaveConvo (to leave the convo) but not a logRemoveMember (because they already left, so can't see the system message)."
+    },
+    "logCreateMessage": {
+      "type": "object",
+      "required": [
+        "rev",
+        "convoId",
+        "message"
+      ],
+      "properties": {
+        "rev": {
+          "type": "string"
+        },
+        "convoId": {
+          "type": "string"
+        },
+        "message": {
+          "refs": [
+            "#messageView",
+            "#deletedMessageView"
+          ],
+          "type": "union"
+        }
+      },
+      "description": "Event indicating a user-originated message was created. Is not emitted for system messages."
+    },
+    "logDeleteMessage": {
+      "type": "object",
+      "required": [
+        "rev",
+        "convoId",
+        "message"
+      ],
+      "properties": {
+        "rev": {
+          "type": "string"
+        },
+        "convoId": {
+          "type": "string"
+        },
+        "message": {
+          "refs": [
+            "#messageView",
+            "#deletedMessageView"
+          ],
+          "type": "union"
+        }
+      },
+      "description": "Event indicating a user-originated message was deleted. Is not emitted for system messages."
+    },
+    "logCreateJoinLink": {
+      "type": "object",
+      "required": [
+        "rev",
+        "convoId",
+        "message"
+      ],
+      "properties": {
+        "rev": {
+          "type": "string"
+        },
+        "convoId": {
+          "type": "string"
+        },
+        "message": {
+          "ref": "#systemMessageDataCreateJoinLink",
+          "type": "ref"
+        }
+      },
+      "description": "[NOTE: This is under active development and should be considered unstable while this note is here]. Event indicating a join link was created for a group convo."
+    },
+    "logEnableJoinLink": {
+      "type": "object",
+      "required": [
+        "rev",
+        "convoId",
+        "message"
+      ],
+      "properties": {
+        "rev": {
+          "type": "string"
+        },
+        "convoId": {
+          "type": "string"
+        },
+        "message": {
+          "ref": "#systemMessageDataEnableJoinLink",
+          "type": "ref"
+        }
+      },
+      "description": "[NOTE: This is under active development and should be considered unstable while this note is here]. Event indicating a join link was enabled for a group convo."
+    },
+    "logRemoveReaction": {
+      "type": "object",
+      "required": [
+        "rev",
+        "convoId",
+        "message",
+        "reaction"
+      ],
+      "properties": {
+        "rev": {
+          "type": "string"
+        },
+        "convoId": {
+          "type": "string"
+        },
+        "message": {
+          "refs": [
+            "#messageView",
+            "#deletedMessageView"
+          ],
+          "type": "union"
+        },
+        "reaction": {
+          "ref": "#reactionView",
+          "type": "ref"
+        }
+      },
+      "description": "Event indicating a reaction was removed from a message."
+    },
+    "messageViewSender": {
+      "type": "object",
+      "required": [
+        "did"
+      ],
+      "properties": {
+        "did": {
+          "type": "string",
+          "format": "did"
+        }
+      }
+    },
+    "systemMessageView": {
+      "type": "object",
+      "required": [
+        "id",
+        "rev",
+        "sentAt",
+        "data"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "rev": {
+          "type": "string"
+        },
+        "data": {
+          "refs": [
+            "#systemMessageDataAddMember",
+            "#systemMessageDataRemoveMember",
+            "#systemMessageDataMemberJoin",
+            "#systemMessageDataMemberLeave",
+            "#systemMessageDataLockConvo",
+            "#systemMessageDataUnlockConvo",
+            "#systemMessageDataLockConvoPermanently",
+            "#systemMessageDataEditGroup",
+            "#systemMessageDataCreateJoinLink",
+            "#systemMessageDataEditJoinLink",
+            "#systemMessageDataEnableJoinLink",
+            "#systemMessageDataDisableJoinLink"
+          ],
+          "type": "union"
+        },
+        "sentAt": {
+          "type": "string",
+          "format": "datetime"
+        }
+      },
+      "description": "[NOTE: This is under active development and should be considered unstable while this note is here]."
+    },
+    "deletedMessageView": {
+      "type": "object",
+      "required": [
+        "id",
+        "rev",
+        "sender",
+        "sentAt"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "rev": {
+          "type": "string"
+        },
+        "sender": {
+          "ref": "#messageViewSender",
+          "type": "ref"
+        },
+        "sentAt": {
+          "type": "string",
+          "format": "datetime"
+        }
+      }
+    },
+    "logDisableJoinLink": {
+      "type": "object",
+      "required": [
+        "rev",
+        "convoId",
+        "message"
+      ],
+      "properties": {
+        "rev": {
+          "type": "string"
+        },
+        "convoId": {
+          "type": "string"
+        },
+        "message": {
+          "ref": "#systemMessageDataDisableJoinLink",
+          "type": "ref"
+        }
+      },
+      "description": "[NOTE: This is under active development and should be considered unstable while this note is here]. Event indicating a join link was disabled for a group convo."
+    },
+    "reactionViewSender": {
+      "type": "object",
+      "required": [
+        "did"
+      ],
+      "properties": {
+        "did": {
+          "type": "string",
+          "format": "did"
+        }
+      }
+    },
+    "logRejectJoinRequest": {
+      "type": "object",
+      "required": [
+        "rev",
+        "convoId",
+        "member"
+      ],
+      "properties": {
+        "rev": {
+          "type": "string"
+        },
+        "member": {
+          "ref": "chat.bsky.actor.defs#profileViewBasic",
+          "type": "ref",
+          "description": "Prospective member who requested to join."
+        },
+        "convoId": {
+          "type": "string"
+        }
+      },
+      "description": "[NOTE: This is under active development and should be considered unstable while this note is here]. Event indicating a join request was rejected by the viewer. Only the owner gets this."
+    },
+    "logApproveJoinRequest": {
+      "type": "object",
+      "required": [
+        "rev",
+        "convoId",
+        "member"
+      ],
+      "properties": {
+        "rev": {
+          "type": "string"
+        },
+        "member": {
+          "ref": "chat.bsky.actor.defs#profileViewBasic",
+          "type": "ref",
+          "description": "Prospective member who requested to join."
+        },
+        "convoId": {
+          "type": "string"
+        }
+      },
+      "description": "[NOTE: This is under active development and should be considered unstable while this note is here]. Event indicating a join request was approved by the viewer. Only the owner gets this. The approved member gets a logBeginConvo."
+    },
+    "logIncomingJoinRequest": {
+      "type": "object",
+      "required": [
+        "rev",
+        "convoId",
+        "member"
+      ],
+      "properties": {
+        "rev": {
+          "type": "string"
+        },
+        "member": {
+          "ref": "chat.bsky.actor.defs#profileViewBasic",
+          "type": "ref",
+          "description": "Prospective member who requested to join."
+        },
+        "convoId": {
+          "type": "string"
+        }
+      },
+      "description": "[NOTE: This is under active development and should be considered unstable while this note is here]. Event indicating a join request was made to a group the viewer owns. Only the owner gets this."
+    },
+    "logOutgoingJoinRequest": {
+      "type": "object",
+      "required": [
+        "rev",
+        "convoId"
+      ],
+      "properties": {
+        "rev": {
+          "type": "string"
+        },
+        "convoId": {
+          "type": "string"
+        }
+      },
+      "description": "[NOTE: This is under active development and should be considered unstable while this note is here]. Event indicating a join request was made by the viewer."
+    },
+    "messageAndReactionView": {
+      "type": "object",
+      "required": [
+        "message",
+        "reaction"
+      ],
+      "properties": {
+        "message": {
+          "ref": "#messageView",
+          "type": "ref"
+        },
+        "reaction": {
+          "ref": "#reactionView",
+          "type": "ref"
+        }
+      }
+    },
+    "logLockConvoPermanently": {
+      "type": "object",
+      "required": [
+        "rev",
+        "convoId",
+        "message"
+      ],
+      "properties": {
+        "rev": {
+          "type": "string"
+        },
+        "convoId": {
+          "type": "string"
+        },
+        "message": {
+          "ref": "#systemMessageDataLockConvoPermanently",
+          "type": "ref"
+        }
+      },
+      "description": "[NOTE: This is under active development and should be considered unstable while this note is here]. Event indicating a group convo was locked permanently."
+    },
+    "systemMessageDataAddMember": {
+      "type": "object",
+      "required": [
+        "member",
+        "role",
+        "addedBy"
+      ],
+      "properties": {
+        "role": {
+          "ref": "chat.bsky.actor.defs#memberRole",
+          "type": "ref",
+          "description": "Role the user was added to the group with. The role from 'member' will reflect the current data, not historical."
+        },
+        "member": {
+          "ref": "chat.bsky.actor.defs#profileViewBasic",
+          "type": "ref",
+          "description": "Current view of the member who was added."
+        },
+        "addedBy": {
+          "ref": "chat.bsky.actor.defs#profileViewBasic",
+          "type": "ref"
+        }
+      },
+      "description": "[NOTE: This is under active development and should be considered unstable while this note is here]. System message indicating a user was added to the group convo."
+    },
+    "systemMessageDataEditGroup": {
+      "type": "object",
+      "properties": {
+        "newName": {
+          "type": "string",
+          "description": "Group name that replaced the old."
+        },
+        "oldName": {
+          "type": "string",
+          "description": "Group name that was replaced."
+        }
+      },
+      "description": "[NOTE: This is under active development and should be considered unstable while this note is here]. System message indicating the group info was edited."
+    },
+    "systemMessageDataLockConvo": {
+      "type": "object",
+      "required": [
+        "lockedBy"
+      ],
+      "properties": {
+        "lockedBy": {
+          "ref": "chat.bsky.actor.defs#profileViewBasic",
+          "type": "ref",
+          "description": "Current view of the member who locked the group."
+        }
+      },
+      "description": "[NOTE: This is under active development and should be considered unstable while this note is here]. System message indicating the group convo was locked."
+    },
+    "systemMessageDataMemberJoin": {
+      "type": "object",
+      "required": [
+        "member",
+        "role"
+      ],
+      "properties": {
+        "role": {
+          "ref": "chat.bsky.actor.defs#memberRole",
+          "type": "ref",
+          "description": "Role the user was added to the group with. The role from 'member' will reflect the current data, not historical."
+        },
+        "member": {
+          "ref": "chat.bsky.actor.defs#profileViewBasic",
+          "type": "ref",
+          "description": "Current view of the member who joined."
+        },
+        "approvedBy": {
+          "ref": "chat.bsky.actor.defs#profileViewBasic",
+          "type": "ref",
+          "description": "If join link was configured to require approval, this will be set to who approved the request. Undefined if approval was not required."
+        }
+      },
+      "description": "[NOTE: This is under active development and should be considered unstable while this note is here]. System message indicating a user joined the group convo via join link."
+    },
+    "systemMessageDataMemberLeave": {
+      "type": "object",
+      "required": [
+        "member"
+      ],
+      "properties": {
+        "member": {
+          "ref": "chat.bsky.actor.defs#profileViewBasic",
+          "type": "ref",
+          "description": "Current view of the member who left the group."
+        }
+      },
+      "description": "[NOTE: This is under active development and should be considered unstable while this note is here]. System message indicating a user voluntarily left the group convo."
+    },
+    "systemMessageDataUnlockConvo": {
+      "type": "object",
+      "required": [
+        "unlockedBy"
+      ],
+      "properties": {
+        "unlockedBy": {
+          "ref": "chat.bsky.actor.defs#profileViewBasic",
+          "type": "ref",
+          "description": "Current view of the member who unlocked the group."
+        }
+      },
+      "description": "[NOTE: This is under active development and should be considered unstable while this note is here]. System message indicating the group convo was unlocked."
+    },
+    "systemMessageDataEditJoinLink": {
+      "type": "object",
+      "properties": {},
+      "description": "[NOTE: This is under active development and should be considered unstable while this note is here]. System message indicating the group join link was edited."
+    },
+    "systemMessageDataRemoveMember": {
+      "type": "object",
+      "required": [
+        "member",
+        "removedBy"
+      ],
+      "properties": {
+        "member": {
+          "ref": "chat.bsky.actor.defs#profileViewBasic",
+          "type": "ref",
+          "description": "Current view of the member who was removed."
+        },
+        "removedBy": {
+          "ref": "chat.bsky.actor.defs#profileViewBasic",
+          "type": "ref"
+        }
+      },
+      "description": "[NOTE: This is under active development and should be considered unstable while this note is here]. System message indicating a user was removed from the group convo."
+    },
+    "systemMessageDataCreateJoinLink": {
+      "type": "object",
+      "properties": {},
+      "description": "[NOTE: This is under active development and should be considered unstable while this note is here]. System message indicating the group join link was created."
+    },
+    "systemMessageDataEnableJoinLink": {
+      "type": "object",
+      "properties": {},
+      "description": "[NOTE: This is under active development and should be considered unstable while this note is here]. System message indicating the group join link was enabled."
+    },
+    "systemMessageDataDisableJoinLink": {
+      "type": "object",
+      "properties": {},
+      "description": "[NOTE: This is under active development and should be considered unstable while this note is here]. System message indicating the group join link was disabled."
+    },
+    "systemMessageDataLockConvoPermanently": {
+      "type": "object",
+      "required": [
+        "lockedBy"
+      ],
+      "properties": {
+        "lockedBy": {
+          "ref": "chat.bsky.actor.defs#profileViewBasic",
+          "type": "ref",
+          "description": "Current view of the member who locked the group."
+        }
+      },
+      "description": "[NOTE: This is under active development and should be considered unstable while this note is here]. System message indicating the group convo was locked permanently."
+    },
+    "replyRef": {
+      "description": "A reference to another message within the same convo, used to indicate that a message is a reply to it.",
+      "type": "object",
+      "required": [
+        "messageId"
+      ],
+      "properties": {
+        "messageId": {
+          "type": "string"
+        }
+      }
+    },
+    "messageBeforeUserJoinedGroupView": {
+      "description": "Placeholder embedded in place of a reply's parent message when that parent was sent before the viewer joined the group convo. The viewer has no access to that history, so no message data is carried.",
+      "type": "object",
+      "properties": {}
+    }
+  },
+  "$type": "com.atproto.lexicon.schema",
+  "lexicon": 1
+}

--- a/generator/overlay-lexicons/chat/bsky/convo/sendMessage.json
+++ b/generator/overlay-lexicons/chat/bsky/convo/sendMessage.json
@@ -1,0 +1,48 @@
+{
+  "id": "chat.bsky.convo.sendMessage",
+  "defs": {
+    "main": {
+      "type": "procedure",
+      "input": {
+        "schema": {
+          "type": "object",
+          "required": [
+            "convoId",
+            "message"
+          ],
+          "properties": {
+            "convoId": {
+              "type": "string"
+            },
+            "message": {
+              "ref": "chat.bsky.convo.defs#messageInput",
+              "type": "ref"
+            }
+          }
+        },
+        "encoding": "application/json"
+      },
+      "errors": [
+        {
+          "name": "ConvoLocked"
+        },
+        {
+          "name": "InvalidConvo"
+        },
+        {
+          "name": "ReplyTargetNotFound"
+        }
+      ],
+      "output": {
+        "schema": {
+          "ref": "chat.bsky.convo.defs#messageView",
+          "type": "ref"
+        },
+        "encoding": "application/json"
+      },
+      "description": "Sends a message to a conversation."
+    }
+  },
+  "$type": "com.atproto.lexicon.schema",
+  "lexicon": 1
+}

--- a/generator/overlay-lexicons/chat/bsky/convo/sendMessageBatch.json
+++ b/generator/overlay-lexicons/chat/bsky/convo/sendMessageBatch.json
@@ -1,0 +1,75 @@
+{
+  "id": "chat.bsky.convo.sendMessageBatch",
+  "defs": {
+    "main": {
+      "type": "procedure",
+      "input": {
+        "schema": {
+          "type": "object",
+          "required": [
+            "items"
+          ],
+          "properties": {
+            "items": {
+              "type": "array",
+              "items": {
+                "ref": "#batchItem",
+                "type": "ref"
+              },
+              "maxLength": 100
+            }
+          }
+        },
+        "encoding": "application/json"
+      },
+      "errors": [
+        {
+          "name": "ConvoLocked"
+        },
+        {
+          "name": "InvalidConvo"
+        },
+        {
+          "name": "ReplyTargetNotFound"
+        }
+      ],
+      "output": {
+        "schema": {
+          "type": "object",
+          "required": [
+            "items"
+          ],
+          "properties": {
+            "items": {
+              "type": "array",
+              "items": {
+                "ref": "chat.bsky.convo.defs#messageView",
+                "type": "ref"
+              }
+            }
+          }
+        },
+        "encoding": "application/json"
+      },
+      "description": "Sends a batch of messages to a conversation."
+    },
+    "batchItem": {
+      "type": "object",
+      "required": [
+        "convoId",
+        "message"
+      ],
+      "properties": {
+        "convoId": {
+          "type": "string"
+        },
+        "message": {
+          "ref": "chat.bsky.convo.defs#messageInput",
+          "type": "ref"
+        }
+      }
+    }
+  },
+  "$type": "com.atproto.lexicon.schema",
+  "lexicon": 1
+}

--- a/models/api/models.api
+++ b/models/api/models.api
@@ -10747,7 +10747,7 @@ public final class io/github/kikin81/atproto/chat/bsky/convo/DeleteMessageForSel
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class io/github/kikin81/atproto/chat/bsky/convo/DeletedMessageView : io/github/kikin81/atproto/chat/bsky/convo/ConvoViewLastMessageUnion, io/github/kikin81/atproto/chat/bsky/convo/GetMessagesResponseMessagesUnion, io/github/kikin81/atproto/chat/bsky/convo/LogAddReactionMessageUnion, io/github/kikin81/atproto/chat/bsky/convo/LogCreateMessageMessageUnion, io/github/kikin81/atproto/chat/bsky/convo/LogDeleteMessageMessageUnion, io/github/kikin81/atproto/chat/bsky/convo/LogReadConvoMessageUnion, io/github/kikin81/atproto/chat/bsky/convo/LogReadMessageMessageUnion, io/github/kikin81/atproto/chat/bsky/convo/LogRemoveReactionMessageUnion {
+public final class io/github/kikin81/atproto/chat/bsky/convo/DeletedMessageView : io/github/kikin81/atproto/chat/bsky/convo/ConvoViewLastMessageUnion, io/github/kikin81/atproto/chat/bsky/convo/GetMessagesResponseMessagesUnion, io/github/kikin81/atproto/chat/bsky/convo/LogAddReactionMessageUnion, io/github/kikin81/atproto/chat/bsky/convo/LogCreateMessageMessageUnion, io/github/kikin81/atproto/chat/bsky/convo/LogDeleteMessageMessageUnion, io/github/kikin81/atproto/chat/bsky/convo/LogReadConvoMessageUnion, io/github/kikin81/atproto/chat/bsky/convo/LogReadMessageMessageUnion, io/github/kikin81/atproto/chat/bsky/convo/LogRemoveReactionMessageUnion, io/github/kikin81/atproto/chat/bsky/convo/MessageViewReplyToUnion {
 	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/DeletedMessageView$Companion;
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/MessageViewSender;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
@@ -12636,18 +12636,40 @@ public final class io/github/kikin81/atproto/chat/bsky/convo/MessageAndReactionV
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class io/github/kikin81/atproto/chat/bsky/convo/MessageBeforeUserJoinedGroupView : io/github/kikin81/atproto/chat/bsky/convo/MessageViewReplyToUnion {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/MessageBeforeUserJoinedGroupView$Companion;
+	public fun <init> ()V
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/convo/MessageBeforeUserJoinedGroupView$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/MessageBeforeUserJoinedGroupView$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/convo/MessageBeforeUserJoinedGroupView;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/convo/MessageBeforeUserJoinedGroupView;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/MessageBeforeUserJoinedGroupView$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
 public final class io/github/kikin81/atproto/chat/bsky/convo/MessageInput {
 	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/MessageInput$Companion;
-	public fun <init> (Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;)V
-	public synthetic fun <init> (Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;)V
+	public synthetic fun <init> (Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lio/github/kikin81/atproto/runtime/AtField;
 	public final fun component2 ()Lio/github/kikin81/atproto/runtime/AtField;
-	public final fun component3 ()Ljava/lang/String;
-	public final fun copy (Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/MessageInput;
-	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/MessageInput;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/MessageInput;
+	public final fun component3 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/MessageInput;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/MessageInput;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/MessageInput;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getEmbed ()Lio/github/kikin81/atproto/runtime/AtField;
 	public final fun getFacets ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun getReplyTo ()Lio/github/kikin81/atproto/runtime/AtField;
 	public final fun getText ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -12739,25 +12761,27 @@ public final class io/github/kikin81/atproto/chat/bsky/convo/MessageRef$Companio
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class io/github/kikin81/atproto/chat/bsky/convo/MessageView : io/github/kikin81/atproto/chat/bsky/convo/ConvoViewLastMessageUnion, io/github/kikin81/atproto/chat/bsky/convo/GetMessagesResponseMessagesUnion, io/github/kikin81/atproto/chat/bsky/convo/LogAddReactionMessageUnion, io/github/kikin81/atproto/chat/bsky/convo/LogCreateMessageMessageUnion, io/github/kikin81/atproto/chat/bsky/convo/LogDeleteMessageMessageUnion, io/github/kikin81/atproto/chat/bsky/convo/LogReadConvoMessageUnion, io/github/kikin81/atproto/chat/bsky/convo/LogReadMessageMessageUnion, io/github/kikin81/atproto/chat/bsky/convo/LogRemoveReactionMessageUnion {
+public final class io/github/kikin81/atproto/chat/bsky/convo/MessageView : io/github/kikin81/atproto/chat/bsky/convo/ConvoViewLastMessageUnion, io/github/kikin81/atproto/chat/bsky/convo/GetMessagesResponseMessagesUnion, io/github/kikin81/atproto/chat/bsky/convo/LogAddReactionMessageUnion, io/github/kikin81/atproto/chat/bsky/convo/LogCreateMessageMessageUnion, io/github/kikin81/atproto/chat/bsky/convo/LogDeleteMessageMessageUnion, io/github/kikin81/atproto/chat/bsky/convo/LogReadConvoMessageUnion, io/github/kikin81/atproto/chat/bsky/convo/LogReadMessageMessageUnion, io/github/kikin81/atproto/chat/bsky/convo/LogRemoveReactionMessageUnion, io/github/kikin81/atproto/chat/bsky/convo/MessageViewReplyToUnion {
 	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/MessageView$Companion;
-	public synthetic fun <init> (Lio/github/kikin81/atproto/chat/bsky/convo/MessageViewEmbedUnion;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/MessageViewSender;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public synthetic fun <init> (Lio/github/kikin81/atproto/chat/bsky/convo/MessageViewEmbedUnion;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/MessageViewSender;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lio/github/kikin81/atproto/chat/bsky/convo/MessageViewEmbedUnion;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Lio/github/kikin81/atproto/chat/bsky/convo/MessageViewReplyToUnion;Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/MessageViewSender;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lio/github/kikin81/atproto/chat/bsky/convo/MessageViewEmbedUnion;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Lio/github/kikin81/atproto/chat/bsky/convo/MessageViewReplyToUnion;Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/MessageViewSender;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lio/github/kikin81/atproto/chat/bsky/convo/MessageViewEmbedUnion;
 	public final fun component2 ()Ljava/util/List;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Ljava/util/List;
-	public final fun component5 ()Ljava/lang/String;
-	public final fun component6 ()Lio/github/kikin81/atproto/chat/bsky/convo/MessageViewSender;
-	public final fun component7-DnBUIck ()Ljava/lang/String;
-	public final fun component8 ()Ljava/lang/String;
-	public final fun copy-itQWBns (Lio/github/kikin81/atproto/chat/bsky/convo/MessageViewEmbedUnion;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/MessageViewSender;Ljava/lang/String;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/MessageView;
-	public static synthetic fun copy-itQWBns$default (Lio/github/kikin81/atproto/chat/bsky/convo/MessageView;Lio/github/kikin81/atproto/chat/bsky/convo/MessageViewEmbedUnion;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/MessageViewSender;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/MessageView;
+	public final fun component5 ()Lio/github/kikin81/atproto/chat/bsky/convo/MessageViewReplyToUnion;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Lio/github/kikin81/atproto/chat/bsky/convo/MessageViewSender;
+	public final fun component8-DnBUIck ()Ljava/lang/String;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy-tlRh8Ww (Lio/github/kikin81/atproto/chat/bsky/convo/MessageViewEmbedUnion;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Lio/github/kikin81/atproto/chat/bsky/convo/MessageViewReplyToUnion;Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/MessageViewSender;Ljava/lang/String;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/MessageView;
+	public static synthetic fun copy-tlRh8Ww$default (Lio/github/kikin81/atproto/chat/bsky/convo/MessageView;Lio/github/kikin81/atproto/chat/bsky/convo/MessageViewEmbedUnion;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Lio/github/kikin81/atproto/chat/bsky/convo/MessageViewReplyToUnion;Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/MessageViewSender;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/MessageView;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getEmbed ()Lio/github/kikin81/atproto/chat/bsky/convo/MessageViewEmbedUnion;
 	public final fun getFacets ()Ljava/util/List;
 	public final fun getId ()Ljava/lang/String;
 	public final fun getReactions ()Ljava/util/List;
+	public final fun getReplyTo ()Lio/github/kikin81/atproto/chat/bsky/convo/MessageViewReplyToUnion;
 	public final fun getRev ()Ljava/lang/String;
 	public final fun getSender ()Lio/github/kikin81/atproto/chat/bsky/convo/MessageViewSender;
 	public final fun getSentAt-DnBUIck ()Ljava/lang/String;
@@ -12818,6 +12842,46 @@ public final class io/github/kikin81/atproto/chat/bsky/convo/MessageViewEmbedUni
 public final class io/github/kikin81/atproto/chat/bsky/convo/MessageViewEmbedUnionUnknownSerializer : io/github/kikin81/atproto/runtime/UnknownMemberSerializer {
 	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/MessageViewEmbedUnionUnknownSerializer;
 	public fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/chat/bsky/convo/MessageViewEmbedUnion$Unknown;
+	public synthetic fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/runtime/UnknownOpenUnionMember;
+}
+
+public abstract interface class io/github/kikin81/atproto/chat/bsky/convo/MessageViewReplyToUnion : io/github/kikin81/atproto/runtime/OpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/MessageViewReplyToUnion$Companion;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/MessageViewReplyToUnion$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/MessageViewReplyToUnion$Unknown : io/github/kikin81/atproto/chat/bsky/convo/MessageViewReplyToUnion, io/github/kikin81/atproto/runtime/UnknownOpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/MessageViewReplyToUnion$Unknown$Companion;
+	public fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/chat/bsky/convo/MessageViewReplyToUnion$Unknown;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/MessageViewReplyToUnion$Unknown;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/MessageViewReplyToUnion$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getRaw ()Lkotlinx/serialization/json/JsonObject;
+	public fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/MessageViewReplyToUnion$Unknown$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/MessageViewReplyToUnionSerializer : io/github/kikin81/atproto/runtime/OpenUnionSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/MessageViewReplyToUnionSerializer;
+	public fun selectKnownDeserializer (Ljava/lang/String;)Lkotlinx/serialization/KSerializer;
+	public fun selectKnownSerializer (Lio/github/kikin81/atproto/chat/bsky/convo/MessageViewReplyToUnion;)Lkotlinx/serialization/KSerializer;
+	public synthetic fun selectKnownSerializer (Lio/github/kikin81/atproto/runtime/OpenUnionMember;)Lkotlinx/serialization/KSerializer;
+	public fun unknownSerializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/MessageViewReplyToUnionUnknownSerializer : io/github/kikin81/atproto/runtime/UnknownMemberSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/MessageViewReplyToUnionUnknownSerializer;
+	public fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/chat/bsky/convo/MessageViewReplyToUnion$Unknown;
 	public synthetic fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/runtime/UnknownOpenUnionMember;
 }
 
@@ -13015,6 +13079,33 @@ public final synthetic class io/github/kikin81/atproto/chat/bsky/convo/RemoveRea
 }
 
 public final class io/github/kikin81/atproto/chat/bsky/convo/RemoveReactionResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/ReplyRef {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/ReplyRef$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/ReplyRef;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/ReplyRef;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/ReplyRef;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMessageId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/convo/ReplyRef$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/ReplyRef$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/convo/ReplyRef;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/convo/ReplyRef;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/ReplyRef$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 


### PR DESCRIPTION
## What

Vendors the reply-carrying pieces of `chat.bsky.convo` as pinned-shadow overlays (`removeWhenPublished: false`), so the SDK exposes DM message replies ahead of the network publishing the lexicon changes.

Added to the overlay set (pinned to `bluesky-social/atproto` @ `4f1e2038`):

- **`defs`** — `#replyRef`, `messageInput.replyTo`, `messageView.replyTo`, and `#messageBeforeUserJoinedGroupView`
- **`sendMessage` / `sendMessageBatch`** — the `ReplyTargetNotFound` error that pairs with `messageInput.replyTo`

## How

Each overlay was **surgically merged** onto the installed `0.1.4` lexicon (added only the reply pieces), rather than dropping in the full upstream file. Notably, `defs` keeps the resolvable `chat.bsky.group.defs#joinLinkView` ref instead of the upstream `chat.bsky.embed.joinLink` migration, which isn't in the corpus and would fail resolution.

## Generates

- `ReplyRef`
- `MessageInput.replyTo: AtField<ReplyRef>`
- `MessageView.replyTo: MessageViewReplyToUnion?`
- `MessageBeforeUserJoinedGroupView`

## Validation

`./gradlew :generator:test :models:compileKotlinJvm` — green; all four types generate and compile.

## Retirement

These are pinned shadows: the NSIDs are already published on-network, so they'll never read as not-yet-publishable. **Retire manually** once the on-network `chat.bsky.convo` lexicons include `replyTo`.