### PR TITLE
fix(oauth): keep session on transient refresh failures, clear only on invalid_grant

### DIFF
--- a/oauth/api/oauth.api
+++ b/oauth/api/oauth.api
@@ -97,6 +97,11 @@ public final class io/github/kikin81/atproto/oauth/OAuthException : java/lang/Ru
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
+public final class io/github/kikin81/atproto/oauth/OAuthRefreshFailedException : java/lang/RuntimeException {
+	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
 public final class io/github/kikin81/atproto/oauth/OAuthSession {
 	public static final field Companion Lio/github/kikin81/atproto/oauth/OAuthSession$Companion;
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;[B[BLjava/lang/String;JLjava/lang/String;)V

--- a/oauth/src/main/kotlin/io/github/kikin81/atproto/oauth/DpopAuthProvider.kt
+++ b/oauth/src/main/kotlin/io/github/kikin81/atproto/oauth/DpopAuthProvider.kt
@@ -3,6 +3,7 @@ package io.github.kikin81.atproto.oauth
 import io.github.kikin81.atproto.runtime.AuthProvider
 import io.ktor.client.HttpClient
 import io.ktor.client.request.forms.submitForm
+import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.Parameters
@@ -28,8 +29,12 @@ import kotlin.io.encoding.ExperimentalEncodingApi
  * - If `DPoP-Nonce` header is present → stores the nonce, retries
  * - If the access token is expired → refreshes via the token endpoint
  *   with the DPoP-bound refresh token, retries
- * - If the refresh token is revoked → clears the session, throws
- *   [OAuthSessionExpiredException]
+ * - If the refresh token is revoked (`error=invalid_grant`) → clears the
+ *   session, throws [OAuthSessionExpiredException]
+ * - If the refresh fails transiently (network error, 5xx/429, or an
+ *   unparseable/captive-portal response) → throws the retryable
+ *   [OAuthRefreshFailedException] and LEAVES THE SESSION INTACT, so a flaky
+ *   connection can't sign the user out
  *
  * Refresh operations are serialized with a [Mutex] to prevent concurrent
  * refreshes from invalidating the session.
@@ -145,26 +150,25 @@ class DpopAuthProvider(
                 headers.append("DPoP", proof)
             }
         } catch (e: Exception) {
-            throw OAuthSessionExpiredException("Refresh request failed", e)
+            // Transient network failure (no signal, DNS, timeout) — the refresh
+            // token isn't necessarily invalid. Retryable; do NOT clear the session.
+            throw OAuthRefreshFailedException("Refresh request failed", e)
         }
 
-        val needsNonce = response.status == HttpStatusCode.Unauthorized ||
-            response.status == HttpStatusCode.BadRequest
-        if (needsNonce) {
-            val nonceHeader = response.headers["DPoP-Nonce"]
-            if (nonceHeader != null) {
-                signer.calibrateClockFromHeader(response.headers["Date"]?.toString())
-                authServerNonce = nonceHeader
-                return refreshTokensWithNonce()
-            }
-            sessionStore.clear()
-            throw OAuthSessionExpiredException("Refresh token rejected (HTTP ${response.status})")
+        // A rotated DPoP-Nonce on a 401/400 is a recoverable use_dpop_nonce
+        // signal — retry once with the new nonce (not a token rejection).
+        val nonceHeader = response.headers["DPoP-Nonce"]
+        val canRetryWithNonce = (
+            response.status == HttpStatusCode.Unauthorized ||
+                response.status == HttpStatusCode.BadRequest
+            ) && nonceHeader != null
+        if (canRetryWithNonce) {
+            signer.calibrateClockFromHeader(response.headers["Date"]?.toString())
+            authServerNonce = nonceHeader
+            return refreshTokensWithNonce()
         }
 
-        if (response.status != HttpStatusCode.OK) {
-            sessionStore.clear()
-            throw OAuthSessionExpiredException("Refresh failed with HTTP ${response.status}")
-        }
+        if (response.status != HttpStatusCode.OK) failRefresh(response)
 
         val tokenResponse = json.decodeFromString(TokenResponse.serializer(), response.bodyAsText())
         session = session.copy(
@@ -194,10 +198,7 @@ class DpopAuthProvider(
             headers.append("DPoP", proof)
         }
 
-        if (response.status != HttpStatusCode.OK) {
-            sessionStore.clear()
-            throw OAuthSessionExpiredException("Refresh failed after nonce retry (HTTP ${response.status})")
-        }
+        if (response.status != HttpStatusCode.OK) failRefresh(response)
 
         val tokenResponse = json.decodeFromString(TokenResponse.serializer(), response.bodyAsText())
         session = session.copy(
@@ -208,6 +209,30 @@ class DpopAuthProvider(
         )
         sessionStore.save(session)
         return true
+    }
+
+    /**
+     * Terminates a non-OK refresh response. Clears the session and throws
+     * [OAuthSessionExpiredException] ONLY when the token endpoint reports the
+     * refresh token is revoked/expired (`error=invalid_grant`, RFC 6749 §5.2).
+     *
+     * Every other failure — 5xx, 429, 408, a proxy/captive-portal body, or any
+     * non-`invalid_grant` error — is treated as transient: throw the retryable
+     * [OAuthRefreshFailedException] and leave the session intact so a later
+     * request with real connectivity can refresh cleanly. This is what keeps a
+     * flaky connection from silently signing the user out.
+     */
+    private suspend fun failRefresh(response: HttpResponse): Nothing {
+        val error = runCatching {
+            json.parseToJsonElement(response.bodyAsText()).jsonObject["error"]?.jsonPrimitive?.content
+        }.getOrNull()
+        if (error == "invalid_grant") {
+            sessionStore.clear()
+            throw OAuthSessionExpiredException("Refresh token revoked (invalid_grant, HTTP ${response.status})")
+        }
+        throw OAuthRefreshFailedException(
+            "Refresh failed (HTTP ${response.status}${error?.let { ", error=$it" } ?: ""})",
+        )
     }
 
     private suspend fun persistNonces() {

--- a/oauth/src/main/kotlin/io/github/kikin81/atproto/oauth/DpopAuthProvider.kt
+++ b/oauth/src/main/kotlin/io/github/kikin81/atproto/oauth/DpopAuthProvider.kt
@@ -14,6 +14,7 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.long
+import kotlin.coroutines.cancellation.CancellationException
 import kotlin.io.encoding.Base64
 import kotlin.io.encoding.ExperimentalEncodingApi
 
@@ -31,8 +32,8 @@ import kotlin.io.encoding.ExperimentalEncodingApi
  *   with the DPoP-bound refresh token, retries
  * - If the refresh token is revoked (`error=invalid_grant`) → clears the
  *   session, throws [OAuthSessionExpiredException]
- * - If the refresh fails transiently (network error, 5xx/429, or an
- *   unparseable/captive-portal response) → throws the retryable
+ * - Otherwise (network error, 5xx/429, unparseable/captive-portal body, or any
+ *   non-`invalid_grant` error) → throws the retryable
  *   [OAuthRefreshFailedException] and LEAVES THE SESSION INTACT, so a flaky
  *   connection can't sign the user out
  *
@@ -149,6 +150,8 @@ class DpopAuthProvider(
             ) {
                 headers.append("DPoP", proof)
             }
+        } catch (e: CancellationException) {
+            throw e // never swallow cooperative cancellation
         } catch (e: Exception) {
             // Transient network failure (no signal, DNS, timeout) — the refresh
             // token isn't necessarily invalid. Retryable; do NOT clear the session.
@@ -187,15 +190,22 @@ class DpopAuthProvider(
             url = session.tokenEndpoint,
             nonce = authServerNonce,
         )
-        val response = refreshClient.submitForm(
-            url = session.tokenEndpoint,
-            formParameters = Parameters.build {
-                append("grant_type", "refresh_token")
-                append("refresh_token", session.refreshToken)
-                append("client_id", session.clientId ?: "")
-            },
-        ) {
-            headers.append("DPoP", proof)
+        val response = try {
+            refreshClient.submitForm(
+                url = session.tokenEndpoint,
+                formParameters = Parameters.build {
+                    append("grant_type", "refresh_token")
+                    append("refresh_token", session.refreshToken)
+                    append("client_id", session.clientId ?: "")
+                },
+            ) {
+                headers.append("DPoP", proof)
+            }
+        } catch (e: CancellationException) {
+            throw e // never swallow cooperative cancellation
+        } catch (e: Exception) {
+            // Same transient contract as the first refresh leg: retryable, no clear.
+            throw OAuthRefreshFailedException("Refresh request failed (nonce retry)", e)
         }
 
         if (response.status != HttpStatusCode.OK) failRefresh(response)
@@ -223,8 +233,11 @@ class DpopAuthProvider(
      * flaky connection from silently signing the user out.
      */
     private suspend fun failRefresh(response: HttpResponse): Nothing {
+        // Read the body first (a suspend call — must not be inside runCatching, which
+        // would swallow CancellationException); only the pure JSON parse is guarded.
+        val body = response.bodyAsText()
         val error = runCatching {
-            json.parseToJsonElement(response.bodyAsText()).jsonObject["error"]?.jsonPrimitive?.content
+            json.parseToJsonElement(body).jsonObject["error"]?.jsonPrimitive?.content
         }.getOrNull()
         if (error == "invalid_grant") {
             sessionStore.clear()

--- a/oauth/src/main/kotlin/io/github/kikin81/atproto/oauth/OAuthExceptions.kt
+++ b/oauth/src/main/kotlin/io/github/kikin81/atproto/oauth/OAuthExceptions.kt
@@ -5,10 +5,11 @@ class OAuthAccountMismatchException(message: String) : RuntimeException(message)
 class OAuthSessionExpiredException(message: String, cause: Throwable? = null) : RuntimeException(message, cause)
 
 /**
- * Thrown when a token refresh could not be completed for a TRANSIENT reason — a
- * network failure, a 5xx/429/408 from the token endpoint, or an unparseable
- * (e.g. captive-portal) response — as opposed to a genuinely revoked/expired
- * refresh token (which is [OAuthSessionExpiredException]).
+ * Thrown when a token refresh could not be completed for a reason that does NOT
+ * prove the refresh token is dead — a network failure, a 5xx/429/408, an
+ * unparseable (e.g. captive-portal) body, or any non-`invalid_grant` error
+ * response — as opposed to a genuinely revoked/expired refresh token
+ * (`error=invalid_grant`, which is [OAuthSessionExpiredException]).
  *
  * The session is deliberately left intact: a later request with real
  * connectivity can refresh cleanly. Callers must treat this as a retryable

--- a/oauth/src/main/kotlin/io/github/kikin81/atproto/oauth/OAuthExceptions.kt
+++ b/oauth/src/main/kotlin/io/github/kikin81/atproto/oauth/OAuthExceptions.kt
@@ -4,6 +4,19 @@ class OAuthAccountMismatchException(message: String) : RuntimeException(message)
 
 class OAuthSessionExpiredException(message: String, cause: Throwable? = null) : RuntimeException(message, cause)
 
+/**
+ * Thrown when a token refresh could not be completed for a TRANSIENT reason — a
+ * network failure, a 5xx/429/408 from the token endpoint, or an unparseable
+ * (e.g. captive-portal) response — as opposed to a genuinely revoked/expired
+ * refresh token (which is [OAuthSessionExpiredException]).
+ *
+ * The session is deliberately left intact: a later request with real
+ * connectivity can refresh cleanly. Callers must treat this as a retryable
+ * error, NOT a sign-out — surfacing it as "logged out" is the bug this type
+ * exists to prevent.
+ */
+class OAuthRefreshFailedException(message: String, cause: Throwable? = null) : RuntimeException(message, cause)
+
 class OAuthException(message: String, cause: Throwable? = null) : RuntimeException(message, cause)
 
 /**

--- a/oauth/src/test/kotlin/io/github/kikin81/atproto/oauth/DpopAuthProviderTest.kt
+++ b/oauth/src/test/kotlin/io/github/kikin81/atproto/oauth/DpopAuthProviderTest.kt
@@ -14,6 +14,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class DpopAuthProviderTest {
@@ -170,10 +171,11 @@ class DpopAuthProviderTest {
         // If the access token is expired AND the server rotates the nonce in
         // the same 401, refreshTokens() may still throw on a network failure.
         // The new nonce must already be persisted so the next cold start
-        // doesn't have to re-discover it (Copilot review on PR #34, comment
-        // 2). Per refreshTokens(), a network-layer exception throws
-        // OAuthSessionExpiredException without calling sessionStore.clear(),
-        // so persisting the nonce is safe.
+        // doesn't have to re-discover it (Copilot review on PR #34, comment 2).
+        // A network-layer failure is TRANSIENT (no signal, not a revoked
+        // token): it must throw the retryable OAuthRefreshFailedException and
+        // leave the session intact — never OAuthSessionExpiredException, which
+        // would clear the session and sign the user out.
         val refreshClient = HttpClient(
             MockEngine { _ ->
                 throw java.io.IOException("simulated network failure")
@@ -199,12 +201,108 @@ class DpopAuthProviderTest {
         store.session = session
         val provider = DpopAuthProvider(session, signer, store, refreshClient)
 
-        assertFailsWith<OAuthSessionExpiredException> {
+        assertFailsWith<OAuthRefreshFailedException> {
             provider.onUnauthorized(mapOf("DPoP-Nonce" to "fresh-nonce"))
         }
 
-        // Refresh threw, but the rotated nonce must already be persisted.
+        // Refresh threw, but the session survives and the rotated nonce is persisted.
+        assertNotNull(store.session, "a network failure must NOT clear the session")
         assertEquals("fresh-nonce", store.session?.pdsNonce)
+    }
+
+    @Test
+    fun refreshOnTransient5xxKeepsSessionAndThrowsRetryable() = runTest {
+        // The core bug: a transient 5xx from the token endpoint (flaky signal,
+        // gateway/captive-portal upstream) must NOT be treated as a revoked
+        // refresh token. Leave the session intact and surface a retryable error.
+        val refreshClient = HttpClient(
+            MockEngine { _ -> respond(ByteReadChannel("upstream unavailable"), HttpStatusCode.ServiceUnavailable) },
+        )
+        val (provider, store) = fixtureWithExpiredToken(refreshClient)
+
+        assertFailsWith<OAuthRefreshFailedException> { provider.onUnauthorized(emptyMap()) }
+        assertNotNull(store.session, "a transient 5xx must NOT clear the session")
+    }
+
+    @Test
+    fun refreshOn400WithoutInvalidGrantKeepsSession() = runTest {
+        // A 400 whose OAuth error is NOT invalid_grant (e.g. a proxy/portal
+        // error, or invalid_request) is not proof the refresh token is revoked
+        // — keep the session and surface a retryable error.
+        val refreshClient = HttpClient(
+            MockEngine { _ -> respond(ByteReadChannel("""{"error":"invalid_request"}"""), HttpStatusCode.BadRequest, jsonHeaders) },
+        )
+        val (provider, store) = fixtureWithExpiredToken(refreshClient)
+
+        assertFailsWith<OAuthRefreshFailedException> { provider.onUnauthorized(emptyMap()) }
+        assertNotNull(store.session, "a non-invalid_grant 400 must NOT clear the session")
+    }
+
+    @Test
+    fun refreshOnInvalidGrantClearsSessionAndThrowsExpired() = runTest {
+        // The genuine revoked/expired refresh token case (RFC 6749 §5.2): the
+        // token endpoint returns 400 with error=invalid_grant. THIS is the only
+        // case that should clear the session and sign the user out.
+        val refreshClient = HttpClient(
+            MockEngine { _ -> respond(ByteReadChannel("""{"error":"invalid_grant"}"""), HttpStatusCode.BadRequest, jsonHeaders) },
+        )
+        val (provider, store) = fixtureWithExpiredToken(refreshClient)
+
+        assertFailsWith<OAuthSessionExpiredException> { provider.onUnauthorized(emptyMap()) }
+        assertNull(store.session, "a revoked refresh token (invalid_grant) must clear the session")
+    }
+
+    @Test
+    fun refreshAfterNonceRetryTransientKeepsSession() = runTest {
+        // Same guarantee on the nonce-retry path: if the first refresh gets a
+        // rotated auth-server nonce (use_dpop_nonce) and the retried refresh
+        // then hits a transient 5xx, keep the session and surface a retryable
+        // error — don't sign the user out.
+        var calls = 0
+        val refreshClient = HttpClient(
+            MockEngine { _ ->
+                calls++
+                if (calls == 1) {
+                    respond(
+                        ByteReadChannel("""{"error":"use_dpop_nonce"}"""),
+                        HttpStatusCode.BadRequest,
+                        headersOf("DPoP-Nonce", "srv-nonce"),
+                    )
+                } else {
+                    respond(ByteReadChannel("upstream unavailable"), HttpStatusCode.ServiceUnavailable)
+                }
+            },
+        )
+        val (provider, store) = fixtureWithExpiredToken(refreshClient)
+
+        assertFailsWith<OAuthRefreshFailedException> { provider.onUnauthorized(emptyMap()) }
+        assertEquals(2, calls, "the nonce-retry must have been attempted")
+        assertNotNull(store.session, "a transient 5xx on the nonce retry must NOT clear the session")
+    }
+
+    /**
+     * Builds a [DpopAuthProvider] whose access token is already expired, so
+     * `onUnauthorized` routes straight to the token-refresh path. Returns the
+     * provider + its store for post-assertions on session survival.
+     */
+    private fun fixtureWithExpiredToken(refreshClient: HttpClient): Pair<DpopAuthProvider, InMemorySessionStore> {
+        val signer = DpopSigner.generate()
+        val exported = signer.exportKeyPair()
+        val store = InMemorySessionStore()
+        val session = OAuthSession(
+            accessToken = makeJwtWithExp((System.currentTimeMillis() / 1000) - 3600),
+            refreshToken = "rt",
+            did = "did:plc:x",
+            handle = "x.test",
+            pdsUrl = "https://pds.test",
+            tokenEndpoint = "https://auth.test/token",
+            clientId = "https://app.test/meta.json",
+            dpopPrivateKey = exported.privateKeyEncoded,
+            dpopPublicKey = exported.publicKeyEncoded,
+            pdsNonce = "old-nonce",
+        )
+        store.session = session
+        return DpopAuthProvider(session, signer, store, refreshClient) to store
     }
 
     @OptIn(ExperimentalEncodingApi::class)

--- a/oauth/src/test/kotlin/io/github/kikin81/atproto/oauth/DpopAuthProviderTest.kt
+++ b/oauth/src/test/kotlin/io/github/kikin81/atproto/oauth/DpopAuthProviderTest.kt
@@ -8,6 +8,7 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
 import io.ktor.utils.io.ByteReadChannel
 import kotlinx.coroutines.test.runTest
+import kotlin.coroutines.cancellation.CancellationException
 import kotlin.io.encoding.Base64
 import kotlin.io.encoding.ExperimentalEncodingApi
 import kotlin.test.Test
@@ -278,6 +279,47 @@ class DpopAuthProviderTest {
         assertFailsWith<OAuthRefreshFailedException> { provider.onUnauthorized(emptyMap()) }
         assertEquals(2, calls, "the nonce-retry must have been attempted")
         assertNotNull(store.session, "a transient 5xx on the nonce retry must NOT clear the session")
+    }
+
+    @Test
+    fun refreshNonceRetryNetworkFailureKeepsSession() = runTest {
+        // The nonce-retry leg must also treat a network failure as transient —
+        // wrap submitForm so it surfaces as retryable, not a raw escape that a
+        // caller might mishandle, and never clear the session.
+        var calls = 0
+        val refreshClient = HttpClient(
+            MockEngine { _ ->
+                calls++
+                if (calls == 1) {
+                    respond(
+                        ByteReadChannel("""{"error":"use_dpop_nonce"}"""),
+                        HttpStatusCode.BadRequest,
+                        headersOf("DPoP-Nonce", "srv-nonce"),
+                    )
+                } else {
+                    throw java.io.IOException("simulated network failure on nonce retry")
+                }
+            },
+        )
+        val (provider, store) = fixtureWithExpiredToken(refreshClient)
+
+        assertFailsWith<OAuthRefreshFailedException> { provider.onUnauthorized(emptyMap()) }
+        assertEquals(2, calls, "the nonce-retry must have been attempted")
+        assertNotNull(store.session, "a network failure on the nonce retry must NOT clear the session")
+    }
+
+    @Test
+    fun refreshDoesNotWrapCancellation() = runTest {
+        // A cancelled coroutine must propagate CancellationException untouched —
+        // wrapping it as OAuthRefreshFailedException would swallow cancellation
+        // and break structured concurrency.
+        val refreshClient = HttpClient(
+            MockEngine { _ -> throw CancellationException("refresh cancelled") },
+        )
+        val (provider, store) = fixtureWithExpiredToken(refreshClient)
+
+        assertFailsWith<CancellationException> { provider.onUnauthorized(emptyMap()) }
+        assertNotNull(store.session, "cancellation must not clear the session")
     }
 
     /**


### PR DESCRIPTION
## Problem

`DpopAuthProvider` silently signed users out on flaky connections. `refreshTokens()` / `refreshTokensWithNonce()` called `sessionStore.clear()` on **any** non-200 refresh response, and the network-exception path threw `OAuthSessionExpiredException` — both conflating a **transient** failure with a genuinely **revoked** refresh token.

At a spot with poor signal (reported IRL: a national park), the token endpoint call routinely returns a transient `5xx`/`429`/`408`, a captive-portal body, or throws outright — none of which mean the refresh token is dead, yet each wiped the session → login screen.

## Fix

Clear the session + throw `OAuthSessionExpiredException` **only** when the token endpoint reports `error=invalid_grant` (RFC 6749 §5.2 — the revoked/expired refresh-token signal). Every other non-200, unparseable/captive-portal body, or network exception now throws a new **retryable `OAuthRefreshFailedException`** and **leaves the session intact**, so a later request with real connectivity refreshes cleanly.

- New `OAuthRefreshFailedException` (retryable; distinct from the terminal `OAuthSessionExpiredException`).
- `failRefresh(response)` helper centralizes the invalid_grant-vs-transient decision; both refresh paths use it.

## Tests (TDD — written first, watched fail)

`DpopAuthProviderTest`:
- transient **5xx** → retryable, session preserved
- **400 without invalid_grant** → retryable, session preserved
- **network exception** → retryable, session preserved (+ rotated nonce still persisted)
- **nonce-retry** hitting a transient 5xx → retryable, session preserved
- **invalid_grant** → clears session + `OAuthSessionExpiredException` (the only sign-out path)

8/8 green. API dump updated for the new exception.

## Downstream

No consumer change needed — nubecita never caught `OAuthSessionExpiredException`; the fix is purely "don't clear the session on transient failures." After release, nubecita bumps its `atproto` pin.

Refs: nubecita-6lrl