### PR TITLE
chore(lexicons): bump @atproto/lex to 0.1.7

### DIFF
--- a/generator/package-lock.json
+++ b/generator/package-lock.json
@@ -8,20 +8,20 @@
       "name": "kikinlex-atproto-generator-lexicons",
       "version": "0.0.0",
       "dependencies": {
-        "@atproto/lex": "0.1.5"
+        "@atproto/lex": "0.1.7"
       }
     },
     "node_modules/@atproto-labs/did-resolver": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@atproto-labs/did-resolver/-/did-resolver-0.3.3.tgz",
-      "integrity": "sha512-AOzZVvBCaMlmRlYDNfAfIVLIvvsHV97z3yajQkjKngt+G+HDMxsKj+RBPmqpSYz6EzI3g+XH+rGIRjXsBEj6cg==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@atproto-labs/did-resolver/-/did-resolver-0.3.4.tgz",
+      "integrity": "sha512-nBECoVG59NfbYthayxfR0s1dLFVdN+RKMaL0p0uaNX/U1SAETksN6Yydmr4oWOKSkyyU3GO9XZeo1yzwHnRcZw==",
       "license": "MIT",
       "dependencies": {
-        "@atproto-labs/fetch": "^0.3.2",
-        "@atproto-labs/pipe": "^0.2.2",
-        "@atproto-labs/simple-store": "^0.4.2",
-        "@atproto-labs/simple-store-memory": "^0.2.2",
-        "@atproto/did": "^0.5.2",
+        "@atproto-labs/fetch": "^0.3.3",
+        "@atproto-labs/pipe": "^0.2.3",
+        "@atproto-labs/simple-store": "^0.4.3",
+        "@atproto-labs/simple-store-memory": "^0.2.3",
+        "@atproto/did": "^0.5.3",
         "zod": "^3.23.8"
       },
       "engines": {
@@ -29,42 +29,42 @@
       }
     },
     "node_modules/@atproto-labs/fetch": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@atproto-labs/fetch/-/fetch-0.3.2.tgz",
-      "integrity": "sha512-NWNQ+MLNEqXpxsfM9mG14eVo0n5z8oWU7yjz/kCROAw5HG+i8a44tQtic90qXw3rBVxFBrrgE4kMftA7jeOiCw==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@atproto-labs/fetch/-/fetch-0.3.3.tgz",
+      "integrity": "sha512-2gABLf0VEI86Sxo6YhGKQYK1tGhTZ4y+3TrCWputnupEZxuS/hw6+pFw9ceXZ3v9nnMNthzsAEcaAQ3V/tXsqg==",
       "license": "MIT",
       "dependencies": {
-        "@atproto-labs/pipe": "^0.2.2"
+        "@atproto-labs/pipe": "^0.2.3"
       },
       "engines": {
         "node": ">=22"
       }
     },
     "node_modules/@atproto-labs/pipe": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@atproto-labs/pipe/-/pipe-0.2.2.tgz",
-      "integrity": "sha512-4xCUqB96I7WWGRlJvkJeOi8fpkrbB5pwW471hpJefqgb8Ep0UHP1solF3QOK+fms42cTfwkZCx3ExfGk6xeOuA==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@atproto-labs/pipe/-/pipe-0.2.3.tgz",
+      "integrity": "sha512-hsjkaKGdhEGKhXuOOfIeYyZSQZfw007AXQJak/QTd9pLY1wHUJG85a9+u13xoMeav95gHkBRzswti7+kqsxgdw==",
       "license": "MIT",
       "engines": {
         "node": ">=22"
       }
     },
     "node_modules/@atproto-labs/simple-store": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@atproto-labs/simple-store/-/simple-store-0.4.2.tgz",
-      "integrity": "sha512-kWF6GCJBWeG+nwakUInainJi2pb4lukQ4ffkpEpLaavZ7ogKSrbsvA7ZFJWGjVsJNVxcamtXeLEl1NpFufs/4g==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@atproto-labs/simple-store/-/simple-store-0.4.3.tgz",
+      "integrity": "sha512-ML1HAEtQIixkcU4FCGbZtAkoHTfmXDi63tNVuSSPG/cVUKyrUURg6Cr1bcfvbbkMTwRj9abEwa3JZR7UUYi4Ew==",
       "license": "MIT",
       "engines": {
         "node": ">=22"
       }
     },
     "node_modules/@atproto-labs/simple-store-memory": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@atproto-labs/simple-store-memory/-/simple-store-memory-0.2.2.tgz",
-      "integrity": "sha512-uhEO3j9I09ksdJxYK0B9hl6X5ZUZ+poUBBq6qpulOjbIlzFPhRG/i23ZnzHhQaeT17LQBeP8xvSPk1QzDsblMA==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@atproto-labs/simple-store-memory/-/simple-store-memory-0.2.3.tgz",
+      "integrity": "sha512-RtL48op8Db/QFNbW+9Y+Os6DOMqysOkoG5QelTZ0qcZt/j0pUBY8v2zSr5/faVJ5Y30h1cONxMydV48tVWf8pg==",
       "license": "MIT",
       "dependencies": {
-        "@atproto-labs/simple-store": "^0.4.2",
+        "@atproto-labs/simple-store": "^0.4.3",
         "lru-cache": "^10.2.0"
       },
       "engines": {
@@ -72,14 +72,14 @@
       }
     },
     "node_modules/@atproto/common": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/@atproto/common/-/common-0.6.4.tgz",
-      "integrity": "sha512-o1T96pBvjFFWkfYREazjPYp3UqON6ZngZmJturUihMjO6E1R2H5W0M2WlwDOECpSX6qvXShi5b5K+KJyoije2Q==",
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@atproto/common/-/common-0.6.5.tgz",
+      "integrity": "sha512-D3JWWRVTbwxFI2eXqbTqHUi+RXXIupQCyWIQIm1dV/2b0tvSrlRsZQglKRYkIJnIbO5F+dlvdn8KfPGpZlpi9A==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/common-web": "^0.5.2",
-        "@atproto/lex-cbor": "^0.1.2",
-        "@atproto/lex-data": "^0.1.3",
+        "@atproto/common-web": "^0.5.3",
+        "@atproto/lex-cbor": "^0.1.3",
+        "@atproto/lex-data": "^0.1.4",
         "multiformats": "^13.0.0",
         "pino": "^10.3.1"
       },
@@ -88,14 +88,14 @@
       }
     },
     "node_modules/@atproto/common-web": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@atproto/common-web/-/common-web-0.5.2.tgz",
-      "integrity": "sha512-oO0JEvM7MM7iXMngq6V51IJlzBZFhFJoDjnGnQT75EO94/8Q5hnM/LP+a8KyWjcBcpcSZwQ0bukNv9phZONdGA==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@atproto/common-web/-/common-web-0.5.3.tgz",
+      "integrity": "sha512-FkMhOcNv1y7r5984+zXB+uMN4zJ4QFLEbZrYyQo6bNCf/Kfav/pEHXXENlaZEOweq2NYXf+tr2giMssBuM9u5A==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/lex-data": "^0.1.3",
-        "@atproto/lex-json": "^0.1.2",
-        "@atproto/syntax": "^0.6.3",
+        "@atproto/lex-data": "^0.1.4",
+        "@atproto/lex-json": "^0.1.3",
+        "@atproto/syntax": "^0.6.4",
         "zod": "^3.23.8"
       },
       "engines": {
@@ -103,9 +103,9 @@
       }
     },
     "node_modules/@atproto/crypto": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@atproto/crypto/-/crypto-0.5.2.tgz",
-      "integrity": "sha512-WU3FN9mx1tnOcbZjH2zJQcvvI5pTyEuHetEhrZSv/a1eL0dJgrDtWfJnht7p9FrpdcDVL/xgAKewzwD5wVYBXQ==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@atproto/crypto/-/crypto-0.5.3.tgz",
+      "integrity": "sha512-Ea5VwU+ofVXrm4BWpTa7gI9kz7A6NwPpCY6r0f5k8UJpNq0GDHSb1F5MdsFDVNnSK5bEI7DIMNZwspkNsAKOgA==",
       "license": "MIT",
       "dependencies": {
         "@noble/curves": "^1.7.0",
@@ -117,9 +117,9 @@
       }
     },
     "node_modules/@atproto/did": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@atproto/did/-/did-0.5.2.tgz",
-      "integrity": "sha512-ilVQ1Nrio6EhL61mt7zPgM0Vnb1N2mOisVP32bUBa+PflGI0wRneflacWyVyyN78RdFJDcPQBmv0dfSNgOcbQA==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@atproto/did/-/did-0.5.3.tgz",
+      "integrity": "sha512-nKcdu5qB9iNJFaBeQOQUJ+6mA1npFcZ3DmD0xB+etkMRd/3UvOQql/CvcMZaYzl+eGoVs1JDdEsvoZz+idfhaw==",
       "license": "MIT",
       "dependencies": {
         "zod": "^3.23.8"
@@ -129,17 +129,17 @@
       }
     },
     "node_modules/@atproto/lex": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/@atproto/lex/-/lex-0.1.5.tgz",
-      "integrity": "sha512-9jF83rw9Zk/g8bXCBC7+Nx59rg6mIgntSP4mXbhh1oArgSLViBSTAfLp9U5X0KdHoCOvMdOih8+DlknLjx0xPA==",
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@atproto/lex/-/lex-0.1.7.tgz",
+      "integrity": "sha512-BynDCIZ3kKalhRcj2lCTW5+ksKmfTOgUVYHi9Z1VqYnAfW8ZaA9MKdN1OBZvitDJzx1qMbmGS+JMszm8yFs5gQ==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/lex-builder": "^0.1.4",
-        "@atproto/lex-client": "^0.1.5",
-        "@atproto/lex-data": "^0.1.3",
-        "@atproto/lex-installer": "^0.1.2",
-        "@atproto/lex-json": "^0.1.2",
-        "@atproto/lex-schema": "^0.1.5",
+        "@atproto/lex-builder": "^0.1.5",
+        "@atproto/lex-client": "^0.2.1",
+        "@atproto/lex-data": "^0.1.4",
+        "@atproto/lex-installer": "^0.1.4",
+        "@atproto/lex-json": "^0.1.3",
+        "@atproto/lex-schema": "^0.1.6",
         "tslib": "^2.8.1",
         "yargs": "^18.0.0"
       },
@@ -152,13 +152,13 @@
       }
     },
     "node_modules/@atproto/lex-builder": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@atproto/lex-builder/-/lex-builder-0.1.4.tgz",
-      "integrity": "sha512-QClKf7tlUmx6HPez6NQGhh1JlGafM3RRYrR13TstL+Vz0HFCdKQ4HgQzF1/Q4ykDIm/PGhHSWw72bI0W3mwOAQ==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@atproto/lex-builder/-/lex-builder-0.1.5.tgz",
+      "integrity": "sha512-wh4nOGD0NuXBbRfrb4XBQZruuboRZs+rfhv2yWCR2zeEAWEqVU2+hVVNdQPDfa+rkghXENF31JIKftbz9NF6Ww==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/lex-document": "^0.1.2",
-        "@atproto/lex-schema": "^0.1.5",
+        "@atproto/lex-document": "^0.1.3",
+        "@atproto/lex-schema": "^0.1.6",
         "prettier": "^3.2.5",
         "ts-morph": "^27.0.0",
         "tslib": "^2.8.1"
@@ -168,12 +168,12 @@
       }
     },
     "node_modules/@atproto/lex-cbor": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@atproto/lex-cbor/-/lex-cbor-0.1.2.tgz",
-      "integrity": "sha512-Ccs4nnlzjWXGHiMnb9LB8tOJpqoVf8f3pAA6Qx72U2/DuK4agkONn90YUemYY5wHPLdZKpvz6O4/gCGJGXE+MA==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@atproto/lex-cbor/-/lex-cbor-0.1.3.tgz",
+      "integrity": "sha512-L9g6X8DAus+CrgrxwKehn5EUjsYuuySmUttkaHngXAT9+QOIsGqe7Bdcfd2FBZxomFjCamp5hFrN5M4hrGpdNA==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/lex-data": "^0.1.3",
+        "@atproto/lex-data": "^0.1.4",
         "cborg": "^4.5.8",
         "tslib": "^2.8.1"
       },
@@ -182,14 +182,14 @@
       }
     },
     "node_modules/@atproto/lex-client": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/@atproto/lex-client/-/lex-client-0.1.5.tgz",
-      "integrity": "sha512-1Ajx/+m3iVaAmgeZedj4d/mYyrazHQ96EU1d8/Vub7zYk0WaNzKGA68Vi0K74f8u340sxKXqYa3O3233xecLNw==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@atproto/lex-client/-/lex-client-0.2.1.tgz",
+      "integrity": "sha512-b/LXpLt3HZZEfItruCcPpHUbzoo+LjoOp0GetlTuHX0UnJYqzk4zLg5qSMTDo4JoHU4hFO1+26R6cg986ZvUAg==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/lex-data": "^0.1.3",
-        "@atproto/lex-json": "^0.1.2",
-        "@atproto/lex-schema": "^0.1.5",
+        "@atproto/lex-data": "^0.1.4",
+        "@atproto/lex-json": "^0.1.3",
+        "@atproto/lex-schema": "^0.1.6",
         "tslib": "^2.8.1"
       },
       "engines": {
@@ -197,9 +197,9 @@
       }
     },
     "node_modules/@atproto/lex-data": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@atproto/lex-data/-/lex-data-0.1.3.tgz",
-      "integrity": "sha512-ysqMYW6cIKce52/+EIbTa+I4pLqZQSBP9aGImN88vAQtd1oZBKPmut6dQk00xSQ8PW9REJRuIHNSFAF4HD+fsw==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@atproto/lex-data/-/lex-data-0.1.4.tgz",
+      "integrity": "sha512-f9U95sk0zUtxHktvK59peU+Shd0cIUYV68p//GS7sfdkAxUIeaspvX6CY+Quv9Oa4aozmsXI52SjaNn1wuU8RQ==",
       "license": "MIT",
       "dependencies": {
         "multiformats": "^13.0.0",
@@ -212,12 +212,12 @@
       }
     },
     "node_modules/@atproto/lex-document": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@atproto/lex-document/-/lex-document-0.1.2.tgz",
-      "integrity": "sha512-UqTxFbgbbE4AzJ6sO/0yJqUgbmBapswnBUKxwIexn+CiWJGMr3OQtbCLYPd+nQ/Ffkmxrwg3ec8lNeJn/hQX4A==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@atproto/lex-document/-/lex-document-0.1.3.tgz",
+      "integrity": "sha512-29NHO3dLlrJCBc7Fh9A0o7ZH2HAvhojmwR9kF1sEL+4GwMg0W/1JfMnF38aA/dT0ytFuZyryK0oCkYCoMVqHNw==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/lex-schema": "^0.1.5",
+        "@atproto/lex-schema": "^0.1.6",
         "core-js": "^3",
         "tslib": "^2.8.1"
       },
@@ -226,18 +226,18 @@
       }
     },
     "node_modules/@atproto/lex-installer": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@atproto/lex-installer/-/lex-installer-0.1.2.tgz",
-      "integrity": "sha512-2yfEEypSd2ofPg0Xl7cvGA3NtnKAg4cQJpb/DMLZ+s0eDBNqPaRZmMuvHkiCkB5rcOpPBcM6KVVWhNZh9D+OiA==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@atproto/lex-installer/-/lex-installer-0.1.4.tgz",
+      "integrity": "sha512-H6AhjPPYbH+6sJ9xNY6zrA1t2IVdze8idk6SgJqQnGESL+v3bblVsfYsx394DveEnQ7pO2sikKwkxZ9emBnBbQ==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/lex-builder": "^0.1.4",
-        "@atproto/lex-cbor": "^0.1.2",
-        "@atproto/lex-data": "^0.1.3",
-        "@atproto/lex-document": "^0.1.2",
-        "@atproto/lex-resolver": "^0.1.2",
-        "@atproto/lex-schema": "^0.1.5",
-        "@atproto/syntax": "^0.6.3",
+        "@atproto/lex-builder": "^0.1.5",
+        "@atproto/lex-cbor": "^0.1.3",
+        "@atproto/lex-data": "^0.1.4",
+        "@atproto/lex-document": "^0.1.3",
+        "@atproto/lex-resolver": "^0.1.4",
+        "@atproto/lex-schema": "^0.1.6",
+        "@atproto/syntax": "^0.6.4",
         "tslib": "^2.8.1"
       },
       "engines": {
@@ -245,12 +245,12 @@
       }
     },
     "node_modules/@atproto/lex-json": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@atproto/lex-json/-/lex-json-0.1.2.tgz",
-      "integrity": "sha512-58nIjoWX0c8T5fcoPPmIaShxKZgfPMhNmrprtR7GuN4PzyMwm59A3CLlKAzzR+vjI3IidEMU+enpLuwUT8L+Nw==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@atproto/lex-json/-/lex-json-0.1.3.tgz",
+      "integrity": "sha512-Ch2w9bCLFOwWINFFxpZo6DBW7+ZxkehciU3P8N94gSyENLe3/5WWXHdHvkiH7EXZrpI7fKY8nVWn4GIL0ttqxw==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/lex-data": "^0.1.3",
+        "@atproto/lex-data": "^0.1.4",
         "tslib": "^2.8.1"
       },
       "engines": {
@@ -258,19 +258,19 @@
       }
     },
     "node_modules/@atproto/lex-resolver": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@atproto/lex-resolver/-/lex-resolver-0.1.2.tgz",
-      "integrity": "sha512-BOy2zvr0pmLUlzSFzFi8wTc5bZlSUkVa98KSUpSqn6D1xP+Qmqpb2eK2jo0gjNOu3+lB8f3WS6lKw0DpUIN/JQ==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@atproto/lex-resolver/-/lex-resolver-0.1.4.tgz",
+      "integrity": "sha512-Q114oD+M3mF0owQDds28r7IY+7H7/ajknceXMLtgwUQ9j9Oeqwrgl3iH0Kbl5vzxfrq8ZPYqFyqzRppr7RsSXQ==",
       "license": "MIT",
       "dependencies": {
-        "@atproto-labs/did-resolver": "^0.3.3",
-        "@atproto/crypto": "^0.5.2",
-        "@atproto/lex-client": "^0.1.5",
-        "@atproto/lex-data": "^0.1.3",
-        "@atproto/lex-document": "^0.1.2",
-        "@atproto/lex-schema": "^0.1.5",
-        "@atproto/repo": "^0.10.2",
-        "@atproto/syntax": "^0.6.3",
+        "@atproto-labs/did-resolver": "^0.3.4",
+        "@atproto/crypto": "^0.5.3",
+        "@atproto/lex-client": "^0.2.1",
+        "@atproto/lex-data": "^0.1.4",
+        "@atproto/lex-document": "^0.1.3",
+        "@atproto/lex-schema": "^0.1.6",
+        "@atproto/repo": "^0.10.3",
+        "@atproto/syntax": "^0.6.4",
         "tslib": "^2.8.1"
       },
       "engines": {
@@ -278,13 +278,13 @@
       }
     },
     "node_modules/@atproto/lex-schema": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/@atproto/lex-schema/-/lex-schema-0.1.5.tgz",
-      "integrity": "sha512-+4lxSYY+F7/JwJXRdqNfU4U+UhiSzfIlretR+R9JT+BHOKEwl7zbJVV+UROiCAmxZMgxqgM6v9Oho0s59Wyovw==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@atproto/lex-schema/-/lex-schema-0.1.6.tgz",
+      "integrity": "sha512-4AMwaB0HumrQuaXmYQDHeeZGKj8x6ACiIb8fX96Y0ZZaiM/JUmgZl0LTl/1kbQ7cGPfG+NoGsiuz1iJuFhTjxw==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/lex-data": "^0.1.3",
-        "@atproto/syntax": "^0.6.3",
+        "@atproto/lex-data": "^0.1.4",
+        "@atproto/syntax": "^0.6.4",
         "@standard-schema/spec": "^1.1.0",
         "tslib": "^2.8.1"
       },
@@ -293,17 +293,17 @@
       }
     },
     "node_modules/@atproto/repo": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@atproto/repo/-/repo-0.10.2.tgz",
-      "integrity": "sha512-/0RdKIQ5ty93nqGHxzf3naf+kGHPDWMQRutR2TKpOkf+VSyoDLMJK2fOdgtcUFETfT8L6bekGwm7rJxe77RbeA==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@atproto/repo/-/repo-0.10.3.tgz",
+      "integrity": "sha512-Zk4xWtE/Mrf1+dAUwJLnWbeYwnvLMXF102mewzhPwsVkU63LsYO6nP9e5d4nqW/ClFDg9WKXo8zAv4792OnZNw==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/common": "^0.6.4",
-        "@atproto/common-web": "^0.5.2",
-        "@atproto/crypto": "^0.5.2",
-        "@atproto/lex-cbor": "^0.1.2",
-        "@atproto/lex-data": "^0.1.3",
-        "@atproto/syntax": "^0.6.3",
+        "@atproto/common": "^0.6.5",
+        "@atproto/common-web": "^0.5.3",
+        "@atproto/crypto": "^0.5.3",
+        "@atproto/lex-cbor": "^0.1.3",
+        "@atproto/lex-data": "^0.1.4",
+        "@atproto/syntax": "^0.6.4",
         "varint": "^6.0.0",
         "zod": "^3.23.8"
       },
@@ -312,9 +312,9 @@
       }
     },
     "node_modules/@atproto/syntax": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/@atproto/syntax/-/syntax-0.6.3.tgz",
-      "integrity": "sha512-io7Ck4o+40iFXhetHYoEtok2gZ8cWcJ1yRftEHe5AmAF0dSGcYmclbx5GatVew59taw+eSG7Ty5D3llop/0BhA==",
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@atproto/syntax/-/syntax-0.6.4.tgz",
+      "integrity": "sha512-ELgpShRGMF65cvLXcoMCZFL0HBzy67yz/Nlhox3yOtTh120B09KjjvZYXhMysVog3nUJqv2EW5rf1VRYCeM/hw==",
       "license": "MIT",
       "dependencies": {
         "iso-datestring-validator": "^2.2.2",
@@ -570,9 +570,9 @@
       "license": "MIT"
     },
     "node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -619,9 +619,9 @@
       "license": "MIT"
     },
     "node_modules/prettier": {
-      "version": "3.9.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.3.tgz",
-      "integrity": "sha512-HWmu+K+zvHNpaMfSnYeqdqrDbR16cuIXaPx8WoHaviQkDJh1/0BNtOZmHVQI5jc3wXv0H1yXc9wjvFdXh+n3hQ==",
+      "version": "3.9.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.4.tgz",
+      "integrity": "sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg==",
       "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"

--- a/generator/package.json
+++ b/generator/package.json
@@ -4,6 +4,6 @@
   "private": true,
   "description": "Pins the @atproto/lex release whose lexicon JSON is consumed by :generator. Not published.",
   "dependencies": {
-    "@atproto/lex": "0.1.5"
+    "@atproto/lex": "0.1.7"
   }
 }


### PR DESCRIPTION
## Lexicon corpus update

Bumps `@atproto/lex` from `0.1.5` to `0.1.7`.

### lexicons.json changes

**Added** (0):
- _(none)_

**Removed** (0):
- _(none)_

**Updated** (0):
- _(none)_

### What reviewers should check

- [ ] CI passes (generator regeneration, runtime tests, sample APK build)
- [ ] Skim the generator golden-file diff if any generator logic was affected
- [ ] Verify no new lexicon references are missing Kotlin types (compile failure in `:models`)

### Release impact

If this PR merges with only additive changes (new types, new fields), expect a `feat:` release. If it removes or renames anything, expect a `BREAKING CHANGE:` release — update the PR title to `feat!: bump @atproto/lex to <version>` before merging.