### PR TITLE
fix(oauth): coalesce concurrent token refreshes into a single rotation

### DIFF
--- a/oauth/src/main/kotlin/io/github/kikin81/atproto/oauth/DpopAuthProvider.kt
+++ b/oauth/src/main/kotlin/io/github/kikin81/atproto/oauth/DpopAuthProvider.kt
@@ -93,12 +93,54 @@ class DpopAuthProvider(
         }
 
         if (isAccessTokenExpired()) {
-            return refreshMutex.withLock { refreshTokens() }
+            return refreshTokensSingleFlight()
         }
 
         if (nonceChanged) return true
 
-        return refreshMutex.withLock { refreshTokens() }
+        return refreshTokensSingleFlight()
+    }
+
+    /**
+     * Serializes refreshes AND coalesces redundant ones. AT Proto refresh
+     * tokens are single-use: replaying an already-consumed token trips the
+     * auth server's reuse detection and revokes the entire session
+     * (`invalid_grant`), so every avoidable rotation is a logout risk avoided.
+     *
+     * Inside the lock, two checks run before any network call:
+     * 1. **In-flight dedup** — if the in-memory tokens changed while this
+     *    caller waited on the mutex, a prior waiter already rotated; adopt
+     *    that result and skip the redundant POST.
+     * 2. **Cross-instance dedup** — if the shared [sessionStore] holds a
+     *    session (same DID) with a different refresh token, another provider
+     *    instance already rotated. Adopt the stored session instead of
+     *    replaying this instance's now-consumed token.
+     */
+    private suspend fun refreshTokensSingleFlight(): Boolean {
+        // Snapshot BEFORE acquiring the lock: waiters queued behind an
+        // in-flight refresh must observe the pre-refresh tokens to detect it.
+        val observedAccessToken = session.accessToken
+        val observedRefreshToken = session.refreshToken
+        refreshMutex.withLock {
+            val rotatedWhileWaiting =
+                session.accessToken != observedAccessToken ||
+                    session.refreshToken != observedRefreshToken
+            if (rotatedWhileWaiting) return true
+
+            val stored = sessionStore.load()
+            if (stored != null) {
+                val rotatedByOtherInstance =
+                    stored.did == session.did && stored.refreshToken != session.refreshToken
+                if (rotatedByOtherInstance) {
+                    session = stored
+                    pdsNonce = stored.pdsNonce
+                    authServerNonce = stored.authServerNonce
+                    return true
+                }
+            }
+
+            return refreshTokens()
+        }
     }
 
     /**
@@ -134,12 +176,33 @@ class DpopAuthProvider(
     }
 
     private suspend fun refreshTokens(): Boolean {
+        val response = postRefreshForm(failureContext = "")
+
+        // A rotated DPoP-Nonce on a 401/400 is a recoverable use_dpop_nonce
+        // signal — retry once with the new nonce (not a token rejection).
+        val nonceHeader = response.headers["DPoP-Nonce"]
+        val isNonceRetryStatus =
+            response.status == HttpStatusCode.Unauthorized ||
+                response.status == HttpStatusCode.BadRequest
+        val canRetryWithNonce = isNonceRetryStatus && nonceHeader != null
+        if (canRetryWithNonce) {
+            signer.calibrateClockFromHeader(response.headers["Date"]?.toString())
+            authServerNonce = nonceHeader
+            return refreshTokensWithNonce()
+        }
+
+        return applyRefreshResponse(response)
+    }
+
+    private suspend fun refreshTokensWithNonce(): Boolean = applyRefreshResponse(postRefreshForm(failureContext = " (nonce retry)"))
+
+    private suspend fun postRefreshForm(failureContext: String): HttpResponse {
         val proof = signer.sign(
             method = "POST",
             url = session.tokenEndpoint,
             nonce = authServerNonce,
         )
-        val response = try {
+        return try {
             refreshClient.submitForm(
                 url = session.tokenEndpoint,
                 formParameters = Parameters.build {
@@ -155,59 +218,11 @@ class DpopAuthProvider(
         } catch (e: Exception) {
             // Transient network failure (no signal, DNS, timeout) — the refresh
             // token isn't necessarily invalid. Retryable; do NOT clear the session.
-            throw OAuthRefreshFailedException("Refresh request failed", e)
+            throw OAuthRefreshFailedException("Refresh request failed$failureContext", e)
         }
-
-        // A rotated DPoP-Nonce on a 401/400 is a recoverable use_dpop_nonce
-        // signal — retry once with the new nonce (not a token rejection).
-        val nonceHeader = response.headers["DPoP-Nonce"]
-        val isNonceRetryStatus =
-            response.status == HttpStatusCode.Unauthorized ||
-                response.status == HttpStatusCode.BadRequest
-        val canRetryWithNonce = isNonceRetryStatus && nonceHeader != null
-        if (canRetryWithNonce) {
-            signer.calibrateClockFromHeader(response.headers["Date"]?.toString())
-            authServerNonce = nonceHeader
-            return refreshTokensWithNonce()
-        }
-
-        if (response.status != HttpStatusCode.OK) failRefresh(response)
-
-        val tokenResponse = json.decodeFromString(TokenResponse.serializer(), response.bodyAsText())
-        session = session.copy(
-            accessToken = tokenResponse.access_token,
-            refreshToken = tokenResponse.refresh_token ?: session.refreshToken,
-            authServerNonce = authServerNonce,
-            pdsNonce = pdsNonce,
-        )
-        sessionStore.save(session)
-        return true
     }
 
-    private suspend fun refreshTokensWithNonce(): Boolean {
-        val proof = signer.sign(
-            method = "POST",
-            url = session.tokenEndpoint,
-            nonce = authServerNonce,
-        )
-        val response = try {
-            refreshClient.submitForm(
-                url = session.tokenEndpoint,
-                formParameters = Parameters.build {
-                    append("grant_type", "refresh_token")
-                    append("refresh_token", session.refreshToken)
-                    append("client_id", session.clientId ?: "")
-                },
-            ) {
-                headers.append("DPoP", proof)
-            }
-        } catch (e: CancellationException) {
-            throw e // never swallow cooperative cancellation
-        } catch (e: Exception) {
-            // Same transient contract as the first refresh leg: retryable, no clear.
-            throw OAuthRefreshFailedException("Refresh request failed (nonce retry)", e)
-        }
-
+    private suspend fun applyRefreshResponse(response: HttpResponse): Boolean {
         if (response.status != HttpStatusCode.OK) failRefresh(response)
 
         val tokenResponse = json.decodeFromString(TokenResponse.serializer(), response.bodyAsText())

--- a/oauth/src/main/kotlin/io/github/kikin81/atproto/oauth/DpopAuthProvider.kt
+++ b/oauth/src/main/kotlin/io/github/kikin81/atproto/oauth/DpopAuthProvider.kt
@@ -41,7 +41,10 @@ import kotlin.io.encoding.ExperimentalEncodingApi
  * refreshes from invalidating the session.
  */
 class DpopAuthProvider(
-    private var session: OAuthSession,
+    // Written under refreshMutex, but read without it (authHeaders,
+    // isAccessTokenExpired, snapshotting) — @Volatile guarantees those
+    // unlocked reads observe the latest rotation across threads.
+    @Volatile private var session: OAuthSession,
     private val signer: DpopSigner,
     private val sessionStore: OAuthSessionStore,
     private val refreshClient: HttpClient,
@@ -49,7 +52,11 @@ class DpopAuthProvider(
 ) : AuthProvider {
 
     private val refreshMutex = Mutex()
+
+    @Volatile
     private var pdsNonce: String? = session.pdsNonce
+
+    @Volatile
     private var authServerNonce: String? = session.authServerNonce
 
     override suspend fun authHeaders(method: String, url: String): Map<String, String> {
@@ -82,6 +89,12 @@ class DpopAuthProvider(
      * 4. Otherwise (no nonce signal: same nonce, no nonce header) refresh.
      */
     override suspend fun onUnauthorized(responseHeaders: Map<String, String>): Boolean {
+        // Snapshot the tokens this 401 was (at the latest) issued against,
+        // before any suspension below — the single-flight check compares
+        // against them to detect a rotation that lands while this call waits.
+        val observedAccessToken = session.accessToken
+        val observedRefreshToken = session.refreshToken
+
         val newNonce = responseHeaders["DPoP-Nonce"] ?: responseHeaders["dpop-nonce"]
         val dateHeader = responseHeaders["Date"] ?: responseHeaders["date"]
         if (dateHeader != null) signer.calibrateClockFromHeader(dateHeader)
@@ -93,12 +106,12 @@ class DpopAuthProvider(
         }
 
         if (isAccessTokenExpired()) {
-            return refreshTokensSingleFlight()
+            return refreshTokensSingleFlight(observedAccessToken, observedRefreshToken)
         }
 
         if (nonceChanged) return true
 
-        return refreshTokensSingleFlight()
+        return refreshTokensSingleFlight(observedAccessToken, observedRefreshToken)
     }
 
     /**
@@ -116,31 +129,41 @@ class DpopAuthProvider(
      *    instance already rotated. Adopt the stored session instead of
      *    replaying this instance's now-consumed token.
      */
-    private suspend fun refreshTokensSingleFlight(): Boolean {
-        // Snapshot BEFORE acquiring the lock: waiters queued behind an
-        // in-flight refresh must observe the pre-refresh tokens to detect it.
-        val observedAccessToken = session.accessToken
-        val observedRefreshToken = session.refreshToken
+    private suspend fun refreshTokensSingleFlight(
+        observedAccessToken: String,
+        observedRefreshToken: String,
+    ): Boolean {
         refreshMutex.withLock {
             val rotatedWhileWaiting =
                 session.accessToken != observedAccessToken ||
                     session.refreshToken != observedRefreshToken
             if (rotatedWhileWaiting) return true
 
-            val stored = sessionStore.load()
-            if (stored != null) {
-                val rotatedByOtherInstance =
-                    stored.did == session.did && stored.refreshToken != session.refreshToken
-                if (rotatedByOtherInstance) {
-                    session = stored
-                    pdsNonce = stored.pdsNonce
-                    authServerNonce = stored.authServerNonce
-                    return true
-                }
+            if (adoptStoredSessionIfRotated()) {
+                pdsNonce = session.pdsNonce
+                return true
             }
 
             return refreshTokens()
         }
+    }
+
+    /**
+     * MUST be called with [refreshMutex] held. If the shared [sessionStore]
+     * holds a same-DID session whose refresh token differs from the in-memory
+     * one, another provider instance already rotated — adopt its tokens (and
+     * its auth-server nonce) instead of ever re-using this instance's
+     * now-consumed refresh token. The caller decides what happens to
+     * [pdsNonce], which may be fresher locally than in the store.
+     */
+    private suspend fun adoptStoredSessionIfRotated(): Boolean {
+        val stored = sessionStore.load() ?: return false
+        val rotatedByOtherInstance =
+            stored.did == session.did && stored.refreshToken != session.refreshToken
+        if (!rotatedByOtherInstance) return false
+        session = stored
+        authServerNonce = stored.authServerNonce
+        return true
     }
 
     /**
@@ -263,9 +286,21 @@ class DpopAuthProvider(
         )
     }
 
+    /**
+     * Persists the freshly-rotated nonces under [refreshMutex]. Adoption runs
+     * first: if another instance sharing the [sessionStore] already rotated
+     * the tokens, saving this instance's in-memory session verbatim would
+     * overwrite the store's only valid refresh token with a consumed one —
+     * re-arming the replay → reuse-detection → `invalid_grant` logout. After
+     * adoption the save is a pure nonce update on top of the latest tokens
+     * ([pdsNonce] stays local: the nonce from this 401 is the freshest).
+     */
     private suspend fun persistNonces() {
-        session = session.copy(authServerNonce = authServerNonce, pdsNonce = pdsNonce)
-        sessionStore.save(session)
+        refreshMutex.withLock {
+            adoptStoredSessionIfRotated()
+            session = session.copy(authServerNonce = authServerNonce, pdsNonce = pdsNonce)
+            sessionStore.save(session)
+        }
     }
 }
 

--- a/oauth/src/test/kotlin/io/github/kikin81/atproto/oauth/DpopAuthProviderTest.kt
+++ b/oauth/src/test/kotlin/io/github/kikin81/atproto/oauth/DpopAuthProviderTest.kt
@@ -450,6 +450,76 @@ class DpopAuthProviderTest {
         )
     }
 
+    @Test
+    fun noncePersistenceMustNotClobberASessionRotatedByAnotherInstance() = runTest {
+        // Instance B holds a stale (already-consumed) refresh token while the
+        // shared store already contains A's rotated session. If B's 401
+        // carries a fresh DPoP-Nonce, the eager nonce persistence must NOT
+        // write B's stale session over the rotated one — that would erase the
+        // only valid refresh token and set up the exact replay → reuse
+        // detection → invalid_grant logout this PR eliminates. B must adopt
+        // the stored rotated tokens and save the new nonce on top of them.
+        var tokenCalls = 0
+        val refreshClient = HttpClient(
+            MockEngine { request ->
+                tokenCalls++
+                val form = (request.body as io.ktor.http.content.OutgoingContent.ByteArrayContent)
+                    .bytes()
+                    .decodeToString()
+                if (form.contains("refresh_token=rt_consumed")) {
+                    // Server-side single-use reuse detection.
+                    respond(
+                        ByteReadChannel("""{"error":"invalid_grant"}"""),
+                        HttpStatusCode.BadRequest,
+                        jsonHeaders,
+                    )
+                } else {
+                    respond(
+                        ByteReadChannel(
+                            """{"access_token":"at_new2","refresh_token":"rt_new2","token_type":"DPoP"}""",
+                        ),
+                        HttpStatusCode.OK,
+                        jsonHeaders,
+                    )
+                }
+            },
+        )
+
+        val signer = DpopSigner.generate()
+        val exported = signer.exportKeyPair()
+        val store = InMemorySessionStore()
+        val staleSession = OAuthSession(
+            accessToken = makeJwtWithExp((System.currentTimeMillis() / 1000) - 3600),
+            refreshToken = "rt_consumed",
+            did = "did:plc:x",
+            handle = "x.test",
+            pdsUrl = "https://pds.test",
+            tokenEndpoint = "https://auth.test/token",
+            clientId = "https://app.test/meta.json",
+            dpopPrivateKey = exported.privateKeyEncoded,
+            dpopPublicKey = exported.publicKeyEncoded,
+            pdsNonce = "old-nonce",
+        )
+        // Another instance already rotated: the store holds the fresh session.
+        store.session = staleSession.copy(accessToken = "at_rotated", refreshToken = "rt_rotated")
+        val providerB = DpopAuthProvider(staleSession, signer, store, refreshClient)
+
+        val recovered = providerB.onUnauthorized(mapOf("DPoP-Nonce" to "fresh-nonce"))
+
+        assertTrue(recovered, "B must recover via adoption")
+        assertEquals(0, tokenCalls, "B must neither replay the consumed token nor rotate redundantly")
+        assertEquals(
+            "rt_rotated",
+            store.session?.refreshToken,
+            "the rotated refresh token must survive B's nonce persistence",
+        )
+        assertEquals("fresh-nonce", store.session?.pdsNonce, "the fresh nonce must be saved on top of the rotated tokens")
+        assertTrue(
+            providerB.authHeaders("GET", "https://pds.test/xrpc/x")["Authorization"]!!.contains("at_rotated"),
+            "B must serve the adopted rotated access token",
+        )
+    }
+
     /**
      * Builds a [DpopAuthProvider] whose access token is already expired, so
      * `onUnauthorized` routes straight to the token-refresh path. Returns the

--- a/oauth/src/test/kotlin/io/github/kikin81/atproto/oauth/DpopAuthProviderTest.kt
+++ b/oauth/src/test/kotlin/io/github/kikin81/atproto/oauth/DpopAuthProviderTest.kt
@@ -7,6 +7,9 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
 import io.ktor.utils.io.ByteReadChannel
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.test.runTest
 import kotlin.coroutines.cancellation.CancellationException
 import kotlin.io.encoding.Base64
@@ -320,6 +323,131 @@ class DpopAuthProviderTest {
 
         assertFailsWith<CancellationException> { provider.onUnauthorized(emptyMap()) }
         assertNotNull(store.session, "cancellation must not clear the session")
+    }
+
+    @Test
+    fun refreshPersistsTheRotatedRefreshToken() = runTest {
+        // AT Proto refresh tokens are single-use and rotate on every refresh.
+        // The server-issued replacement MUST be what lands in the store — a
+        // stale persisted refresh token is a future invalid_grant (session
+        // revocation via reuse detection) waiting for the next cold start.
+        val refreshClient = HttpClient(
+            MockEngine { _ ->
+                respond(
+                    ByteReadChannel(
+                        """{"access_token":"at_new","refresh_token":"rt_rotated","token_type":"DPoP"}""",
+                    ),
+                    HttpStatusCode.OK,
+                    jsonHeaders,
+                )
+            },
+        )
+        val (provider, store) = fixtureWithExpiredToken(refreshClient)
+
+        assertTrue(provider.onUnauthorized(emptyMap()))
+
+        assertEquals("rt_rotated", store.session?.refreshToken, "rotated refresh token must be persisted")
+        assertEquals("at_new", store.session?.accessToken)
+    }
+
+    @Test
+    fun concurrentUnauthorizedCallsRotateExactlyOnce() = runTest {
+        // Refresh tokens are single-use: every redundant rotation widens the
+        // window where the persisted token is stale. N callers racing into
+        // onUnauthorized must produce exactly ONE token-endpoint POST; the
+        // waiters queued behind the in-flight refresh adopt its result.
+        var tokenCalls = 0
+        val gate = CompletableDeferred<Unit>()
+        val refreshClient = HttpClient(
+            MockEngine { _ ->
+                tokenCalls++
+                gate.await()
+                respond(
+                    ByteReadChannel(
+                        """{"access_token":"at_new","refresh_token":"rt_new","token_type":"DPoP"}""",
+                    ),
+                    HttpStatusCode.OK,
+                    jsonHeaders,
+                )
+            },
+        )
+        val (provider, store) = fixtureWithExpiredToken(refreshClient)
+
+        val results = (1..3).map { async { provider.onUnauthorized(emptyMap()) } }
+        // Let all three callers run up to the mutex / in-flight request...
+        testScheduler.advanceUntilIdle()
+        // ...then release the single in-flight refresh response.
+        gate.complete(Unit)
+        val recovered = results.awaitAll()
+
+        assertEquals(listOf(true, true, true), recovered, "every caller must report recovery")
+        assertEquals(1, tokenCalls, "concurrent 401s must be coalesced into a single rotation")
+        assertEquals("rt_new", store.session?.refreshToken)
+    }
+
+    @Test
+    fun secondProviderSharingTheStoreAdoptsTheRotatedSessionInsteadOfReplayingTheConsumedToken() = runTest {
+        // Two provider instances built from the same persisted session (e.g.
+        // a client cache invalidation window): after A rotates, B still holds
+        // the CONSUMED refresh token in memory. B must adopt the stored
+        // rotated session instead of replaying the consumed token — replaying
+        // trips the auth server's reuse detection and revokes the whole
+        // session (the "user suddenly logged out" bug).
+        var tokenCalls = 0
+        val refreshClient = HttpClient(
+            MockEngine { request ->
+                tokenCalls++
+                val form = (request.body as io.ktor.http.content.OutgoingContent.ByteArrayContent)
+                    .bytes()
+                    .decodeToString()
+                if (form.contains("refresh_token=rt_consumed") && tokenCalls > 1) {
+                    // Simulate server-side single-use reuse detection.
+                    respond(
+                        ByteReadChannel("""{"error":"invalid_grant"}"""),
+                        HttpStatusCode.BadRequest,
+                        jsonHeaders,
+                    )
+                } else {
+                    respond(
+                        ByteReadChannel(
+                            """{"access_token":"at_new","refresh_token":"rt_new","token_type":"DPoP"}""",
+                        ),
+                        HttpStatusCode.OK,
+                        jsonHeaders,
+                    )
+                }
+            },
+        )
+
+        val signer = DpopSigner.generate()
+        val exported = signer.exportKeyPair()
+        val store = InMemorySessionStore()
+        val session = OAuthSession(
+            accessToken = makeJwtWithExp((System.currentTimeMillis() / 1000) - 3600),
+            refreshToken = "rt_consumed",
+            did = "did:plc:x",
+            handle = "x.test",
+            pdsUrl = "https://pds.test",
+            tokenEndpoint = "https://auth.test/token",
+            clientId = "https://app.test/meta.json",
+            dpopPrivateKey = exported.privateKeyEncoded,
+            dpopPublicKey = exported.publicKeyEncoded,
+            pdsNonce = "old-nonce",
+        )
+        store.session = session
+        val providerA = DpopAuthProvider(session, signer, store, refreshClient)
+        val providerB = DpopAuthProvider(session, signer, store, refreshClient)
+
+        assertTrue(providerA.onUnauthorized(emptyMap()), "A performs the real rotation")
+        assertTrue(providerB.onUnauthorized(emptyMap()), "B must recover by adopting the stored session")
+
+        assertEquals(1, tokenCalls, "B must NOT replay the consumed refresh token")
+        assertNotNull(store.session, "the session must survive")
+        assertEquals("rt_new", store.session?.refreshToken)
+        assertTrue(
+            providerB.authHeaders("GET", "https://pds.test/xrpc/x")["Authorization"]!!.contains("at_new"),
+            "B must serve the adopted rotated access token",
+        )
     }
 
     /**


### PR DESCRIPTION
AT Proto refresh tokens are single-use; replaying a consumed token trips the auth server's reuse detection and revokes the entire session (`invalid_grant`) — surfacing to users as a spurious logout. Follow-up to #159, which narrowed session-clearing to `invalid_grant` but left two replay paths open:

1. **Queued waiters re-rotated:** expiry was checked outside `refreshMutex` and never re-checked inside, so N concurrent 401s produced N sequential rotations.
2. **Cross-instance replay:** `AtOAuth.createClient()` builds a fresh `DpopAuthProvider` per call; a second instance built from the same persisted session replays the now-consumed refresh token on its next 401 → reuse detection → whole session revoked.

`refreshTokensSingleFlight()` snapshots the tokens before the mutex and, inside the lock, (1) returns early when a prior waiter already rotated, and (2) adopts the stored session when another instance sharing the `OAuthSessionStore` rotated first.

Also dedupes the two near-identical refresh legs into `postRefreshForm`/`applyRefreshResponse` — nonce-retry and `invalid_grant` classification are behavior-identical, guarded by the existing tests.

New tests: rotated-refresh-token persistence pin, N-concurrent-callers → exactly one token POST, two-providers-one-store adoption (the second provider previously received `invalid_grant` and cleared the session — reproducing the production logout).

Stacked follow-up: #163 hardens the persist-after-rotation window.

Refs: nubecita-09xt.4