### PR TITLE
fix(oauth): survive persist failures after token rotation

### DIFF
--- a/oauth/api/oauth.api
+++ b/oauth/api/oauth.api
@@ -1,6 +1,6 @@
 public final class io/github/kikin81/atproto/oauth/AtOAuth {
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lio/github/kikin81/atproto/oauth/OAuthSessionStore;Lio/ktor/client/HttpClient;Lkotlinx/serialization/json/Json;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lio/github/kikin81/atproto/oauth/OAuthSessionStore;Lio/ktor/client/HttpClient;Lkotlinx/serialization/json/Json;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lio/github/kikin81/atproto/oauth/OAuthSessionStore;Lio/ktor/client/HttpClient;Lkotlinx/serialization/json/Json;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lio/github/kikin81/atproto/oauth/OAuthSessionStore;Lio/ktor/client/HttpClient;Lkotlinx/serialization/json/Json;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun beginLogin (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun beginSignup (Ljava/lang/String;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun beginSignup$default (Lio/github/kikin81/atproto/oauth/AtOAuth;Ljava/lang/String;ZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
@@ -45,8 +45,8 @@ public final class io/github/kikin81/atproto/oauth/DiscoveryChain {
 }
 
 public final class io/github/kikin81/atproto/oauth/DpopAuthProvider : io/github/kikin81/atproto/runtime/AuthProvider {
-	public fun <init> (Lio/github/kikin81/atproto/oauth/OAuthSession;Lio/github/kikin81/atproto/oauth/DpopSigner;Lio/github/kikin81/atproto/oauth/OAuthSessionStore;Lio/ktor/client/HttpClient;Lkotlinx/serialization/json/Json;)V
-	public synthetic fun <init> (Lio/github/kikin81/atproto/oauth/OAuthSession;Lio/github/kikin81/atproto/oauth/DpopSigner;Lio/github/kikin81/atproto/oauth/OAuthSessionStore;Lio/ktor/client/HttpClient;Lkotlinx/serialization/json/Json;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lio/github/kikin81/atproto/oauth/OAuthSession;Lio/github/kikin81/atproto/oauth/DpopSigner;Lio/github/kikin81/atproto/oauth/OAuthSessionStore;Lio/ktor/client/HttpClient;Lkotlinx/serialization/json/Json;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Lio/github/kikin81/atproto/oauth/OAuthSession;Lio/github/kikin81/atproto/oauth/DpopSigner;Lio/github/kikin81/atproto/oauth/OAuthSessionStore;Lio/ktor/client/HttpClient;Lkotlinx/serialization/json/Json;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun authHeaders (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun onUnauthorized (Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }

--- a/oauth/src/main/kotlin/io/github/kikin81/atproto/oauth/AtOAuth.kt
+++ b/oauth/src/main/kotlin/io/github/kikin81/atproto/oauth/AtOAuth.kt
@@ -74,6 +74,12 @@ class AtOAuth(
     private val httpClient: HttpClient,
     private val json: Json = Json { ignoreUnknownKeys = true },
     private val scope: String = "atproto transition:generic",
+    /**
+     * Forwarded to every [DpopAuthProvider] built by [createClient]: invoked
+     * when persisting a rotated session fails even after a retry. See
+     * [DpopAuthProvider]'s `onPersistFailure` for the durability implications.
+     */
+    private val onSessionPersistFailure: (Throwable) -> Unit = {},
 ) {
     // Transient state during the login/signup flow (between beginX and completeLogin)
     private var pendingState: PendingAuthState? = null
@@ -300,6 +306,7 @@ class AtOAuth(
             signer = signer,
             sessionStore = sessionStore,
             refreshClient = httpClient,
+            onPersistFailure = onSessionPersistFailure,
         )
         return XrpcClient(
             baseUrl = pdsUrl,

--- a/oauth/src/main/kotlin/io/github/kikin81/atproto/oauth/DpopAuthProvider.kt
+++ b/oauth/src/main/kotlin/io/github/kikin81/atproto/oauth/DpopAuthProvider.kt
@@ -2,6 +2,7 @@ package io.github.kikin81.atproto.oauth
 
 import io.github.kikin81.atproto.runtime.AuthProvider
 import io.ktor.client.HttpClient
+import io.ktor.client.network.sockets.ConnectTimeoutException
 import io.ktor.client.request.forms.submitForm
 import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.bodyAsText
@@ -14,6 +15,9 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.long
+import java.net.ConnectException
+import java.net.UnknownHostException
+import java.nio.channels.UnresolvedAddressException
 import kotlin.coroutines.cancellation.CancellationException
 import kotlin.io.encoding.Base64
 import kotlin.io.encoding.ExperimentalEncodingApi
@@ -49,6 +53,16 @@ class DpopAuthProvider(
     private val sessionStore: OAuthSessionStore,
     private val refreshClient: HttpClient,
     private val json: Json = Json { ignoreUnknownKeys = true },
+    /**
+     * Invoked when persisting a rotated session fails even after one retry.
+     * By then the server has already consumed the old refresh token, so the
+     * in-memory session is the only valid copy: the provider keeps serving it
+     * and reports the durability gap here (e.g. to a crash reporter) instead
+     * of throwing. If the process dies before a later save succeeds, the
+     * persisted refresh token is stale and the next cold-start refresh will
+     * be rejected as reuse (`invalid_grant`).
+     */
+    private val onPersistFailure: (Throwable) -> Unit = {},
 ) : AuthProvider {
 
     private val refreshMutex = Mutex()
@@ -239,11 +253,21 @@ class DpopAuthProvider(
         } catch (e: CancellationException) {
             throw e // never swallow cooperative cancellation
         } catch (e: Exception) {
-            // Transient network failure (no signal, DNS, timeout) — the refresh
-            // token isn't necessarily invalid. Retryable; do NOT clear the session.
-            throw OAuthRefreshFailedException("Refresh request failed$failureContext", e)
+            // Transient network failure — the refresh token isn't necessarily
+            // invalid. Retryable; do NOT clear the session. Pre-send failures
+            // (DNS, connect) are flagged: the request never reached the server,
+            // so the single-use refresh token was provably NOT consumed and a
+            // retry with the same token is safe. Post-send failures (response
+            // lost) stay ambiguous — the server may have already rotated.
+            val notConsumed = if (isPreSendFailure(e)) " (request not sent; refresh token not consumed)" else ""
+            throw OAuthRefreshFailedException("Refresh request failed$failureContext$notConsumed", e)
         }
     }
+
+    private fun isPreSendFailure(e: Exception): Boolean = e is UnknownHostException ||
+        e is ConnectException ||
+        e is UnresolvedAddressException ||
+        e is ConnectTimeoutException
 
     private suspend fun applyRefreshResponse(response: HttpResponse): Boolean {
         if (response.status != HttpStatusCode.OK) failRefresh(response)
@@ -255,8 +279,36 @@ class DpopAuthProvider(
             authServerNonce = authServerNonce,
             pdsNonce = pdsNonce,
         )
-        sessionStore.save(session)
+        persistRotatedSession()
         return true
+    }
+
+    /**
+     * Persists the rotated session, retrying once. A rotation the server has
+     * already performed must never be failed client-side: throwing here would
+     * fail a request that holds a perfectly good token and push callers toward
+     * replaying the consumed refresh token (reuse detection → session
+     * revocation). A persist that fails both attempts is reported through
+     * [onPersistFailure] and otherwise swallowed — the in-memory session
+     * remains the source of truth for this provider's lifetime.
+     */
+    private suspend fun persistRotatedSession() {
+        val firstFailure = try {
+            sessionStore.save(session)
+            return
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            e
+        }
+        try {
+            sessionStore.save(session)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (retryFailure: Exception) {
+            retryFailure.addSuppressed(firstFailure)
+            onPersistFailure(retryFailure)
+        }
     }
 
     /**

--- a/oauth/src/main/kotlin/io/github/kikin81/atproto/oauth/OAuthSession.kt
+++ b/oauth/src/main/kotlin/io/github/kikin81/atproto/oauth/OAuthSession.kt
@@ -52,6 +52,18 @@ data class OAuthSession(
  */
 interface OAuthSessionStore {
     suspend fun load(): OAuthSession?
+
+    /**
+     * Persists the session. MUST be durable before returning: [save] is
+     * called AFTER the authorization server has already rotated the
+     * single-use refresh token, so a write that is deferred (e.g. Android
+     * `SharedPreferences.apply()`) or lost to process death leaves a
+     * consumed refresh token on disk — the next cold-start refresh is then
+     * rejected as token reuse (`invalid_grant`) and the whole session is
+     * revoked. Prefer synchronous commits (`commit()`, DataStore
+     * `updateData`) over fire-and-forget writes.
+     */
     suspend fun save(session: OAuthSession)
+
     suspend fun clear()
 }

--- a/oauth/src/test/kotlin/io/github/kikin81/atproto/oauth/DpopAuthProviderTest.kt
+++ b/oauth/src/test/kotlin/io/github/kikin81/atproto/oauth/DpopAuthProviderTest.kt
@@ -520,15 +520,129 @@ class DpopAuthProviderTest {
         )
     }
 
+    @Test
+    fun persistFailureAfterRotationStillRecoversAndSignalsOnPersistFailure() = runTest {
+        // By the time the token endpoint returns 200 the server has ALREADY
+        // consumed the old refresh token. If persisting the rotated session
+        // fails, the in-memory session is still the only valid one — the
+        // provider must keep serving it (return true) rather than throw,
+        // and surface the persistence gap through onPersistFailure so the
+        // app can report it. Throwing here would fail a request that holds
+        // a perfectly good token and invite a consumed-token replay.
+        val refreshClient = HttpClient(
+            MockEngine { _ ->
+                respond(
+                    ByteReadChannel(
+                        """{"access_token":"at_new","refresh_token":"rt_new","token_type":"DPoP"}""",
+                    ),
+                    HttpStatusCode.OK,
+                    jsonHeaders,
+                )
+            },
+        )
+        val store = object : OAuthSessionStore {
+            var session: OAuthSession? = null
+            var saveAttempts = 0
+            override suspend fun load(): OAuthSession? = session
+            override suspend fun save(session: OAuthSession) {
+                saveAttempts++
+                throw java.io.IOException("simulated persist failure #$saveAttempts")
+            }
+            override suspend fun clear() {
+                session = null
+            }
+        }
+        val persistFailures = mutableListOf<Throwable>()
+        val (provider, _) = fixtureWithExpiredToken(refreshClient, store, persistFailures::add)
+
+        assertTrue(provider.onUnauthorized(emptyMap()), "rotation succeeded server-side — must recover")
+
+        assertEquals(2, store.saveAttempts, "save must be retried exactly once")
+        assertEquals(1, persistFailures.size, "the persist failure must be signalled exactly once")
+        assertTrue(
+            provider.authHeaders("GET", "https://pds.test/xrpc/x")["Authorization"]!!.contains("at_new"),
+            "the in-memory rotated token must be served despite the persist failure",
+        )
+    }
+
+    @Test
+    fun persistRetrySucceedsSilently() = runTest {
+        val refreshClient = HttpClient(
+            MockEngine { _ ->
+                respond(
+                    ByteReadChannel(
+                        """{"access_token":"at_new","refresh_token":"rt_new","token_type":"DPoP"}""",
+                    ),
+                    HttpStatusCode.OK,
+                    jsonHeaders,
+                )
+            },
+        )
+        val store = object : OAuthSessionStore {
+            var session: OAuthSession? = null
+            var saveAttempts = 0
+            override suspend fun load(): OAuthSession? = session
+            override suspend fun save(session: OAuthSession) {
+                saveAttempts++
+                if (saveAttempts == 1) throw java.io.IOException("transient persist hiccup")
+                this.session = session
+            }
+            override suspend fun clear() {
+                session = null
+            }
+        }
+        val persistFailures = mutableListOf<Throwable>()
+        val (provider, _) = fixtureWithExpiredToken(refreshClient, store, persistFailures::add)
+
+        assertTrue(provider.onUnauthorized(emptyMap()))
+
+        assertEquals("rt_new", store.session?.refreshToken, "the retry must persist the rotated token")
+        assertTrue(persistFailures.isEmpty(), "a recovered persist must not be signalled")
+    }
+
+    @Test
+    fun preSendNetworkFailureIsMarkedAsTokenNotConsumed() = runTest {
+        // A DNS / connect-phase failure means the refresh request never
+        // reached the server, so the refresh token was NOT consumed — callers
+        // (and their telemetry) can safely retry with the same token. The
+        // thrown message must carry that distinction; a post-send failure
+        // (response lost) stays ambiguous.
+        val refreshClient = HttpClient(
+            MockEngine { _ -> throw java.net.UnknownHostException("auth.test") },
+        )
+        val (provider, store) = fixtureWithExpiredToken(refreshClient)
+
+        val failure = assertFailsWith<OAuthRefreshFailedException> { provider.onUnauthorized(emptyMap()) }
+
+        assertTrue(
+            failure.message!!.contains("not consumed"),
+            "pre-send failures must state the refresh token was not consumed, got: ${failure.message}",
+        )
+        assertNotNull(store.session, "a pre-send failure must not clear the session")
+    }
+
     /**
      * Builds a [DpopAuthProvider] whose access token is already expired, so
      * `onUnauthorized` routes straight to the token-refresh path. Returns the
      * provider + its store for post-assertions on session survival.
      */
     private fun fixtureWithExpiredToken(refreshClient: HttpClient): Pair<DpopAuthProvider, InMemorySessionStore> {
+        val store = InMemorySessionStore()
+        val (provider, _) = fixtureWithExpiredToken(refreshClient, store) {}
+        return provider to store
+    }
+
+    /**
+     * Variant taking a custom [store] (e.g. one whose `save` fails) and an
+     * [onPersistFailure] hook, for the rotation-persistence hardening tests.
+     */
+    private fun fixtureWithExpiredToken(
+        refreshClient: HttpClient,
+        store: OAuthSessionStore,
+        onPersistFailure: (Throwable) -> Unit,
+    ): Pair<DpopAuthProvider, OAuthSessionStore> {
         val signer = DpopSigner.generate()
         val exported = signer.exportKeyPair()
-        val store = InMemorySessionStore()
         val session = OAuthSession(
             accessToken = makeJwtWithExp((System.currentTimeMillis() / 1000) - 3600),
             refreshToken = "rt",
@@ -541,8 +655,8 @@ class DpopAuthProviderTest {
             dpopPublicKey = exported.publicKeyEncoded,
             pdsNonce = "old-nonce",
         )
-        store.session = session
-        return DpopAuthProvider(session, signer, store, refreshClient) to store
+        (store as? InMemorySessionStore)?.session = session
+        return DpopAuthProvider(session, signer, store, refreshClient, onPersistFailure = onPersistFailure) to store
     }
 
     @OptIn(ExperimentalEncodingApi::class)

--- a/samples/android/src/main/kotlin/io/github/kikin81/atproto/samples/bluesky/session/AndroidOAuthSessionStore.kt
+++ b/samples/android/src/main/kotlin/io/github/kikin81/atproto/samples/bluesky/session/AndroidOAuthSessionStore.kt
@@ -6,7 +6,10 @@ import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKey
 import io.github.kikin81.atproto.oauth.OAuthSession
 import io.github.kikin81.atproto.oauth.OAuthSessionStore
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
+import java.io.IOException
 
 class AndroidOAuthSessionStore(appContext: Context) : OAuthSessionStore {
 
@@ -34,9 +37,20 @@ class AndroidOAuthSessionStore(appContext: Context) : OAuthSessionStore {
         // rotated the single-use refresh token (see OAuthSessionStore.save).
         // apply()'s deferred write can be lost to process death, stranding the
         // consumed token on disk → invalid_grant (reuse detection) on the next
-        // cold start → the whole session is revoked.
-        @Suppress("ApplySharedPref")
-        prefs.edit().putString(KEY, json.encodeToString(OAuthSession.serializer(), session)).commit()
+        // cold start → the whole session is revoked. The synchronous disk +
+        // crypto work moves off the caller's thread (suspend fns are expected
+        // to be main-safe), and a false return becomes an IOException so
+        // DpopAuthProvider's retry + onPersistFailure actually engage.
+        withContext(Dispatchers.IO) {
+            @Suppress("ApplySharedPref")
+            val committed = prefs
+                .edit()
+                .putString(KEY, json.encodeToString(OAuthSession.serializer(), session))
+                .commit()
+            if (!committed) {
+                throw IOException("SharedPreferences commit() failed to persist the rotated session")
+            }
+        }
     }
 
     override suspend fun clear() {

--- a/samples/android/src/main/kotlin/io/github/kikin81/atproto/samples/bluesky/session/AndroidOAuthSessionStore.kt
+++ b/samples/android/src/main/kotlin/io/github/kikin81/atproto/samples/bluesky/session/AndroidOAuthSessionStore.kt
@@ -30,7 +30,13 @@ class AndroidOAuthSessionStore(appContext: Context) : OAuthSessionStore {
     }
 
     override suspend fun save(session: OAuthSession) {
-        prefs.edit().putString(KEY, json.encodeToString(OAuthSession.serializer(), session)).apply()
+        // commit(), not apply(): save() runs after the auth server has already
+        // rotated the single-use refresh token (see OAuthSessionStore.save).
+        // apply()'s deferred write can be lost to process death, stranding the
+        // consumed token on disk → invalid_grant (reuse detection) on the next
+        // cold start → the whole session is revoked.
+        @Suppress("ApplySharedPref")
+        prefs.edit().putString(KEY, json.encodeToString(OAuthSession.serializer(), session)).commit()
     }
 
     override suspend fun clear() {


### PR DESCRIPTION
Stacked on #162 (retarget to `main` after it merges).

By the time the token endpoint returns 200, the server has already consumed the single-use refresh token — so a client-side persist failure must not fail the refresh. Throwing would fail a request that holds a perfectly good token and push callers toward replaying the consumed token (reuse detection → `invalid_grant` → session revoked → spurious logout).

- `sessionStore.save()` after rotation now retries once, then swallows-and-signals via a new optional `onPersistFailure` callback on `DpopAuthProvider`, threaded through `AtOAuth(onSessionPersistFailure = …)` so consuming apps can report the durability gap (Nubecita will wire it to Crashlytics).
- `OAuthSessionStore.save` KDoc now states the durability contract: it runs after the server has already rotated, so deferred writes (`SharedPreferences.apply()`) lose the only valid token to process death.
- The Android sample store honors the contract: `apply()` → `commit()`.
- Pre-send network failures (DNS/connect) are labeled "refresh token not consumed" in `OAuthRefreshFailedException`, distinguishing them from ambiguous post-send response loss.

New tests: persist-fails-twice → still recovers + signals exactly once + serves the rotated in-memory token; persist-retry-succeeds → silent; pre-send failure message contract.

Refs: nubecita-09xt.5