### PR TITLE
style(oauth): wrap refresh nonce-retry check to satisfy ktlint

### DIFF
--- a/oauth/src/main/kotlin/io/github/kikin81/atproto/oauth/DpopAuthProvider.kt
+++ b/oauth/src/main/kotlin/io/github/kikin81/atproto/oauth/DpopAuthProvider.kt
@@ -161,10 +161,10 @@ class DpopAuthProvider(
         // A rotated DPoP-Nonce on a 401/400 is a recoverable use_dpop_nonce
         // signal — retry once with the new nonce (not a token rejection).
         val nonceHeader = response.headers["DPoP-Nonce"]
-        val canRetryWithNonce = (
+        val isNonceRetryStatus =
             response.status == HttpStatusCode.Unauthorized ||
                 response.status == HttpStatusCode.BadRequest
-            ) && nonceHeader != null
+        val canRetryWithNonce = isNonceRetryStatus && nonceHeader != null
         if (canRetryWithNonce) {
             signer.calibrateClockFromHeader(response.headers["Date"]?.toString())
             authServerNonce = nonceHeader


### PR DESCRIPTION
## Why

The `fix(oauth)` merge (#159) broke **Lint on `main`**, which **blocked the release** (semantic-release never ran). Root cause: the `canRetryWithNonce` expression tripped ktlint's wrapping rule, but a **warm Gradle daemon masked it locally** (the known "daemon caches editorconfig" trap) so it passed the PR's cached run and slipped through — then failed on `main`'s cold build with `spotless (ktlint) … files were modified`.

## Fix

Extract the status check into `isNonceRetryStatus` — clearer and ktlint-stable. Verified with a **cold** run (`spotlessApply --no-build-cache --rerun-tasks --no-daemon`) that makes no further changes. No behavior change; the `DpopAuthProviderTest` suite is unchanged and green (10/10).

Unblocks the release carrying the transient-refresh-logout fix (#159).

Refs: nubecita-6lrl