### PR TITLE
chore(lexicons): re-vendor drifted chat.bsky.convo overlays + adopt group join-links

### DIFF
--- a/generator/overlay-lexicons.json
+++ b/generator/overlay-lexicons.json
@@ -51,26 +51,42 @@
     },
     {
       "nsid": "chat.bsky.convo.defs",
-      "source": "https://github.com/bluesky-social/atproto/blob/4f1e20387bb2a212e263590ac7a3458e8f939091/lexicons/chat/bsky/convo/defs.json",
-      "commit": "4f1e20387bb2a212e263590ac7a3458e8f939091",
-      "vendoredAt": "2026-07-01",
+      "source": "https://github.com/bluesky-social/atproto/blob/9b05af9168fb11131160980a373415262aadf549/lexicons/chat/bsky/convo/defs.json",
+      "commit": "9b05af9168fb11131160980a373415262aadf549",
+      "vendoredAt": "2026-07-07",
       "reason": "PINNED shadow (removeWhenPublished=false). Already published on-network; vendored to add message replies (messageInput/messageView.replyTo, #replyRef, #messageBeforeUserJoinedGroupView) ahead of the network. RE-VENDOR on drift; retire MANUALLY once the on-network convo.defs includes replyTo.",
       "removeWhenPublished": false
     },
     {
       "nsid": "chat.bsky.convo.sendMessage",
-      "source": "https://github.com/bluesky-social/atproto/blob/4f1e20387bb2a212e263590ac7a3458e8f939091/lexicons/chat/bsky/convo/sendMessage.json",
-      "commit": "4f1e20387bb2a212e263590ac7a3458e8f939091",
-      "vendoredAt": "2026-07-01",
+      "source": "https://github.com/bluesky-social/atproto/blob/9b05af9168fb11131160980a373415262aadf549/lexicons/chat/bsky/convo/sendMessage.json",
+      "commit": "9b05af9168fb11131160980a373415262aadf549",
+      "vendoredAt": "2026-07-07",
       "reason": "PINNED shadow (removeWhenPublished=false). Already published on-network; vendored for the ReplyTargetNotFound error that pairs with messageInput.replyTo (see chat.bsky.convo.defs). RE-VENDOR on drift; retire MANUALLY once the on-network sendMessage includes it.",
       "removeWhenPublished": false
     },
     {
       "nsid": "chat.bsky.convo.sendMessageBatch",
-      "source": "https://github.com/bluesky-social/atproto/blob/4f1e20387bb2a212e263590ac7a3458e8f939091/lexicons/chat/bsky/convo/sendMessageBatch.json",
-      "commit": "4f1e20387bb2a212e263590ac7a3458e8f939091",
-      "vendoredAt": "2026-07-01",
+      "source": "https://github.com/bluesky-social/atproto/blob/9b05af9168fb11131160980a373415262aadf549/lexicons/chat/bsky/convo/sendMessageBatch.json",
+      "commit": "9b05af9168fb11131160980a373415262aadf549",
+      "vendoredAt": "2026-07-07",
       "reason": "PINNED shadow (removeWhenPublished=false). Already published on-network; vendored for the ReplyTargetNotFound error that pairs with the batch reply input. RE-VENDOR on drift; retire MANUALLY once the on-network sendMessageBatch includes it.",
+      "removeWhenPublished": false
+    },
+    {
+      "nsid": "chat.bsky.embed.joinLink",
+      "source": "https://github.com/bluesky-social/atproto/blob/9b05af9168fb11131160980a373415262aadf549/lexicons/chat/bsky/embed/joinLink.json",
+      "commit": "9b05af9168fb11131160980a373415262aadf549",
+      "vendoredAt": "2026-07-07",
+      "reason": "New group join-link message embed, pulled in as a dependency of the re-vendored chat.bsky.convo.defs message/messageView embed unions. Present in bluesky-social/atproto main but unpublished on-network (npx lex install -> RecordNotFound). Its #view refs the join-link preview defs added to the chat.bsky.group.defs superset shadow. Retire once publishable.",
+      "removeWhenPublished": true
+    },
+    {
+      "nsid": "chat.bsky.group.defs",
+      "source": "https://github.com/bluesky-social/atproto/blob/9b05af9168fb11131160980a373415262aadf549/lexicons/chat/bsky/group/defs.json",
+      "commit": "9b05af9168fb11131160980a373415262aadf549",
+      "vendoredAt": "2026-07-07",
+      "reason": "PINNED SUPERSET shadow (removeWhenPublished=false). Merges upstream main's new join-link preview defs (joinLinkPreviewView / disabledJoinLinkPreviewView / invalidJoinLinkPreviewView / joinLinkViewerState / joinRequestConvoView — needed by chat.bsky.embed.joinLink#view) with our still-on-network groupPublicView, which main deleted alongside chat.bsky.group.getGroupPublicInfo even though both remain published on-network. Intentionally NOT byte-equal to main (it re-adds groupPublicView), so it will always read as DRIFTED here — that is expected. RE-VENDOR by re-merging upstream + groupPublicView on drift; retire MANUALLY once the network catches up (join-links published AND getGroupPublicInfo removed).",
       "removeWhenPublished": false
     }
   ]

--- a/generator/overlay-lexicons/chat/bsky/convo/defs.json
+++ b/generator/overlay-lexicons/chat/bsky/convo/defs.json
@@ -1,179 +1,96 @@
 {
+  "lexicon": 1,
   "id": "chat.bsky.convo.defs",
   "defs": {
     "convoKind": {
       "type": "string",
-      "knownValues": [
-        "direct",
-        "group"
-      ]
+      "knownValues": ["direct", "group"]
     },
-    "convoView": {
-      "type": "object",
-      "required": [
-        "id",
-        "rev",
-        "members",
-        "muted",
-        "unreadCount"
-      ],
-      "properties": {
-        "id": {
-          "type": "string"
-        },
-        "rev": {
-          "type": "string"
-        },
-        "kind": {
-          "refs": [
-            "#directConvo",
-            "#groupConvo"
-          ],
-          "type": "union",
-          "description": "Union field that has data specific to different kinds of convos."
-        },
-        "muted": {
-          "type": "boolean"
-        },
-        "status": {
-          "ref": "#convoStatus",
-          "type": "ref",
-          "description": "Convo status for the viewer member (not the convo itself)."
-        },
-        "members": {
-          "type": "array",
-          "items": {
-            "ref": "chat.bsky.actor.defs#profileViewBasic",
-            "type": "ref"
-          },
-          "description": "Members of this conversation. For direct convos, it will be an immutable list of the 2 members. For group convos, it will a list of important members (the first few members, the viewer, the member who invited the viewer, the member who sent the last message, the member who sent the last reaction), but will not contain the full list of members. NOTE: TBD an endpoint to list all members."
-        },
-        "lastMessage": {
-          "refs": [
-            "#messageView",
-            "#deletedMessageView",
-            "#systemMessageView"
-          ],
-          "type": "union"
-        },
-        "unreadCount": {
-          "type": "integer"
-        },
-        "lastReaction": {
-          "refs": [
-            "#messageAndReactionView"
-          ],
-          "type": "union"
-        }
-      }
-    },
-    "groupConvo": {
-      "type": "object",
-      "required": [
-        "name",
-        "lockStatus"
-      ],
-      "properties": {
-        "name": {
-          "type": "string",
-          "maxLength": 1280,
-          "description": "The display name of the group conversation.",
-          "maxGraphemes": 128
-        },
-        "joinLink": {
-          "ref": "chat.bsky.group.defs#joinLinkView",
-          "type": "ref"
-        },
-        "lockStatus": {
-          "ref": "#convoLockStatus",
-          "type": "ref",
-          "description": "The lock status of the conversation."
-        }
-      },
-      "description": "[NOTE: This is under active development and should be considered unstable while this note is here]."
-    },
-    "messageRef": {
-      "type": "object",
-      "required": [
-        "did",
-        "messageId",
-        "convoId"
-      ],
-      "properties": {
-        "did": {
-          "type": "string",
-          "format": "did"
-        },
-        "convoId": {
-          "type": "string"
-        },
-        "messageId": {
-          "type": "string"
-        }
-      }
+    "convoLockStatus": {
+      "type": "string",
+      "knownValues": ["unlocked", "locked", "locked-permanently"]
     },
     "convoStatus": {
       "type": "string",
-      "knownValues": [
-        "request",
-        "accepted"
-      ]
+      "knownValues": ["request", "accepted"]
     },
-    "directConvo": {
+    "convoRef": {
       "type": "object",
-      "properties": {},
-      "description": "[NOTE: This is under active development and should be considered unstable while this note is here]."
-    },
-    "messageView": {
-      "type": "object",
-      "required": [
-        "id",
-        "rev",
-        "text",
-        "sender",
-        "sentAt"
-      ],
+      "required": ["did", "convoId"],
       "properties": {
-        "id": {
-          "type": "string"
-        },
-        "rev": {
-          "type": "string"
-        },
+        "did": { "type": "string", "format": "did" },
+        "convoId": { "type": "string" }
+      }
+    },
+    "messageRef": {
+      "type": "object",
+      "required": ["did", "messageId", "convoId"],
+      "properties": {
+        "did": { "type": "string", "format": "did" },
+        "convoId": { "type": "string" },
+        "messageId": { "type": "string" }
+      }
+    },
+    "messageInput": {
+      "type": "object",
+      "required": ["text"],
+      "properties": {
         "text": {
           "type": "string",
           "maxLength": 10000,
           "maxGraphemes": 1000
         },
+        "facets": {
+          "type": "array",
+          "description": "Annotations of text (mentions, URLs, hashtags, etc)",
+          "items": { "type": "ref", "ref": "app.bsky.richtext.facet" }
+        },
         "embed": {
-          "refs": [
-            "app.bsky.embed.record#view"
-          ],
-          "type": "union"
+          "type": "union",
+          "refs": ["app.bsky.embed.record", "chat.bsky.embed.joinLink"]
+        },
+        "replyTo": {
+          "description": "If set, the message this message is replying to. The referenced message must be in the same convo.",
+          "type": "ref",
+          "ref": "#replyRef"
+        }
+      }
+    },
+    "replyRef": {
+      "description": "A reference to another message within the same convo, used to indicate that a message is a reply to it.",
+      "type": "object",
+      "required": ["messageId"],
+      "properties": {
+        "messageId": { "type": "string" }
+      }
+    },
+    "messageView": {
+      "type": "object",
+      "required": ["id", "rev", "text", "sender", "sentAt"],
+      "properties": {
+        "id": { "type": "string" },
+        "rev": { "type": "string" },
+        "text": {
+          "type": "string",
+          "maxLength": 10000,
+          "maxGraphemes": 1000
         },
         "facets": {
           "type": "array",
-          "items": {
-            "ref": "app.bsky.richtext.facet",
-            "type": "ref"
-          },
-          "description": "Annotations of text (mentions, URLs, hashtags, etc)"
+          "description": "Annotations of text (mentions, URLs, hashtags, etc)",
+          "items": { "type": "ref", "ref": "app.bsky.richtext.facet" }
         },
-        "sender": {
-          "ref": "#messageViewSender",
-          "type": "ref"
-        },
-        "sentAt": {
-          "type": "string",
-          "format": "datetime"
+        "embed": {
+          "type": "union",
+          "refs": [
+            "app.bsky.embed.record#view",
+            "chat.bsky.embed.joinLink#view"
+          ]
         },
         "reactions": {
           "type": "array",
-          "items": {
-            "ref": "#reactionView",
-            "type": "ref"
-          },
-          "description": "Reactions to this message, in ascending order of creation time."
+          "description": "Reactions to this message, in ascending order of creation time.",
+          "items": { "type": "ref", "ref": "#reactionView" }
         },
         "replyTo": {
           "description": "If set, the message this message is replying to. The full view of the referenced message is embedded so the client can render it inline. Only a single level is embedded: the embedded message will not itself have a populated 'replyTo' field even if it was also a reply.",
@@ -183,544 +100,27 @@
             "#deletedMessageView",
             "#messageBeforeUserJoinedGroupView"
           ]
-        }
+        },
+        "sender": { "type": "ref", "ref": "#messageViewSender" },
+        "sentAt": { "type": "string", "format": "datetime" }
       }
     },
-    "logAddMember": {
+    "systemMessageReferredUser": {
       "type": "object",
-      "required": [
-        "rev",
-        "convoId",
-        "message"
-      ],
+      "required": ["did"],
       "properties": {
-        "rev": {
-          "type": "string"
-        },
-        "convoId": {
-          "type": "string"
-        },
-        "message": {
-          "ref": "#systemMessageDataAddMember",
-          "type": "ref"
-        }
-      },
-      "description": "[NOTE: This is under active development and should be considered unstable while this note is here]. Event indicating a member was added to a group convo. The member who was added gets a logBeginConvo (to create the convo) but also a logAddMember (to show the system message as the first message the user sees)."
-    },
-    "logEditGroup": {
-      "type": "object",
-      "required": [
-        "rev",
-        "convoId",
-        "message"
-      ],
-      "properties": {
-        "rev": {
-          "type": "string"
-        },
-        "convoId": {
-          "type": "string"
-        },
-        "message": {
-          "ref": "#systemMessageDataEditGroup",
-          "type": "ref"
-        }
-      },
-      "description": "[NOTE: This is under active development and should be considered unstable while this note is here]. Event indicating info about group convo was edited."
-    },
-    "logLockConvo": {
-      "type": "object",
-      "required": [
-        "rev",
-        "convoId",
-        "message"
-      ],
-      "properties": {
-        "rev": {
-          "type": "string"
-        },
-        "convoId": {
-          "type": "string"
-        },
-        "message": {
-          "ref": "#systemMessageDataLockConvo",
-          "type": "ref"
-        }
-      },
-      "description": "[NOTE: This is under active development and should be considered unstable while this note is here]. Event indicating a group convo was locked."
-    },
-    "logMuteConvo": {
-      "type": "object",
-      "required": [
-        "rev",
-        "convoId"
-      ],
-      "properties": {
-        "rev": {
-          "type": "string"
-        },
-        "convoId": {
-          "type": "string"
-        }
-      },
-      "description": "Event indicating the viewer muted a convo. Can be direct or group."
-    },
-    "logReadConvo": {
-      "type": "object",
-      "required": [
-        "rev",
-        "convoId",
-        "message"
-      ],
-      "properties": {
-        "rev": {
-          "type": "string"
-        },
-        "convoId": {
-          "type": "string"
-        },
-        "message": {
-          "refs": [
-            "#messageView",
-            "#deletedMessageView",
-            "#systemMessageView"
-          ],
-          "type": "union"
-        }
-      },
-      "description": "[NOTE: This is under active development and should be considered unstable while this note is here]. Event indicating a convo was read up to a certain message."
-    },
-    "messageInput": {
-      "type": "object",
-      "required": [
-        "text"
-      ],
-      "properties": {
-        "text": {
-          "type": "string",
-          "maxLength": 10000,
-          "maxGraphemes": 1000
-        },
-        "embed": {
-          "refs": [
-            "app.bsky.embed.record"
-          ],
-          "type": "union"
-        },
-        "facets": {
-          "type": "array",
-          "items": {
-            "ref": "app.bsky.richtext.facet",
-            "type": "ref"
-          },
-          "description": "Annotations of text (mentions, URLs, hashtags, etc)"
-        },
-        "replyTo": {
-          "description": "If set, the message this message is replying to. The referenced message must be in the same convo.",
-          "type": "ref",
-          "ref": "#replyRef"
-        }
-      }
-    },
-    "reactionView": {
-      "type": "object",
-      "required": [
-        "value",
-        "sender",
-        "createdAt"
-      ],
-      "properties": {
-        "value": {
-          "type": "string"
-        },
-        "sender": {
-          "ref": "#reactionViewSender",
-          "type": "ref"
-        },
-        "createdAt": {
-          "type": "string",
-          "format": "datetime"
-        }
-      }
-    },
-    "logBeginConvo": {
-      "type": "object",
-      "required": [
-        "rev",
-        "convoId"
-      ],
-      "properties": {
-        "rev": {
-          "type": "string"
-        },
-        "convoId": {
-          "type": "string"
-        }
-      },
-      "description": "Event indicating a convo containing the viewer was started. Can be direct or group. When a member is added to a group convo, they also get this event."
-    },
-    "logLeaveConvo": {
-      "type": "object",
-      "required": [
-        "rev",
-        "convoId"
-      ],
-      "properties": {
-        "rev": {
-          "type": "string"
-        },
-        "convoId": {
-          "type": "string"
-        }
-      },
-      "description": "Event indicating the viewer left a convo. Can be direct or group."
-    },
-    "logMemberJoin": {
-      "type": "object",
-      "required": [
-        "rev",
-        "convoId",
-        "message"
-      ],
-      "properties": {
-        "rev": {
-          "type": "string"
-        },
-        "convoId": {
-          "type": "string"
-        },
-        "message": {
-          "ref": "#systemMessageDataMemberJoin",
-          "type": "ref"
-        }
-      },
-      "description": "[NOTE: This is under active development and should be considered unstable while this note is here]. Event indicating a member joined a group convo via join link. The member who was added gets a logBeginConvo (to create the convo) but also a logMemberJoin (to show the system message as the first message the user sees)."
-    },
-    "logAcceptConvo": {
-      "type": "object",
-      "required": [
-        "rev",
-        "convoId"
-      ],
-      "properties": {
-        "rev": {
-          "type": "string"
-        },
-        "convoId": {
-          "type": "string"
-        }
-      },
-      "description": "Event indicating the viewer accepted a convo, and it can be moved out of the request inbox. Can be direct or group."
-    },
-    "logAddReaction": {
-      "type": "object",
-      "required": [
-        "rev",
-        "convoId",
-        "message",
-        "reaction"
-      ],
-      "properties": {
-        "rev": {
-          "type": "string"
-        },
-        "convoId": {
-          "type": "string"
-        },
-        "message": {
-          "refs": [
-            "#messageView",
-            "#deletedMessageView"
-          ],
-          "type": "union"
-        },
-        "reaction": {
-          "ref": "#reactionView",
-          "type": "ref"
-        }
-      },
-      "description": "Event indicating a reaction was added to a message."
-    },
-    "logMemberLeave": {
-      "type": "object",
-      "required": [
-        "rev",
-        "convoId",
-        "message"
-      ],
-      "properties": {
-        "rev": {
-          "type": "string"
-        },
-        "convoId": {
-          "type": "string"
-        },
-        "message": {
-          "ref": "#systemMessageDataMemberLeave",
-          "type": "ref"
-        }
-      },
-      "description": "[NOTE: This is under active development and should be considered unstable while this note is here]. Event indicating a member voluntarily left a group convo. The member who was removed gets a logLeaveConvo (to leave the convo) but not a logMemberLeave (because they already left, so can't see the system message)."
-    },
-    "logReadMessage": {
-      "type": "object",
-      "required": [
-        "rev",
-        "convoId",
-        "message"
-      ],
-      "properties": {
-        "rev": {
-          "type": "string"
-        },
-        "convoId": {
-          "type": "string"
-        },
-        "message": {
-          "refs": [
-            "#messageView",
-            "#deletedMessageView",
-            "#systemMessageView"
-          ],
-          "type": "union"
-        }
-      },
-      "description": "DEPRECATED: use logReadConvo instead. Event indicating a convo was read up to a certain message."
-    },
-    "logUnlockConvo": {
-      "type": "object",
-      "required": [
-        "rev",
-        "convoId",
-        "message"
-      ],
-      "properties": {
-        "rev": {
-          "type": "string"
-        },
-        "convoId": {
-          "type": "string"
-        },
-        "message": {
-          "ref": "#systemMessageDataUnlockConvo",
-          "type": "ref"
-        }
-      },
-      "description": "[NOTE: This is under active development and should be considered unstable while this note is here]. Event indicating a group convo was unlocked."
-    },
-    "logUnmuteConvo": {
-      "type": "object",
-      "required": [
-        "rev",
-        "convoId"
-      ],
-      "properties": {
-        "rev": {
-          "type": "string"
-        },
-        "convoId": {
-          "type": "string"
-        }
-      },
-      "description": "Event indicating the viewer unmuted a convo. Can be direct or group."
-    },
-    "convoLockStatus": {
-      "type": "string",
-      "knownValues": [
-        "unlocked",
-        "locked",
-        "locked-permanently"
-      ]
-    },
-    "logEditJoinLink": {
-      "type": "object",
-      "required": [
-        "rev",
-        "convoId",
-        "message"
-      ],
-      "properties": {
-        "rev": {
-          "type": "string"
-        },
-        "convoId": {
-          "type": "string"
-        },
-        "message": {
-          "ref": "#systemMessageDataEditJoinLink",
-          "type": "ref"
-        }
-      },
-      "description": "[NOTE: This is under active development and should be considered unstable while this note is here]. Event indicating a settings about a join link for a group convo were edited."
-    },
-    "logRemoveMember": {
-      "type": "object",
-      "required": [
-        "rev",
-        "convoId",
-        "message"
-      ],
-      "properties": {
-        "rev": {
-          "type": "string"
-        },
-        "convoId": {
-          "type": "string"
-        },
-        "message": {
-          "ref": "#systemMessageDataRemoveMember",
-          "type": "ref"
-        }
-      },
-      "description": "[NOTE: This is under active development and should be considered unstable while this note is here]. Event indicating a member was removed from a group convo. The member who was removed gets a logLeaveConvo (to leave the convo) but not a logRemoveMember (because they already left, so can't see the system message)."
-    },
-    "logCreateMessage": {
-      "type": "object",
-      "required": [
-        "rev",
-        "convoId",
-        "message"
-      ],
-      "properties": {
-        "rev": {
-          "type": "string"
-        },
-        "convoId": {
-          "type": "string"
-        },
-        "message": {
-          "refs": [
-            "#messageView",
-            "#deletedMessageView"
-          ],
-          "type": "union"
-        }
-      },
-      "description": "Event indicating a user-originated message was created. Is not emitted for system messages."
-    },
-    "logDeleteMessage": {
-      "type": "object",
-      "required": [
-        "rev",
-        "convoId",
-        "message"
-      ],
-      "properties": {
-        "rev": {
-          "type": "string"
-        },
-        "convoId": {
-          "type": "string"
-        },
-        "message": {
-          "refs": [
-            "#messageView",
-            "#deletedMessageView"
-          ],
-          "type": "union"
-        }
-      },
-      "description": "Event indicating a user-originated message was deleted. Is not emitted for system messages."
-    },
-    "logCreateJoinLink": {
-      "type": "object",
-      "required": [
-        "rev",
-        "convoId",
-        "message"
-      ],
-      "properties": {
-        "rev": {
-          "type": "string"
-        },
-        "convoId": {
-          "type": "string"
-        },
-        "message": {
-          "ref": "#systemMessageDataCreateJoinLink",
-          "type": "ref"
-        }
-      },
-      "description": "[NOTE: This is under active development and should be considered unstable while this note is here]. Event indicating a join link was created for a group convo."
-    },
-    "logEnableJoinLink": {
-      "type": "object",
-      "required": [
-        "rev",
-        "convoId",
-        "message"
-      ],
-      "properties": {
-        "rev": {
-          "type": "string"
-        },
-        "convoId": {
-          "type": "string"
-        },
-        "message": {
-          "ref": "#systemMessageDataEnableJoinLink",
-          "type": "ref"
-        }
-      },
-      "description": "[NOTE: This is under active development and should be considered unstable while this note is here]. Event indicating a join link was enabled for a group convo."
-    },
-    "logRemoveReaction": {
-      "type": "object",
-      "required": [
-        "rev",
-        "convoId",
-        "message",
-        "reaction"
-      ],
-      "properties": {
-        "rev": {
-          "type": "string"
-        },
-        "convoId": {
-          "type": "string"
-        },
-        "message": {
-          "refs": [
-            "#messageView",
-            "#deletedMessageView"
-          ],
-          "type": "union"
-        },
-        "reaction": {
-          "ref": "#reactionView",
-          "type": "ref"
-        }
-      },
-      "description": "Event indicating a reaction was removed from a message."
-    },
-    "messageViewSender": {
-      "type": "object",
-      "required": [
-        "did"
-      ],
-      "properties": {
-        "did": {
-          "type": "string",
-          "format": "did"
-        }
+        "did": { "type": "string", "format": "did" }
       }
     },
     "systemMessageView": {
       "type": "object",
-      "required": [
-        "id",
-        "rev",
-        "sentAt",
-        "data"
-      ],
+      "required": ["id", "rev", "sentAt", "data"],
       "properties": {
-        "id": {
-          "type": "string"
-        },
-        "rev": {
-          "type": "string"
-        },
+        "id": { "type": "string" },
+        "rev": { "type": "string" },
+        "sentAt": { "type": "string", "format": "datetime" },
         "data": {
+          "type": "union",
           "refs": [
             "#systemMessageDataAddMember",
             "#systemMessageDataRemoveMember",
@@ -734,371 +134,744 @@
             "#systemMessageDataEditJoinLink",
             "#systemMessageDataEnableJoinLink",
             "#systemMessageDataDisableJoinLink"
-          ],
-          "type": "union"
-        },
-        "sentAt": {
-          "type": "string",
-          "format": "datetime"
+          ]
         }
-      },
-      "description": "[NOTE: This is under active development and should be considered unstable while this note is here]."
+      }
+    },
+    "systemMessageDataAddMember": {
+      "description": "System message indicating a user was added to the group convo.",
+      "type": "object",
+      "required": ["member", "role", "addedBy"],
+      "properties": {
+        "member": {
+          "description": "Current view of the member who was added.",
+          "type": "ref",
+          "ref": "#systemMessageReferredUser"
+        },
+        "role": {
+          "description": "Role the user was added to the group with. The role from 'member' will reflect the current data, not historical.",
+          "type": "ref",
+          "ref": "chat.bsky.actor.defs#memberRole"
+        },
+        "addedBy": {
+          "type": "ref",
+          "ref": "#systemMessageReferredUser"
+        }
+      }
+    },
+    "systemMessageDataRemoveMember": {
+      "description": "System message indicating a user was removed from the group convo.",
+      "type": "object",
+      "required": ["member", "removedBy"],
+      "properties": {
+        "member": {
+          "description": "Current view of the member who was removed.",
+          "type": "ref",
+          "ref": "#systemMessageReferredUser"
+        },
+        "removedBy": {
+          "type": "ref",
+          "ref": "#systemMessageReferredUser"
+        }
+      }
+    },
+    "systemMessageDataMemberJoin": {
+      "description": "System message indicating a user joined the group convo via join link.",
+      "type": "object",
+      "required": ["member", "role"],
+      "properties": {
+        "member": {
+          "description": "Current view of the member who joined.",
+          "type": "ref",
+          "ref": "#systemMessageReferredUser"
+        },
+        "role": {
+          "description": "Role the user was added to the group with. The role from 'member' will reflect the current data, not historical.",
+          "type": "ref",
+          "ref": "chat.bsky.actor.defs#memberRole"
+        },
+        "approvedBy": {
+          "description": "If join link was configured to require approval, this will be set to who approved the request. Undefined if approval was not required.",
+          "type": "ref",
+          "ref": "#systemMessageReferredUser"
+        }
+      }
+    },
+    "systemMessageDataMemberLeave": {
+      "description": "System message indicating a user voluntarily left the group convo.",
+      "type": "object",
+      "required": ["member"],
+      "properties": {
+        "member": {
+          "description": "Current view of the member who left the group.",
+          "type": "ref",
+          "ref": "#systemMessageReferredUser"
+        }
+      }
+    },
+    "systemMessageDataLockConvo": {
+      "description": "System message indicating the group convo was locked.",
+      "type": "object",
+      "required": ["lockedBy"],
+      "properties": {
+        "lockedBy": {
+          "description": "Current view of the member who locked the group.",
+          "type": "ref",
+          "ref": "#systemMessageReferredUser"
+        }
+      }
+    },
+    "systemMessageDataUnlockConvo": {
+      "description": "System message indicating the group convo was unlocked.",
+      "type": "object",
+      "required": ["unlockedBy"],
+      "properties": {
+        "unlockedBy": {
+          "description": "Current view of the member who unlocked the group.",
+          "type": "ref",
+          "ref": "#systemMessageReferredUser"
+        }
+      }
+    },
+    "systemMessageDataLockConvoPermanently": {
+      "description": "System message indicating the group convo was locked permanently.",
+      "type": "object",
+      "required": ["lockedBy"],
+      "properties": {
+        "lockedBy": {
+          "description": "Current view of the member who locked the group.",
+          "type": "ref",
+          "ref": "#systemMessageReferredUser"
+        }
+      }
+    },
+    "systemMessageDataEditGroup": {
+      "description": "System message indicating the group info was edited.",
+      "type": "object",
+      "properties": {
+        "oldName": {
+          "description": "Group name that was replaced.",
+          "type": "string"
+        },
+        "newName": {
+          "description": "Group name that replaced the old.",
+          "type": "string"
+        }
+      }
+    },
+    "systemMessageDataCreateJoinLink": {
+      "description": "System message indicating the group join link was created.",
+      "type": "object",
+      "properties": {}
+    },
+    "systemMessageDataEditJoinLink": {
+      "description": "System message indicating the group join link was edited.",
+      "type": "object",
+      "properties": {}
+    },
+    "systemMessageDataEnableJoinLink": {
+      "description": "System message indicating the group join link was enabled.",
+      "type": "object",
+      "properties": {}
+    },
+    "systemMessageDataDisableJoinLink": {
+      "description": "System message indicating the group join link was disabled.",
+      "type": "object",
+      "properties": {}
     },
     "deletedMessageView": {
       "type": "object",
-      "required": [
-        "id",
-        "rev",
-        "sender",
-        "sentAt"
-      ],
+      "required": ["id", "rev", "sender", "sentAt"],
       "properties": {
-        "id": {
-          "type": "string"
-        },
-        "rev": {
-          "type": "string"
-        },
-        "sender": {
-          "ref": "#messageViewSender",
-          "type": "ref"
-        },
-        "sentAt": {
-          "type": "string",
-          "format": "datetime"
-        }
-      }
-    },
-    "logDisableJoinLink": {
-      "type": "object",
-      "required": [
-        "rev",
-        "convoId",
-        "message"
-      ],
-      "properties": {
-        "rev": {
-          "type": "string"
-        },
-        "convoId": {
-          "type": "string"
-        },
-        "message": {
-          "ref": "#systemMessageDataDisableJoinLink",
-          "type": "ref"
-        }
-      },
-      "description": "[NOTE: This is under active development and should be considered unstable while this note is here]. Event indicating a join link was disabled for a group convo."
-    },
-    "reactionViewSender": {
-      "type": "object",
-      "required": [
-        "did"
-      ],
-      "properties": {
-        "did": {
-          "type": "string",
-          "format": "did"
-        }
-      }
-    },
-    "logRejectJoinRequest": {
-      "type": "object",
-      "required": [
-        "rev",
-        "convoId",
-        "member"
-      ],
-      "properties": {
-        "rev": {
-          "type": "string"
-        },
-        "member": {
-          "ref": "chat.bsky.actor.defs#profileViewBasic",
-          "type": "ref",
-          "description": "Prospective member who requested to join."
-        },
-        "convoId": {
-          "type": "string"
-        }
-      },
-      "description": "[NOTE: This is under active development and should be considered unstable while this note is here]. Event indicating a join request was rejected by the viewer. Only the owner gets this."
-    },
-    "logApproveJoinRequest": {
-      "type": "object",
-      "required": [
-        "rev",
-        "convoId",
-        "member"
-      ],
-      "properties": {
-        "rev": {
-          "type": "string"
-        },
-        "member": {
-          "ref": "chat.bsky.actor.defs#profileViewBasic",
-          "type": "ref",
-          "description": "Prospective member who requested to join."
-        },
-        "convoId": {
-          "type": "string"
-        }
-      },
-      "description": "[NOTE: This is under active development and should be considered unstable while this note is here]. Event indicating a join request was approved by the viewer. Only the owner gets this. The approved member gets a logBeginConvo."
-    },
-    "logIncomingJoinRequest": {
-      "type": "object",
-      "required": [
-        "rev",
-        "convoId",
-        "member"
-      ],
-      "properties": {
-        "rev": {
-          "type": "string"
-        },
-        "member": {
-          "ref": "chat.bsky.actor.defs#profileViewBasic",
-          "type": "ref",
-          "description": "Prospective member who requested to join."
-        },
-        "convoId": {
-          "type": "string"
-        }
-      },
-      "description": "[NOTE: This is under active development and should be considered unstable while this note is here]. Event indicating a join request was made to a group the viewer owns. Only the owner gets this."
-    },
-    "logOutgoingJoinRequest": {
-      "type": "object",
-      "required": [
-        "rev",
-        "convoId"
-      ],
-      "properties": {
-        "rev": {
-          "type": "string"
-        },
-        "convoId": {
-          "type": "string"
-        }
-      },
-      "description": "[NOTE: This is under active development and should be considered unstable while this note is here]. Event indicating a join request was made by the viewer."
-    },
-    "messageAndReactionView": {
-      "type": "object",
-      "required": [
-        "message",
-        "reaction"
-      ],
-      "properties": {
-        "message": {
-          "ref": "#messageView",
-          "type": "ref"
-        },
-        "reaction": {
-          "ref": "#reactionView",
-          "type": "ref"
-        }
-      }
-    },
-    "logLockConvoPermanently": {
-      "type": "object",
-      "required": [
-        "rev",
-        "convoId",
-        "message"
-      ],
-      "properties": {
-        "rev": {
-          "type": "string"
-        },
-        "convoId": {
-          "type": "string"
-        },
-        "message": {
-          "ref": "#systemMessageDataLockConvoPermanently",
-          "type": "ref"
-        }
-      },
-      "description": "[NOTE: This is under active development and should be considered unstable while this note is here]. Event indicating a group convo was locked permanently."
-    },
-    "systemMessageDataAddMember": {
-      "type": "object",
-      "required": [
-        "member",
-        "role",
-        "addedBy"
-      ],
-      "properties": {
-        "role": {
-          "ref": "chat.bsky.actor.defs#memberRole",
-          "type": "ref",
-          "description": "Role the user was added to the group with. The role from 'member' will reflect the current data, not historical."
-        },
-        "member": {
-          "ref": "chat.bsky.actor.defs#profileViewBasic",
-          "type": "ref",
-          "description": "Current view of the member who was added."
-        },
-        "addedBy": {
-          "ref": "chat.bsky.actor.defs#profileViewBasic",
-          "type": "ref"
-        }
-      },
-      "description": "[NOTE: This is under active development and should be considered unstable while this note is here]. System message indicating a user was added to the group convo."
-    },
-    "systemMessageDataEditGroup": {
-      "type": "object",
-      "properties": {
-        "newName": {
-          "type": "string",
-          "description": "Group name that replaced the old."
-        },
-        "oldName": {
-          "type": "string",
-          "description": "Group name that was replaced."
-        }
-      },
-      "description": "[NOTE: This is under active development and should be considered unstable while this note is here]. System message indicating the group info was edited."
-    },
-    "systemMessageDataLockConvo": {
-      "type": "object",
-      "required": [
-        "lockedBy"
-      ],
-      "properties": {
-        "lockedBy": {
-          "ref": "chat.bsky.actor.defs#profileViewBasic",
-          "type": "ref",
-          "description": "Current view of the member who locked the group."
-        }
-      },
-      "description": "[NOTE: This is under active development and should be considered unstable while this note is here]. System message indicating the group convo was locked."
-    },
-    "systemMessageDataMemberJoin": {
-      "type": "object",
-      "required": [
-        "member",
-        "role"
-      ],
-      "properties": {
-        "role": {
-          "ref": "chat.bsky.actor.defs#memberRole",
-          "type": "ref",
-          "description": "Role the user was added to the group with. The role from 'member' will reflect the current data, not historical."
-        },
-        "member": {
-          "ref": "chat.bsky.actor.defs#profileViewBasic",
-          "type": "ref",
-          "description": "Current view of the member who joined."
-        },
-        "approvedBy": {
-          "ref": "chat.bsky.actor.defs#profileViewBasic",
-          "type": "ref",
-          "description": "If join link was configured to require approval, this will be set to who approved the request. Undefined if approval was not required."
-        }
-      },
-      "description": "[NOTE: This is under active development and should be considered unstable while this note is here]. System message indicating a user joined the group convo via join link."
-    },
-    "systemMessageDataMemberLeave": {
-      "type": "object",
-      "required": [
-        "member"
-      ],
-      "properties": {
-        "member": {
-          "ref": "chat.bsky.actor.defs#profileViewBasic",
-          "type": "ref",
-          "description": "Current view of the member who left the group."
-        }
-      },
-      "description": "[NOTE: This is under active development and should be considered unstable while this note is here]. System message indicating a user voluntarily left the group convo."
-    },
-    "systemMessageDataUnlockConvo": {
-      "type": "object",
-      "required": [
-        "unlockedBy"
-      ],
-      "properties": {
-        "unlockedBy": {
-          "ref": "chat.bsky.actor.defs#profileViewBasic",
-          "type": "ref",
-          "description": "Current view of the member who unlocked the group."
-        }
-      },
-      "description": "[NOTE: This is under active development and should be considered unstable while this note is here]. System message indicating the group convo was unlocked."
-    },
-    "systemMessageDataEditJoinLink": {
-      "type": "object",
-      "properties": {},
-      "description": "[NOTE: This is under active development and should be considered unstable while this note is here]. System message indicating the group join link was edited."
-    },
-    "systemMessageDataRemoveMember": {
-      "type": "object",
-      "required": [
-        "member",
-        "removedBy"
-      ],
-      "properties": {
-        "member": {
-          "ref": "chat.bsky.actor.defs#profileViewBasic",
-          "type": "ref",
-          "description": "Current view of the member who was removed."
-        },
-        "removedBy": {
-          "ref": "chat.bsky.actor.defs#profileViewBasic",
-          "type": "ref"
-        }
-      },
-      "description": "[NOTE: This is under active development and should be considered unstable while this note is here]. System message indicating a user was removed from the group convo."
-    },
-    "systemMessageDataCreateJoinLink": {
-      "type": "object",
-      "properties": {},
-      "description": "[NOTE: This is under active development and should be considered unstable while this note is here]. System message indicating the group join link was created."
-    },
-    "systemMessageDataEnableJoinLink": {
-      "type": "object",
-      "properties": {},
-      "description": "[NOTE: This is under active development and should be considered unstable while this note is here]. System message indicating the group join link was enabled."
-    },
-    "systemMessageDataDisableJoinLink": {
-      "type": "object",
-      "properties": {},
-      "description": "[NOTE: This is under active development and should be considered unstable while this note is here]. System message indicating the group join link was disabled."
-    },
-    "systemMessageDataLockConvoPermanently": {
-      "type": "object",
-      "required": [
-        "lockedBy"
-      ],
-      "properties": {
-        "lockedBy": {
-          "ref": "chat.bsky.actor.defs#profileViewBasic",
-          "type": "ref",
-          "description": "Current view of the member who locked the group."
-        }
-      },
-      "description": "[NOTE: This is under active development and should be considered unstable while this note is here]. System message indicating the group convo was locked permanently."
-    },
-    "replyRef": {
-      "description": "A reference to another message within the same convo, used to indicate that a message is a reply to it.",
-      "type": "object",
-      "required": [
-        "messageId"
-      ],
-      "properties": {
-        "messageId": {
-          "type": "string"
-        }
+        "id": { "type": "string" },
+        "rev": { "type": "string" },
+        "sender": { "type": "ref", "ref": "#messageViewSender" },
+        "sentAt": { "type": "string", "format": "datetime" }
       }
     },
     "messageBeforeUserJoinedGroupView": {
       "description": "Placeholder embedded in place of a reply's parent message when that parent was sent before the viewer joined the group convo. The viewer has no access to that history, so no message data is carried.",
       "type": "object",
       "properties": {}
+    },
+    "messageViewSender": {
+      "type": "object",
+      "required": ["did"],
+      "properties": {
+        "did": { "type": "string", "format": "did" }
+      }
+    },
+    "reactionView": {
+      "type": "object",
+      "required": ["value", "sender", "createdAt"],
+      "properties": {
+        "value": { "type": "string" },
+        "sender": { "type": "ref", "ref": "#reactionViewSender" },
+        "createdAt": { "type": "string", "format": "datetime" }
+      }
+    },
+    "reactionViewSender": {
+      "type": "object",
+      "required": ["did"],
+      "properties": {
+        "did": { "type": "string", "format": "did" }
+      }
+    },
+    "messageAndReactionView": {
+      "type": "object",
+      "required": ["message", "reaction"],
+      "properties": {
+        "message": { "type": "ref", "ref": "#messageView" },
+        "reaction": { "type": "ref", "ref": "#reactionView" }
+      }
+    },
+    "convoView": {
+      "type": "object",
+      "required": ["id", "rev", "members", "muted", "unreadCount"],
+      "properties": {
+        "id": { "type": "string" },
+        "rev": { "type": "string" },
+        "members": {
+          "description": "Members of this conversation. For direct convos, it will be an immutable list of the 2 members. For group convos, it will a list of important members (the first few members, the viewer, the member who added the viewer, the member who sent the last message, the member who sent the last reaction), but will not contain the full list of members. Use chat.bsky.convo.getConvoMembers to list all members.",
+          "type": "array",
+          "items": {
+            "type": "ref",
+            "ref": "chat.bsky.actor.defs#profileViewBasic"
+          }
+        },
+        "lastMessage": {
+          "type": "union",
+          "refs": ["#messageView", "#deletedMessageView", "#systemMessageView"]
+        },
+        "lastReaction": {
+          "type": "union",
+          "refs": ["#messageAndReactionView"]
+        },
+        "muted": { "type": "boolean" },
+        "status": {
+          "description": "Convo status for the viewer member (not the convo itself).",
+          "type": "ref",
+          "ref": "#convoStatus"
+        },
+        "unreadCount": { "type": "integer" },
+        "kind": {
+          "description": "Union field that has data specific to different kinds of convos.",
+          "type": "union",
+          "refs": ["#directConvo", "#groupConvo"]
+        }
+      }
+    },
+    "directConvo": {
+      "type": "object",
+      "properties": {}
+    },
+    "groupConvo": {
+      "type": "object",
+      "required": [
+        "createdAt",
+        "lockStatus",
+        "lockStatusModerationOverride",
+        "memberCount",
+        "memberLimit",
+        "name"
+      ],
+      "properties": {
+        "createdAt": {
+          "type": "string",
+          "format": "datetime"
+        },
+        "joinLink": {
+          "type": "ref",
+          "ref": "chat.bsky.group.defs#joinLinkView"
+        },
+        "joinRequestCount": {
+          "type": "integer",
+          "description": "The total number of pending join requests for the group conversation. Only present for the owner. Capped at 21."
+        },
+        "lockStatus": {
+          "description": "The lock status of the conversation.",
+          "type": "ref",
+          "ref": "#convoLockStatus"
+        },
+        "lockStatusModerationOverride": {
+          "description": "Whether the lock status is being forced by a moderation override (account inactivation or convo takedown) rather than the owner's own setting.",
+          "type": "boolean"
+        },
+        "memberCount": {
+          "type": "integer",
+          "description": "The total number of members in the group conversation."
+        },
+        "memberLimit": {
+          "type": "integer",
+          "description": "The maximum number of members allowed in the group conversation."
+        },
+        "name": {
+          "type": "string",
+          "description": "The display name of the group conversation.",
+          "maxGraphemes": 50,
+          "maxLength": 500
+        },
+        "unreadJoinRequestCount": {
+          "type": "integer",
+          "description": "The number of unread join requests for the group conversation. Only present for the owner."
+        }
+      }
+    },
+    "logBeginConvo": {
+      "description": "Event indicating a convo containing the viewer was started. Can be direct or group. When a member is added to a group convo, they also get this event.",
+      "type": "object",
+      "required": ["rev", "convoId"],
+      "properties": {
+        "rev": { "type": "string" },
+        "convoId": { "type": "string" }
+      }
+    },
+    "logAcceptConvo": {
+      "description": "Event indicating the viewer accepted a convo, and it can be moved out of the request inbox. Can be direct or group.",
+      "type": "object",
+      "required": ["rev", "convoId"],
+      "properties": {
+        "rev": { "type": "string" },
+        "convoId": { "type": "string" }
+      }
+    },
+    "logLeaveConvo": {
+      "description": "Event indicating the viewer left a convo. Can be direct or group.",
+      "type": "object",
+      "required": ["rev", "convoId"],
+      "properties": {
+        "rev": { "type": "string" },
+        "convoId": { "type": "string" }
+      }
+    },
+    "logMuteConvo": {
+      "description": "Event indicating the viewer muted a convo. Can be direct or group.",
+      "type": "object",
+      "required": ["rev", "convoId"],
+      "properties": {
+        "rev": { "type": "string" },
+        "convoId": { "type": "string" }
+      }
+    },
+    "logUnmuteConvo": {
+      "description": "Event indicating the viewer unmuted a convo. Can be direct or group.",
+      "type": "object",
+      "required": ["rev", "convoId"],
+      "properties": {
+        "rev": { "type": "string" },
+        "convoId": { "type": "string" }
+      }
+    },
+    "logCreateMessage": {
+      "description": "Event indicating a user-originated message was created. Is not emitted for system messages.",
+      "type": "object",
+      "required": ["rev", "convoId", "message"],
+      "properties": {
+        "rev": { "type": "string" },
+        "convoId": { "type": "string" },
+        "message": {
+          "type": "union",
+          "refs": ["#messageView", "#deletedMessageView"]
+        },
+        "relatedProfiles": {
+          "description": "Profiles referred to in the message view. This isn't required for compatibility, because it was added later, but should generally be present.",
+          "type": "array",
+          "items": {
+            "type": "ref",
+            "ref": "chat.bsky.actor.defs#profileViewBasic"
+          }
+        }
+      }
+    },
+    "logDeleteMessage": {
+      "description": "Event indicating a user-originated message was deleted. Is not emitted for system messages.",
+      "type": "object",
+      "required": ["rev", "convoId", "message"],
+      "properties": {
+        "rev": { "type": "string" },
+        "convoId": { "type": "string" },
+        "message": {
+          "type": "union",
+          "refs": ["#messageView", "#deletedMessageView"]
+        }
+      }
+    },
+    "logReadMessage": {
+      "description": "DEPRECATED: use logReadConvo instead. Event indicating a convo was read up to a certain message.",
+      "type": "object",
+      "required": ["rev", "convoId", "message"],
+      "properties": {
+        "rev": { "type": "string" },
+        "convoId": { "type": "string" },
+        "message": {
+          "type": "union",
+          "refs": ["#messageView", "#deletedMessageView", "#systemMessageView"]
+        }
+      }
+    },
+    "logAddReaction": {
+      "description": "Event indicating a reaction was added to a message.",
+      "type": "object",
+      "required": ["rev", "convoId", "message", "reaction"],
+      "properties": {
+        "rev": { "type": "string" },
+        "convoId": { "type": "string" },
+        "message": {
+          "type": "union",
+          "refs": ["#messageView", "#deletedMessageView"]
+        },
+        "reaction": { "type": "ref", "ref": "#reactionView" },
+        "relatedProfiles": {
+          "description": "Profiles referred in the message and reaction views. This isn't required for compatibility, because it was added later, but should generally be present.",
+          "type": "array",
+          "items": {
+            "type": "ref",
+            "ref": "chat.bsky.actor.defs#profileViewBasic"
+          }
+        }
+      }
+    },
+    "logRemoveReaction": {
+      "description": "Event indicating a reaction was removed from a message.",
+      "type": "object",
+      "required": ["rev", "convoId", "message", "reaction"],
+      "properties": {
+        "rev": { "type": "string" },
+        "convoId": { "type": "string" },
+        "message": {
+          "type": "union",
+          "refs": ["#messageView", "#deletedMessageView"]
+        },
+        "reaction": { "type": "ref", "ref": "#reactionView" },
+        "relatedProfiles": {
+          "description": "Profiles referred in the message and reaction views. This isn't required for compatibility, because it was added later, but should generally be present.",
+          "type": "array",
+          "items": {
+            "type": "ref",
+            "ref": "chat.bsky.actor.defs#profileViewBasic"
+          }
+        }
+      }
+    },
+    "logReadConvo": {
+      "description": "Event indicating a convo was read up to a certain message.",
+      "type": "object",
+      "required": ["rev", "convoId", "message"],
+      "properties": {
+        "rev": { "type": "string" },
+        "convoId": { "type": "string" },
+        "message": {
+          "type": "union",
+          "refs": ["#messageView", "#deletedMessageView", "#systemMessageView"]
+        }
+      }
+    },
+    "logAddMember": {
+      "description": "Event indicating a member was added to a group convo. The member who was added gets a logBeginConvo (to create the convo) but also a logAddMember (to show the system message as the first message the user sees).",
+      "type": "object",
+      "required": ["rev", "convoId", "message", "relatedProfiles"],
+      "properties": {
+        "rev": { "type": "string" },
+        "convoId": { "type": "string" },
+        "message": {
+          "description": "A system message with data of type #systemMessageDataAddMember",
+          "type": "ref",
+          "ref": "#systemMessageView"
+        },
+        "relatedProfiles": {
+          "description": "Profiles referred in the system message.",
+          "type": "array",
+          "items": {
+            "type": "ref",
+            "ref": "chat.bsky.actor.defs#profileViewBasic"
+          }
+        }
+      }
+    },
+    "logRemoveMember": {
+      "description": "Event indicating a member was removed from a group convo. The member who was removed gets a logLeaveConvo (to leave the convo) but not a logRemoveMember (because they already left, so can't see the system message).",
+      "type": "object",
+      "required": ["rev", "convoId", "message", "relatedProfiles"],
+      "properties": {
+        "rev": { "type": "string" },
+        "convoId": { "type": "string" },
+        "message": {
+          "description": "A system message with data of type #systemMessageDataRemoveMember",
+          "type": "ref",
+          "ref": "#systemMessageView"
+        },
+        "relatedProfiles": {
+          "description": "Profiles referred in the system message.",
+          "type": "array",
+          "items": {
+            "type": "ref",
+            "ref": "chat.bsky.actor.defs#profileViewBasic"
+          }
+        }
+      }
+    },
+    "logMemberJoin": {
+      "description": "Event indicating a member joined a group convo via join link. The member who was added gets a logBeginConvo (to create the convo) but also a logMemberJoin (to show the system message as the first message the user sees).",
+      "type": "object",
+      "required": ["rev", "convoId", "message", "relatedProfiles"],
+      "properties": {
+        "rev": { "type": "string" },
+        "convoId": { "type": "string" },
+        "message": {
+          "description": "A system message with data of type #systemMessageDataMemberJoin",
+          "type": "ref",
+          "ref": "#systemMessageView"
+        },
+        "relatedProfiles": {
+          "description": "Profiles referred in the system message.",
+          "type": "array",
+          "items": {
+            "type": "ref",
+            "ref": "chat.bsky.actor.defs#profileViewBasic"
+          }
+        }
+      }
+    },
+    "logMemberLeave": {
+      "description": "Event indicating a member voluntarily left a group convo. The member who was removed gets a logLeaveConvo (to leave the convo) but not a logMemberLeave (because they already left, so can't see the system message).",
+      "type": "object",
+      "required": ["rev", "convoId", "message", "relatedProfiles"],
+      "properties": {
+        "rev": { "type": "string" },
+        "convoId": { "type": "string" },
+        "message": {
+          "description": "A system message with data of type #systemMessageDataMemberLeave",
+          "type": "ref",
+          "ref": "#systemMessageView"
+        },
+        "relatedProfiles": {
+          "description": "Profiles referred in the system message.",
+          "type": "array",
+          "items": {
+            "type": "ref",
+            "ref": "chat.bsky.actor.defs#profileViewBasic"
+          }
+        }
+      }
+    },
+    "logLockConvo": {
+      "description": "Event indicating a group convo was locked.",
+      "type": "object",
+      "required": ["rev", "convoId", "message", "relatedProfiles"],
+      "properties": {
+        "rev": { "type": "string" },
+        "convoId": { "type": "string" },
+        "message": {
+          "description": "A system message with data of type #systemMessageDataLockConvo",
+          "type": "ref",
+          "ref": "#systemMessageView"
+        },
+        "relatedProfiles": {
+          "description": "Profiles referred in the system message.",
+          "type": "array",
+          "items": {
+            "type": "ref",
+            "ref": "chat.bsky.actor.defs#profileViewBasic"
+          }
+        }
+      }
+    },
+    "logUnlockConvo": {
+      "description": "Event indicating a group convo was unlocked.",
+      "type": "object",
+      "required": ["rev", "convoId", "message", "relatedProfiles"],
+      "properties": {
+        "rev": { "type": "string" },
+        "convoId": { "type": "string" },
+        "message": {
+          "description": "A system message with data of type #systemMessageDataUnlockConvo",
+          "type": "ref",
+          "ref": "#systemMessageView"
+        },
+        "relatedProfiles": {
+          "description": "Profiles referred in the system message.",
+          "type": "array",
+          "items": {
+            "type": "ref",
+            "ref": "chat.bsky.actor.defs#profileViewBasic"
+          }
+        }
+      }
+    },
+    "logLockConvoPermanently": {
+      "description": "Event indicating a group convo was locked permanently.",
+      "type": "object",
+      "required": ["rev", "convoId", "message", "relatedProfiles"],
+      "properties": {
+        "rev": { "type": "string" },
+        "convoId": { "type": "string" },
+        "message": {
+          "description": "A system message with data of type #systemMessageDataLockConvoPermanently",
+          "type": "ref",
+          "ref": "#systemMessageView"
+        },
+        "relatedProfiles": {
+          "description": "Profiles referred in the system message.",
+          "type": "array",
+          "items": {
+            "type": "ref",
+            "ref": "chat.bsky.actor.defs#profileViewBasic"
+          }
+        }
+      }
+    },
+    "logEditGroup": {
+      "description": "Event indicating info about group convo was edited.",
+      "type": "object",
+      "required": ["rev", "convoId", "message"],
+      "properties": {
+        "rev": { "type": "string" },
+        "convoId": { "type": "string" },
+        "message": {
+          "description": "A system message with data of type #systemMessageDataEditGroup",
+          "type": "ref",
+          "ref": "#systemMessageView"
+        }
+      }
+    },
+    "logCreateJoinLink": {
+      "description": "Event indicating a join link was created for a group convo.",
+      "type": "object",
+      "required": ["rev", "convoId", "message"],
+      "properties": {
+        "rev": { "type": "string" },
+        "convoId": { "type": "string" },
+        "message": {
+          "description": "A system message with data of type #systemMessageDataCreateJoinLink",
+          "type": "ref",
+          "ref": "#systemMessageView"
+        }
+      }
+    },
+    "logEditJoinLink": {
+      "description": "Event indicating a settings about a join link for a group convo were edited.",
+      "type": "object",
+      "required": ["rev", "convoId", "message"],
+      "properties": {
+        "rev": { "type": "string" },
+        "convoId": { "type": "string" },
+        "message": {
+          "description": "A system message with data of type #systemMessageDataEditJoinLink",
+          "type": "ref",
+          "ref": "#systemMessageView"
+        }
+      }
+    },
+    "logEnableJoinLink": {
+      "description": "Event indicating a join link was enabled for a group convo.",
+      "type": "object",
+      "required": ["rev", "convoId", "message"],
+      "properties": {
+        "rev": { "type": "string" },
+        "convoId": { "type": "string" },
+        "message": {
+          "description": "A system message with data of type #systemMessageDataEnableJoinLink",
+          "type": "ref",
+          "ref": "#systemMessageView"
+        }
+      }
+    },
+    "logDisableJoinLink": {
+      "description": "Event indicating a join link was disabled for a group convo.",
+      "type": "object",
+      "required": ["rev", "convoId", "message"],
+      "properties": {
+        "rev": { "type": "string" },
+        "convoId": { "type": "string" },
+        "message": {
+          "description": "A system message with data of type #systemMessageDataDisableJoinLink",
+          "type": "ref",
+          "ref": "#systemMessageView"
+        }
+      }
+    },
+    "logIncomingJoinRequest": {
+      "description": "Event indicating a join request was made to a group the viewer owns. Only the owner gets this.",
+      "type": "object",
+      "required": ["rev", "convoId", "member"],
+      "properties": {
+        "rev": { "type": "string" },
+        "convoId": { "type": "string" },
+        "member": {
+          "description": "Prospective member who requested to join.",
+          "type": "ref",
+          "ref": "chat.bsky.actor.defs#profileViewBasic"
+        }
+      }
+    },
+    "logApproveJoinRequest": {
+      "description": "Event indicating a join request was approved by the viewer. Only the owner gets this. The approved member gets a logBeginConvo.",
+      "type": "object",
+      "required": ["rev", "convoId", "member"],
+      "properties": {
+        "rev": { "type": "string" },
+        "convoId": { "type": "string" },
+        "member": {
+          "description": "Prospective member who requested to join.",
+          "type": "ref",
+          "ref": "chat.bsky.actor.defs#profileViewBasic"
+        }
+      }
+    },
+    "logRejectJoinRequest": {
+      "description": "Event indicating a join request was rejected by the viewer. Only the owner gets this.",
+      "type": "object",
+      "required": ["rev", "convoId", "member"],
+      "properties": {
+        "rev": { "type": "string" },
+        "convoId": { "type": "string" },
+        "member": {
+          "description": "Prospective member who requested to join.",
+          "type": "ref",
+          "ref": "chat.bsky.actor.defs#profileViewBasic"
+        }
+      }
+    },
+    "logOutgoingJoinRequest": {
+      "description": "Event indicating a join request was made by the requester. Only requester actor gets this.",
+      "type": "object",
+      "required": ["rev", "convoId"],
+      "properties": {
+        "rev": { "type": "string" },
+        "convoId": { "type": "string" }
+      }
+    },
+    "logWithdrawIncomingJoinRequest": {
+      "description": "Event indicating a prospective member withdrew their join request. Only the owner gets this.",
+      "type": "object",
+      "required": ["rev", "convoId", "member"],
+      "properties": {
+        "rev": { "type": "string" },
+        "convoId": { "type": "string" },
+        "member": {
+          "description": "Prospective member who withdrew their join request.",
+          "type": "ref",
+          "ref": "chat.bsky.actor.defs#profileViewBasic"
+        }
+      }
+    },
+    "logWithdrawOutgoingJoinRequest": {
+      "description": "Event indicating the viewer withdrew their own join request. Only requester actor gets this.",
+      "type": "object",
+      "required": ["rev", "convoId"],
+      "properties": {
+        "rev": { "type": "string" },
+        "convoId": { "type": "string" }
+      }
+    },
+    "logReadJoinRequests": {
+      "description": "Event indicating the group owner marked join requests as read. Only the owner gets this.",
+      "type": "object",
+      "required": ["rev", "convoId"],
+      "properties": {
+        "rev": { "type": "string" },
+        "convoId": { "type": "string" }
+      }
     }
-  },
-  "$type": "com.atproto.lexicon.schema",
-  "lexicon": 1
+  }
 }

--- a/generator/overlay-lexicons/chat/bsky/convo/sendMessage.json
+++ b/generator/overlay-lexicons/chat/bsky/convo/sendMessage.json
@@ -1,48 +1,36 @@
 {
+  "lexicon": 1,
   "id": "chat.bsky.convo.sendMessage",
   "defs": {
     "main": {
       "type": "procedure",
+      "description": "Sends a message to a conversation.",
+      "errors": [
+        { "name": "ConvoLocked" },
+        { "name": "InvalidConvo" },
+        { "name": "ReplyTargetNotFound" }
+      ],
       "input": {
+        "encoding": "application/json",
         "schema": {
           "type": "object",
-          "required": [
-            "convoId",
-            "message"
-          ],
+          "required": ["convoId", "message"],
           "properties": {
-            "convoId": {
-              "type": "string"
-            },
+            "convoId": { "type": "string" },
             "message": {
-              "ref": "chat.bsky.convo.defs#messageInput",
-              "type": "ref"
+              "type": "ref",
+              "ref": "chat.bsky.convo.defs#messageInput"
             }
           }
-        },
-        "encoding": "application/json"
-      },
-      "errors": [
-        {
-          "name": "ConvoLocked"
-        },
-        {
-          "name": "InvalidConvo"
-        },
-        {
-          "name": "ReplyTargetNotFound"
         }
-      ],
-      "output": {
-        "schema": {
-          "ref": "chat.bsky.convo.defs#messageView",
-          "type": "ref"
-        },
-        "encoding": "application/json"
       },
-      "description": "Sends a message to a conversation."
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "ref",
+          "ref": "chat.bsky.convo.defs#messageView"
+        }
+      }
     }
-  },
-  "$type": "com.atproto.lexicon.schema",
-  "lexicon": 1
+  }
 }

--- a/generator/overlay-lexicons/chat/bsky/convo/sendMessageBatch.json
+++ b/generator/overlay-lexicons/chat/bsky/convo/sendMessageBatch.json
@@ -1,75 +1,59 @@
 {
+  "lexicon": 1,
   "id": "chat.bsky.convo.sendMessageBatch",
   "defs": {
     "main": {
       "type": "procedure",
-      "input": {
-        "schema": {
-          "type": "object",
-          "required": [
-            "items"
-          ],
-          "properties": {
-            "items": {
-              "type": "array",
-              "items": {
-                "ref": "#batchItem",
-                "type": "ref"
-              },
-              "maxLength": 100
-            }
-          }
-        },
-        "encoding": "application/json"
-      },
+      "description": "Sends a batch of messages to a conversation.",
       "errors": [
-        {
-          "name": "ConvoLocked"
-        },
-        {
-          "name": "InvalidConvo"
-        },
-        {
-          "name": "ReplyTargetNotFound"
-        }
+        { "name": "ConvoLocked" },
+        { "name": "InvalidConvo" },
+        { "name": "ReplyTargetNotFound" }
       ],
-      "output": {
+      "input": {
+        "encoding": "application/json",
         "schema": {
           "type": "object",
-          "required": [
-            "items"
-          ],
+          "required": ["items"],
           "properties": {
             "items": {
               "type": "array",
+              "maxLength": 100,
               "items": {
-                "ref": "chat.bsky.convo.defs#messageView",
-                "type": "ref"
+                "type": "ref",
+                "ref": "#batchItem"
               }
             }
           }
-        },
-        "encoding": "application/json"
+        }
       },
-      "description": "Sends a batch of messages to a conversation."
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["items"],
+          "properties": {
+            "items": {
+              "type": "array",
+              "items": {
+                "type": "ref",
+                "ref": "chat.bsky.convo.defs#messageView"
+              }
+            }
+          }
+        }
+      }
     },
     "batchItem": {
       "type": "object",
-      "required": [
-        "convoId",
-        "message"
-      ],
+      "required": ["convoId", "message"],
       "properties": {
-        "convoId": {
-          "type": "string"
-        },
+        "convoId": { "type": "string" },
         "message": {
-          "ref": "chat.bsky.convo.defs#messageInput",
-          "type": "ref"
+          "type": "ref",
+          "ref": "chat.bsky.convo.defs#messageInput"
         }
       }
     }
-  },
-  "$type": "com.atproto.lexicon.schema",
-  "lexicon": 1
+  }
 }

--- a/generator/overlay-lexicons/chat/bsky/embed/joinLink.json
+++ b/generator/overlay-lexicons/chat/bsky/embed/joinLink.json
@@ -1,0 +1,31 @@
+{
+  "lexicon": 1,
+  "id": "chat.bsky.embed.joinLink",
+  "description": "A join link embedded in a chat message.",
+  "defs": {
+    "main": {
+      "type": "object",
+      "required": ["code"],
+      "properties": {
+        "code": {
+          "type": "string",
+          "description": "The join link code."
+        }
+      }
+    },
+    "view": {
+      "type": "object",
+      "required": ["joinLinkPreview"],
+      "properties": {
+        "joinLinkPreview": {
+          "type": "union",
+          "refs": [
+            "chat.bsky.group.defs#joinLinkPreviewView",
+            "chat.bsky.group.defs#disabledJoinLinkPreviewView",
+            "chat.bsky.group.defs#invalidJoinLinkPreviewView"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/generator/overlay-lexicons/chat/bsky/group/defs.json
+++ b/generator/overlay-lexicons/chat/bsky/group/defs.json
@@ -1,0 +1,215 @@
+{
+  "lexicon": 1,
+  "id": "chat.bsky.group.defs",
+  "defs": {
+    "linkEnabledStatus": {
+      "type": "string",
+      "knownValues": [
+        "enabled",
+        "disabled"
+      ]
+    },
+    "joinRule": {
+      "type": "string",
+      "knownValues": [
+        "anyone",
+        "followedByOwner"
+      ]
+    },
+    "joinLinkView": {
+      "description": "Join link view to be used within a group view, so the convo is surrounding, not specified inside this view.",
+      "type": "object",
+      "required": [
+        "code",
+        "enabledStatus",
+        "requireApproval",
+        "joinRule",
+        "createdAt"
+      ],
+      "properties": {
+        "code": {
+          "type": "string"
+        },
+        "enabledStatus": {
+          "type": "ref",
+          "ref": "#linkEnabledStatus"
+        },
+        "requireApproval": {
+          "type": "boolean"
+        },
+        "joinRule": {
+          "type": "ref",
+          "ref": "#joinRule"
+        },
+        "createdAt": {
+          "type": "string",
+          "format": "datetime"
+        }
+      }
+    },
+    "joinLinkPreviewView": {
+      "description": "Preview that can be shown in feeds, including to unauthenticated viewers.",
+      "type": "object",
+      "required": [
+        "convoId",
+        "code",
+        "name",
+        "owner",
+        "memberCount",
+        "memberLimit",
+        "requireApproval",
+        "joinRule"
+      ],
+      "properties": {
+        "convoId": {
+          "type": "string"
+        },
+        "code": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "owner": {
+          "type": "ref",
+          "ref": "chat.bsky.actor.defs#profileViewBasic"
+        },
+        "memberCount": {
+          "type": "integer"
+        },
+        "memberLimit": {
+          "type": "integer"
+        },
+        "requireApproval": {
+          "type": "boolean"
+        },
+        "joinRule": {
+          "type": "ref",
+          "ref": "#joinRule"
+        },
+        "convo": {
+          "type": "ref",
+          "ref": "chat.bsky.convo.defs#convoView",
+          "description": "Present only if the request is authenticated and the user is a member of the group."
+        },
+        "viewer": {
+          "type": "ref",
+          "ref": "#joinLinkViewerState"
+        }
+      }
+    },
+    "disabledJoinLinkPreviewView": {
+      "description": "Preview for a disabled join link. Carries only the code so clients can correlate with the input and render a disabled state.",
+      "type": "object",
+      "required": [
+        "code"
+      ],
+      "properties": {
+        "code": {
+          "type": "string"
+        }
+      }
+    },
+    "invalidJoinLinkPreviewView": {
+      "description": "Preview for a join link code that does not map to an existing link. Carries only the code so clients can correlate with the input and render an invalid state.",
+      "type": "object",
+      "required": [
+        "code"
+      ],
+      "properties": {
+        "code": {
+          "type": "string"
+        }
+      }
+    },
+    "joinLinkViewerState": {
+      "type": "object",
+      "properties": {
+        "requestedAt": {
+          "type": "string",
+          "format": "datetime"
+        }
+      }
+    },
+    "joinRequestView": {
+      "description": "A join request from the perspective of the group owner.",
+      "type": "object",
+      "required": [
+        "convoId",
+        "requestedBy",
+        "requestedAt"
+      ],
+      "properties": {
+        "convoId": {
+          "type": "string"
+        },
+        "requestedBy": {
+          "type": "ref",
+          "ref": "chat.bsky.actor.defs#profileViewBasic"
+        },
+        "requestedAt": {
+          "type": "string",
+          "format": "datetime"
+        }
+      }
+    },
+    "joinRequestConvoView": {
+      "description": "A join request from the perspective of the requester, including enough group context to render the request in a list (e.g. group name, owner, member count).",
+      "type": "object",
+      "required": [
+        "convoId",
+        "name",
+        "owner",
+        "memberCount",
+        "memberLimit",
+        "viewer"
+      ],
+      "properties": {
+        "convoId": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "owner": {
+          "type": "ref",
+          "ref": "chat.bsky.actor.defs#profileViewBasic"
+        },
+        "memberCount": {
+          "type": "integer"
+        },
+        "memberLimit": {
+          "type": "integer"
+        },
+        "viewer": {
+          "type": "ref",
+          "ref": "#joinLinkViewerState"
+        }
+      }
+    },
+    "groupPublicView": {
+      "type": "object",
+      "required": [
+        "name",
+        "owner",
+        "memberCount",
+        "requireApproval"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "owner": {
+          "ref": "chat.bsky.actor.defs#profileViewBasic",
+          "type": "ref"
+        },
+        "memberCount": {
+          "type": "integer"
+        },
+        "requireApproval": {
+          "type": "boolean"
+        }
+      }
+    }
+  }
+}

--- a/models/api/models.api
+++ b/models/api/models.api
@@ -10488,6 +10488,35 @@ public final class io/github/kikin81/atproto/chat/bsky/convo/AddReactionResponse
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class io/github/kikin81/atproto/chat/bsky/convo/ConvoRef {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/ConvoRef$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2-UyB9Nic ()Ljava/lang/String;
+	public final fun copy-aB4ouW8 (Ljava/lang/String;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/ConvoRef;
+	public static synthetic fun copy-aB4ouW8$default (Lio/github/kikin81/atproto/chat/bsky/convo/ConvoRef;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/ConvoRef;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConvoId ()Ljava/lang/String;
+	public final fun getDid-UyB9Nic ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/convo/ConvoRef$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/ConvoRef$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/convo/ConvoRef;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/convo/ConvoRef;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/ConvoRef$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
 public final class io/github/kikin81/atproto/chat/bsky/convo/ConvoService {
 	public fun <init> (Lio/github/kikin81/atproto/runtime/XrpcClient;Ljava/lang/String;)V
 	public synthetic fun <init> (Lio/github/kikin81/atproto/runtime/XrpcClient;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -11230,17 +11259,29 @@ public final class io/github/kikin81/atproto/chat/bsky/convo/GetMessagesResponse
 
 public final class io/github/kikin81/atproto/chat/bsky/convo/GroupConvo : io/github/kikin81/atproto/chat/bsky/convo/ConvoViewKindUnion {
 	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/GroupConvo$Companion;
-	public fun <init> (Lio/github/kikin81/atproto/chat/bsky/group/JoinLinkView;Ljava/lang/String;Ljava/lang/String;)V
-	public synthetic fun <init> (Lio/github/kikin81/atproto/chat/bsky/group/JoinLinkView;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Lio/github/kikin81/atproto/chat/bsky/group/JoinLinkView;
-	public final fun component2 ()Ljava/lang/String;
-	public final fun component3 ()Ljava/lang/String;
-	public final fun copy (Lio/github/kikin81/atproto/chat/bsky/group/JoinLinkView;Ljava/lang/String;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/GroupConvo;
-	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/GroupConvo;Lio/github/kikin81/atproto/chat/bsky/group/JoinLinkView;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/GroupConvo;
+	public synthetic fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/group/JoinLinkView;Ljava/lang/Long;Ljava/lang/String;ZJJLjava/lang/String;Ljava/lang/Long;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/group/JoinLinkView;Ljava/lang/Long;Ljava/lang/String;ZJJLjava/lang/String;Ljava/lang/Long;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-DnBUIck ()Ljava/lang/String;
+	public final fun component2 ()Lio/github/kikin81/atproto/chat/bsky/group/JoinLinkView;
+	public final fun component3 ()Ljava/lang/Long;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Z
+	public final fun component6 ()J
+	public final fun component7 ()J
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Ljava/lang/Long;
+	public final fun copy-nfOqpjM (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/group/JoinLinkView;Ljava/lang/Long;Ljava/lang/String;ZJJLjava/lang/String;Ljava/lang/Long;)Lio/github/kikin81/atproto/chat/bsky/convo/GroupConvo;
+	public static synthetic fun copy-nfOqpjM$default (Lio/github/kikin81/atproto/chat/bsky/convo/GroupConvo;Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/group/JoinLinkView;Ljava/lang/Long;Ljava/lang/String;ZJJLjava/lang/String;Ljava/lang/Long;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/GroupConvo;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCreatedAt-DnBUIck ()Ljava/lang/String;
 	public final fun getJoinLink ()Lio/github/kikin81/atproto/chat/bsky/group/JoinLinkView;
+	public final fun getJoinRequestCount ()Ljava/lang/Long;
 	public final fun getLockStatus ()Ljava/lang/String;
+	public final fun getLockStatusModerationOverride ()Z
+	public final fun getMemberCount ()J
+	public final fun getMemberLimit ()J
 	public final fun getName ()Ljava/lang/String;
+	public final fun getUnreadJoinRequestCount ()Ljava/lang/Long;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -11569,15 +11610,17 @@ public final class io/github/kikin81/atproto/chat/bsky/convo/LogAcceptConvo$Comp
 
 public final class io/github/kikin81/atproto/chat/bsky/convo/LogAddMember : io/github/kikin81/atproto/chat/bsky/convo/GetLogResponseLogsUnion {
 	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/LogAddMember$Companion;
-	public fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataAddMember;Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageView;Ljava/util/List;Ljava/lang/String;)V
 	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataAddMember;
-	public final fun component3 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataAddMember;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/LogAddMember;
-	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/LogAddMember;Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataAddMember;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/LogAddMember;
+	public final fun component2 ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageView;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageView;Ljava/util/List;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/LogAddMember;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/LogAddMember;Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageView;Ljava/util/List;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/LogAddMember;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getConvoId ()Ljava/lang/String;
-	public final fun getMessage ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataAddMember;
+	public final fun getMessage ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageView;
+	public final fun getRelatedProfiles ()Ljava/util/List;
 	public final fun getRev ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -11600,17 +11643,20 @@ public final class io/github/kikin81/atproto/chat/bsky/convo/LogAddMember$Compan
 
 public final class io/github/kikin81/atproto/chat/bsky/convo/LogAddReaction : io/github/kikin81/atproto/chat/bsky/convo/GetLogResponseLogsUnion {
 	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/LogAddReaction$Companion;
-	public fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/LogAddReactionMessageUnion;Lio/github/kikin81/atproto/chat/bsky/convo/ReactionView;Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/LogAddReactionMessageUnion;Lio/github/kikin81/atproto/chat/bsky/convo/ReactionView;Ljava/util/List;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/LogAddReactionMessageUnion;Lio/github/kikin81/atproto/chat/bsky/convo/ReactionView;Ljava/util/List;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Lio/github/kikin81/atproto/chat/bsky/convo/LogAddReactionMessageUnion;
 	public final fun component3 ()Lio/github/kikin81/atproto/chat/bsky/convo/ReactionView;
-	public final fun component4 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/LogAddReactionMessageUnion;Lio/github/kikin81/atproto/chat/bsky/convo/ReactionView;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/LogAddReaction;
-	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/LogAddReaction;Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/LogAddReactionMessageUnion;Lio/github/kikin81/atproto/chat/bsky/convo/ReactionView;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/LogAddReaction;
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/LogAddReactionMessageUnion;Lio/github/kikin81/atproto/chat/bsky/convo/ReactionView;Ljava/util/List;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/LogAddReaction;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/LogAddReaction;Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/LogAddReactionMessageUnion;Lio/github/kikin81/atproto/chat/bsky/convo/ReactionView;Ljava/util/List;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/LogAddReaction;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getConvoId ()Ljava/lang/String;
 	public final fun getMessage ()Lio/github/kikin81/atproto/chat/bsky/convo/LogAddReactionMessageUnion;
 	public final fun getReaction ()Lio/github/kikin81/atproto/chat/bsky/convo/ReactionView;
+	public final fun getRelatedProfiles ()Ljava/util/List;
 	public final fun getRev ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -11733,15 +11779,15 @@ public final class io/github/kikin81/atproto/chat/bsky/convo/LogBeginConvo$Compa
 
 public final class io/github/kikin81/atproto/chat/bsky/convo/LogCreateJoinLink : io/github/kikin81/atproto/chat/bsky/convo/GetLogResponseLogsUnion {
 	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/LogCreateJoinLink$Companion;
-	public fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataCreateJoinLink;Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageView;Ljava/lang/String;)V
 	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataCreateJoinLink;
+	public final fun component2 ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageView;
 	public final fun component3 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataCreateJoinLink;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/LogCreateJoinLink;
-	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/LogCreateJoinLink;Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataCreateJoinLink;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/LogCreateJoinLink;
+	public final fun copy (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageView;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/LogCreateJoinLink;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/LogCreateJoinLink;Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageView;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/LogCreateJoinLink;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getConvoId ()Ljava/lang/String;
-	public final fun getMessage ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataCreateJoinLink;
+	public final fun getMessage ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageView;
 	public final fun getRev ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -11764,15 +11810,18 @@ public final class io/github/kikin81/atproto/chat/bsky/convo/LogCreateJoinLink$C
 
 public final class io/github/kikin81/atproto/chat/bsky/convo/LogCreateMessage : io/github/kikin81/atproto/chat/bsky/convo/GetLogResponseLogsUnion {
 	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/LogCreateMessage$Companion;
-	public fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/LogCreateMessageMessageUnion;Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/LogCreateMessageMessageUnion;Ljava/util/List;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/LogCreateMessageMessageUnion;Ljava/util/List;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Lio/github/kikin81/atproto/chat/bsky/convo/LogCreateMessageMessageUnion;
-	public final fun component3 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/LogCreateMessageMessageUnion;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/LogCreateMessage;
-	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/LogCreateMessage;Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/LogCreateMessageMessageUnion;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/LogCreateMessage;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/LogCreateMessageMessageUnion;Ljava/util/List;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/LogCreateMessage;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/LogCreateMessage;Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/LogCreateMessageMessageUnion;Ljava/util/List;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/LogCreateMessage;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getConvoId ()Ljava/lang/String;
 	public final fun getMessage ()Lio/github/kikin81/atproto/chat/bsky/convo/LogCreateMessageMessageUnion;
+	public final fun getRelatedProfiles ()Ljava/util/List;
 	public final fun getRev ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -11906,15 +11955,15 @@ public final class io/github/kikin81/atproto/chat/bsky/convo/LogDeleteMessageMes
 
 public final class io/github/kikin81/atproto/chat/bsky/convo/LogDisableJoinLink : io/github/kikin81/atproto/chat/bsky/convo/GetLogResponseLogsUnion {
 	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/LogDisableJoinLink$Companion;
-	public fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataDisableJoinLink;Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageView;Ljava/lang/String;)V
 	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataDisableJoinLink;
+	public final fun component2 ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageView;
 	public final fun component3 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataDisableJoinLink;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/LogDisableJoinLink;
-	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/LogDisableJoinLink;Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataDisableJoinLink;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/LogDisableJoinLink;
+	public final fun copy (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageView;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/LogDisableJoinLink;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/LogDisableJoinLink;Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageView;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/LogDisableJoinLink;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getConvoId ()Ljava/lang/String;
-	public final fun getMessage ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataDisableJoinLink;
+	public final fun getMessage ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageView;
 	public final fun getRev ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -11937,15 +11986,15 @@ public final class io/github/kikin81/atproto/chat/bsky/convo/LogDisableJoinLink$
 
 public final class io/github/kikin81/atproto/chat/bsky/convo/LogEditGroup : io/github/kikin81/atproto/chat/bsky/convo/GetLogResponseLogsUnion {
 	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/LogEditGroup$Companion;
-	public fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataEditGroup;Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageView;Ljava/lang/String;)V
 	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataEditGroup;
+	public final fun component2 ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageView;
 	public final fun component3 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataEditGroup;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/LogEditGroup;
-	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/LogEditGroup;Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataEditGroup;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/LogEditGroup;
+	public final fun copy (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageView;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/LogEditGroup;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/LogEditGroup;Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageView;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/LogEditGroup;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getConvoId ()Ljava/lang/String;
-	public final fun getMessage ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataEditGroup;
+	public final fun getMessage ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageView;
 	public final fun getRev ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -11968,15 +12017,15 @@ public final class io/github/kikin81/atproto/chat/bsky/convo/LogEditGroup$Compan
 
 public final class io/github/kikin81/atproto/chat/bsky/convo/LogEditJoinLink : io/github/kikin81/atproto/chat/bsky/convo/GetLogResponseLogsUnion {
 	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/LogEditJoinLink$Companion;
-	public fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataEditJoinLink;Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageView;Ljava/lang/String;)V
 	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataEditJoinLink;
+	public final fun component2 ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageView;
 	public final fun component3 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataEditJoinLink;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/LogEditJoinLink;
-	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/LogEditJoinLink;Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataEditJoinLink;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/LogEditJoinLink;
+	public final fun copy (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageView;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/LogEditJoinLink;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/LogEditJoinLink;Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageView;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/LogEditJoinLink;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getConvoId ()Ljava/lang/String;
-	public final fun getMessage ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataEditJoinLink;
+	public final fun getMessage ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageView;
 	public final fun getRev ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -11999,15 +12048,15 @@ public final class io/github/kikin81/atproto/chat/bsky/convo/LogEditJoinLink$Com
 
 public final class io/github/kikin81/atproto/chat/bsky/convo/LogEnableJoinLink : io/github/kikin81/atproto/chat/bsky/convo/GetLogResponseLogsUnion {
 	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/LogEnableJoinLink$Companion;
-	public fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataEnableJoinLink;Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageView;Ljava/lang/String;)V
 	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataEnableJoinLink;
+	public final fun component2 ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageView;
 	public final fun component3 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataEnableJoinLink;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/LogEnableJoinLink;
-	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/LogEnableJoinLink;Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataEnableJoinLink;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/LogEnableJoinLink;
+	public final fun copy (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageView;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/LogEnableJoinLink;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/LogEnableJoinLink;Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageView;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/LogEnableJoinLink;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getConvoId ()Ljava/lang/String;
-	public final fun getMessage ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataEnableJoinLink;
+	public final fun getMessage ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageView;
 	public final fun getRev ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -12090,15 +12139,17 @@ public final class io/github/kikin81/atproto/chat/bsky/convo/LogLeaveConvo$Compa
 
 public final class io/github/kikin81/atproto/chat/bsky/convo/LogLockConvo : io/github/kikin81/atproto/chat/bsky/convo/GetLogResponseLogsUnion {
 	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/LogLockConvo$Companion;
-	public fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataLockConvo;Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageView;Ljava/util/List;Ljava/lang/String;)V
 	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataLockConvo;
-	public final fun component3 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataLockConvo;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/LogLockConvo;
-	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/LogLockConvo;Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataLockConvo;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/LogLockConvo;
+	public final fun component2 ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageView;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageView;Ljava/util/List;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/LogLockConvo;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/LogLockConvo;Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageView;Ljava/util/List;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/LogLockConvo;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getConvoId ()Ljava/lang/String;
-	public final fun getMessage ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataLockConvo;
+	public final fun getMessage ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageView;
+	public final fun getRelatedProfiles ()Ljava/util/List;
 	public final fun getRev ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -12121,15 +12172,17 @@ public final class io/github/kikin81/atproto/chat/bsky/convo/LogLockConvo$Compan
 
 public final class io/github/kikin81/atproto/chat/bsky/convo/LogLockConvoPermanently : io/github/kikin81/atproto/chat/bsky/convo/GetLogResponseLogsUnion {
 	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/LogLockConvoPermanently$Companion;
-	public fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataLockConvoPermanently;Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageView;Ljava/util/List;Ljava/lang/String;)V
 	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataLockConvoPermanently;
-	public final fun component3 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataLockConvoPermanently;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/LogLockConvoPermanently;
-	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/LogLockConvoPermanently;Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataLockConvoPermanently;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/LogLockConvoPermanently;
+	public final fun component2 ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageView;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageView;Ljava/util/List;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/LogLockConvoPermanently;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/LogLockConvoPermanently;Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageView;Ljava/util/List;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/LogLockConvoPermanently;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getConvoId ()Ljava/lang/String;
-	public final fun getMessage ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataLockConvoPermanently;
+	public final fun getMessage ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageView;
+	public final fun getRelatedProfiles ()Ljava/util/List;
 	public final fun getRev ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -12152,15 +12205,17 @@ public final class io/github/kikin81/atproto/chat/bsky/convo/LogLockConvoPermane
 
 public final class io/github/kikin81/atproto/chat/bsky/convo/LogMemberJoin : io/github/kikin81/atproto/chat/bsky/convo/GetLogResponseLogsUnion {
 	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/LogMemberJoin$Companion;
-	public fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataMemberJoin;Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageView;Ljava/util/List;Ljava/lang/String;)V
 	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataMemberJoin;
-	public final fun component3 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataMemberJoin;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/LogMemberJoin;
-	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/LogMemberJoin;Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataMemberJoin;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/LogMemberJoin;
+	public final fun component2 ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageView;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageView;Ljava/util/List;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/LogMemberJoin;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/LogMemberJoin;Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageView;Ljava/util/List;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/LogMemberJoin;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getConvoId ()Ljava/lang/String;
-	public final fun getMessage ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataMemberJoin;
+	public final fun getMessage ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageView;
+	public final fun getRelatedProfiles ()Ljava/util/List;
 	public final fun getRev ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -12183,15 +12238,17 @@ public final class io/github/kikin81/atproto/chat/bsky/convo/LogMemberJoin$Compa
 
 public final class io/github/kikin81/atproto/chat/bsky/convo/LogMemberLeave : io/github/kikin81/atproto/chat/bsky/convo/GetLogResponseLogsUnion {
 	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/LogMemberLeave$Companion;
-	public fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataMemberLeave;Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageView;Ljava/util/List;Ljava/lang/String;)V
 	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataMemberLeave;
-	public final fun component3 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataMemberLeave;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/LogMemberLeave;
-	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/LogMemberLeave;Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataMemberLeave;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/LogMemberLeave;
+	public final fun component2 ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageView;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageView;Ljava/util/List;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/LogMemberLeave;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/LogMemberLeave;Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageView;Ljava/util/List;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/LogMemberLeave;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getConvoId ()Ljava/lang/String;
-	public final fun getMessage ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataMemberLeave;
+	public final fun getMessage ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageView;
+	public final fun getRelatedProfiles ()Ljava/util/List;
 	public final fun getRev ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -12341,6 +12398,35 @@ public final class io/github/kikin81/atproto/chat/bsky/convo/LogReadConvoMessage
 	public synthetic fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/runtime/UnknownOpenUnionMember;
 }
 
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogReadJoinRequests {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/LogReadJoinRequests$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/LogReadJoinRequests;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/LogReadJoinRequests;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/LogReadJoinRequests;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConvoId ()Ljava/lang/String;
+	public final fun getRev ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/convo/LogReadJoinRequests$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/LogReadJoinRequests$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/convo/LogReadJoinRequests;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/convo/LogReadJoinRequests;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogReadJoinRequests$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
 public final class io/github/kikin81/atproto/chat/bsky/convo/LogReadMessage : io/github/kikin81/atproto/chat/bsky/convo/GetLogResponseLogsUnion {
 	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/LogReadMessage$Companion;
 	public fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/LogReadMessageMessageUnion;Ljava/lang/String;)V
@@ -12445,15 +12531,17 @@ public final class io/github/kikin81/atproto/chat/bsky/convo/LogRejectJoinReques
 
 public final class io/github/kikin81/atproto/chat/bsky/convo/LogRemoveMember : io/github/kikin81/atproto/chat/bsky/convo/GetLogResponseLogsUnion {
 	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/LogRemoveMember$Companion;
-	public fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataRemoveMember;Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageView;Ljava/util/List;Ljava/lang/String;)V
 	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataRemoveMember;
-	public final fun component3 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataRemoveMember;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/LogRemoveMember;
-	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/LogRemoveMember;Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataRemoveMember;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/LogRemoveMember;
+	public final fun component2 ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageView;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageView;Ljava/util/List;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/LogRemoveMember;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/LogRemoveMember;Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageView;Ljava/util/List;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/LogRemoveMember;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getConvoId ()Ljava/lang/String;
-	public final fun getMessage ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataRemoveMember;
+	public final fun getMessage ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageView;
+	public final fun getRelatedProfiles ()Ljava/util/List;
 	public final fun getRev ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -12476,17 +12564,20 @@ public final class io/github/kikin81/atproto/chat/bsky/convo/LogRemoveMember$Com
 
 public final class io/github/kikin81/atproto/chat/bsky/convo/LogRemoveReaction : io/github/kikin81/atproto/chat/bsky/convo/GetLogResponseLogsUnion {
 	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/LogRemoveReaction$Companion;
-	public fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/LogRemoveReactionMessageUnion;Lio/github/kikin81/atproto/chat/bsky/convo/ReactionView;Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/LogRemoveReactionMessageUnion;Lio/github/kikin81/atproto/chat/bsky/convo/ReactionView;Ljava/util/List;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/LogRemoveReactionMessageUnion;Lio/github/kikin81/atproto/chat/bsky/convo/ReactionView;Ljava/util/List;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Lio/github/kikin81/atproto/chat/bsky/convo/LogRemoveReactionMessageUnion;
 	public final fun component3 ()Lio/github/kikin81/atproto/chat/bsky/convo/ReactionView;
-	public final fun component4 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/LogRemoveReactionMessageUnion;Lio/github/kikin81/atproto/chat/bsky/convo/ReactionView;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/LogRemoveReaction;
-	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/LogRemoveReaction;Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/LogRemoveReactionMessageUnion;Lio/github/kikin81/atproto/chat/bsky/convo/ReactionView;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/LogRemoveReaction;
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/LogRemoveReactionMessageUnion;Lio/github/kikin81/atproto/chat/bsky/convo/ReactionView;Ljava/util/List;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/LogRemoveReaction;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/LogRemoveReaction;Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/LogRemoveReactionMessageUnion;Lio/github/kikin81/atproto/chat/bsky/convo/ReactionView;Ljava/util/List;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/LogRemoveReaction;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getConvoId ()Ljava/lang/String;
 	public final fun getMessage ()Lio/github/kikin81/atproto/chat/bsky/convo/LogRemoveReactionMessageUnion;
 	public final fun getReaction ()Lio/github/kikin81/atproto/chat/bsky/convo/ReactionView;
+	public final fun getRelatedProfiles ()Ljava/util/List;
 	public final fun getRev ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -12549,15 +12640,17 @@ public final class io/github/kikin81/atproto/chat/bsky/convo/LogRemoveReactionMe
 
 public final class io/github/kikin81/atproto/chat/bsky/convo/LogUnlockConvo : io/github/kikin81/atproto/chat/bsky/convo/GetLogResponseLogsUnion {
 	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/LogUnlockConvo$Companion;
-	public fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataUnlockConvo;Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageView;Ljava/util/List;Ljava/lang/String;)V
 	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataUnlockConvo;
-	public final fun component3 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataUnlockConvo;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/LogUnlockConvo;
-	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/LogUnlockConvo;Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataUnlockConvo;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/LogUnlockConvo;
+	public final fun component2 ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageView;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageView;Ljava/util/List;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/LogUnlockConvo;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/LogUnlockConvo;Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageView;Ljava/util/List;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/LogUnlockConvo;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getConvoId ()Ljava/lang/String;
-	public final fun getMessage ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataUnlockConvo;
+	public final fun getMessage ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageView;
+	public final fun getRelatedProfiles ()Ljava/util/List;
 	public final fun getRev ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -12604,6 +12697,66 @@ public final synthetic class io/github/kikin81/atproto/chat/bsky/convo/LogUnmute
 }
 
 public final class io/github/kikin81/atproto/chat/bsky/convo/LogUnmuteConvo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogWithdrawIncomingJoinRequest {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/LogWithdrawIncomingJoinRequest$Companion;
+	public fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/LogWithdrawIncomingJoinRequest;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/LogWithdrawIncomingJoinRequest;Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/LogWithdrawIncomingJoinRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConvoId ()Ljava/lang/String;
+	public final fun getMember ()Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;
+	public final fun getRev ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/convo/LogWithdrawIncomingJoinRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/LogWithdrawIncomingJoinRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/convo/LogWithdrawIncomingJoinRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/convo/LogWithdrawIncomingJoinRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogWithdrawIncomingJoinRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogWithdrawOutgoingJoinRequest {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/LogWithdrawOutgoingJoinRequest$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/LogWithdrawOutgoingJoinRequest;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/LogWithdrawOutgoingJoinRequest;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/LogWithdrawOutgoingJoinRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConvoId ()Ljava/lang/String;
+	public final fun getRev ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/convo/LogWithdrawOutgoingJoinRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/LogWithdrawOutgoingJoinRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/convo/LogWithdrawOutgoingJoinRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/convo/LogWithdrawOutgoingJoinRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogWithdrawOutgoingJoinRequest$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -13223,15 +13376,15 @@ public final class io/github/kikin81/atproto/chat/bsky/convo/SendMessageRequest$
 
 public final class io/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataAddMember : io/github/kikin81/atproto/chat/bsky/convo/SystemMessageViewDataUnion {
 	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataAddMember$Companion;
-	public fun <init> (Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;Ljava/lang/String;)V
-	public final fun component1 ()Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;
-	public final fun component2 ()Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;
+	public fun <init> (Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageReferredUser;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageReferredUser;Ljava/lang/String;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageReferredUser;
+	public final fun component2 ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageReferredUser;
 	public final fun component3 ()Ljava/lang/String;
-	public final fun copy (Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataAddMember;
-	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataAddMember;Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataAddMember;
+	public final fun copy (Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageReferredUser;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageReferredUser;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataAddMember;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataAddMember;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageReferredUser;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageReferredUser;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataAddMember;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getAddedBy ()Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;
-	public final fun getMember ()Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;
+	public final fun getAddedBy ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageReferredUser;
+	public final fun getMember ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageReferredUser;
 	public final fun getRole ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -13365,12 +13518,12 @@ public final class io/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataEn
 
 public final class io/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataLockConvo : io/github/kikin81/atproto/chat/bsky/convo/SystemMessageViewDataUnion {
 	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataLockConvo$Companion;
-	public fun <init> (Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;)V
-	public final fun component1 ()Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;
-	public final fun copy (Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;)Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataLockConvo;
-	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataLockConvo;Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataLockConvo;
+	public fun <init> (Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageReferredUser;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageReferredUser;
+	public final fun copy (Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageReferredUser;)Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataLockConvo;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataLockConvo;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageReferredUser;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataLockConvo;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getLockedBy ()Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;
+	public final fun getLockedBy ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageReferredUser;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -13392,12 +13545,12 @@ public final class io/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataLo
 
 public final class io/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataLockConvoPermanently : io/github/kikin81/atproto/chat/bsky/convo/SystemMessageViewDataUnion {
 	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataLockConvoPermanently$Companion;
-	public fun <init> (Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;)V
-	public final fun component1 ()Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;
-	public final fun copy (Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;)Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataLockConvoPermanently;
-	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataLockConvoPermanently;Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataLockConvoPermanently;
+	public fun <init> (Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageReferredUser;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageReferredUser;
+	public final fun copy (Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageReferredUser;)Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataLockConvoPermanently;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataLockConvoPermanently;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageReferredUser;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataLockConvoPermanently;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getLockedBy ()Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;
+	public final fun getLockedBy ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageReferredUser;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -13419,16 +13572,16 @@ public final class io/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataLo
 
 public final class io/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataMemberJoin : io/github/kikin81/atproto/chat/bsky/convo/SystemMessageViewDataUnion {
 	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataMemberJoin$Companion;
-	public fun <init> (Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;Ljava/lang/String;)V
-	public synthetic fun <init> (Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;
-	public final fun component2 ()Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;
+	public fun <init> (Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageReferredUser;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageReferredUser;Ljava/lang/String;)V
+	public synthetic fun <init> (Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageReferredUser;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageReferredUser;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageReferredUser;
+	public final fun component2 ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageReferredUser;
 	public final fun component3 ()Ljava/lang/String;
-	public final fun copy (Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataMemberJoin;
-	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataMemberJoin;Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataMemberJoin;
+	public final fun copy (Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageReferredUser;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageReferredUser;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataMemberJoin;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataMemberJoin;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageReferredUser;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageReferredUser;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataMemberJoin;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getApprovedBy ()Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;
-	public final fun getMember ()Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;
+	public final fun getApprovedBy ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageReferredUser;
+	public final fun getMember ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageReferredUser;
 	public final fun getRole ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -13451,12 +13604,12 @@ public final class io/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataMe
 
 public final class io/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataMemberLeave : io/github/kikin81/atproto/chat/bsky/convo/SystemMessageViewDataUnion {
 	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataMemberLeave$Companion;
-	public fun <init> (Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;)V
-	public final fun component1 ()Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;
-	public final fun copy (Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;)Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataMemberLeave;
-	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataMemberLeave;Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataMemberLeave;
+	public fun <init> (Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageReferredUser;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageReferredUser;
+	public final fun copy (Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageReferredUser;)Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataMemberLeave;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataMemberLeave;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageReferredUser;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataMemberLeave;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getMember ()Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;
+	public final fun getMember ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageReferredUser;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -13478,14 +13631,14 @@ public final class io/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataMe
 
 public final class io/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataRemoveMember : io/github/kikin81/atproto/chat/bsky/convo/SystemMessageViewDataUnion {
 	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataRemoveMember$Companion;
-	public fun <init> (Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;)V
-	public final fun component1 ()Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;
-	public final fun component2 ()Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;
-	public final fun copy (Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;)Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataRemoveMember;
-	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataRemoveMember;Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataRemoveMember;
+	public fun <init> (Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageReferredUser;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageReferredUser;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageReferredUser;
+	public final fun component2 ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageReferredUser;
+	public final fun copy (Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageReferredUser;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageReferredUser;)Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataRemoveMember;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataRemoveMember;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageReferredUser;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageReferredUser;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataRemoveMember;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getMember ()Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;
-	public final fun getRemovedBy ()Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;
+	public final fun getMember ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageReferredUser;
+	public final fun getRemovedBy ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageReferredUser;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -13507,12 +13660,12 @@ public final class io/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataRe
 
 public final class io/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataUnlockConvo : io/github/kikin81/atproto/chat/bsky/convo/SystemMessageViewDataUnion {
 	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataUnlockConvo$Companion;
-	public fun <init> (Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;)V
-	public final fun component1 ()Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;
-	public final fun copy (Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;)Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataUnlockConvo;
-	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataUnlockConvo;Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataUnlockConvo;
+	public fun <init> (Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageReferredUser;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageReferredUser;
+	public final fun copy (Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageReferredUser;)Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataUnlockConvo;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataUnlockConvo;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageReferredUser;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataUnlockConvo;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getUnlockedBy ()Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;
+	public final fun getUnlockedBy ()Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageReferredUser;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -13529,6 +13682,33 @@ public final synthetic class io/github/kikin81/atproto/chat/bsky/convo/SystemMes
 }
 
 public final class io/github/kikin81/atproto/chat/bsky/convo/SystemMessageDataUnlockConvo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/SystemMessageReferredUser {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageReferredUser$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-UyB9Nic ()Ljava/lang/String;
+	public final fun copy-OoJ1cAE (Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageReferredUser;
+	public static synthetic fun copy-OoJ1cAE$default (Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageReferredUser;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageReferredUser;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDid-UyB9Nic ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/convo/SystemMessageReferredUser$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageReferredUser$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageReferredUser;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/convo/SystemMessageReferredUser;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/SystemMessageReferredUser$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -13826,6 +14006,100 @@ public final class io/github/kikin81/atproto/chat/bsky/convo/UpdateReadResponse$
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class io/github/kikin81/atproto/chat/bsky/embed/JoinLink : io/github/kikin81/atproto/chat/bsky/convo/MessageInputEmbedUnion {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/embed/JoinLink$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/embed/JoinLink;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/embed/JoinLink;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/embed/JoinLink;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCode ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/embed/JoinLink$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/embed/JoinLink$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/embed/JoinLink;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/embed/JoinLink;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/embed/JoinLink$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/embed/JoinLinkView : io/github/kikin81/atproto/chat/bsky/convo/MessageViewEmbedUnion {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/embed/JoinLinkView$Companion;
+	public fun <init> (Lio/github/kikin81/atproto/chat/bsky/embed/JoinLinkViewJoinLinkPreviewUnion;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/chat/bsky/embed/JoinLinkViewJoinLinkPreviewUnion;
+	public final fun copy (Lio/github/kikin81/atproto/chat/bsky/embed/JoinLinkViewJoinLinkPreviewUnion;)Lio/github/kikin81/atproto/chat/bsky/embed/JoinLinkView;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/embed/JoinLinkView;Lio/github/kikin81/atproto/chat/bsky/embed/JoinLinkViewJoinLinkPreviewUnion;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/embed/JoinLinkView;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getJoinLinkPreview ()Lio/github/kikin81/atproto/chat/bsky/embed/JoinLinkViewJoinLinkPreviewUnion;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/embed/JoinLinkView$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/embed/JoinLinkView$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/embed/JoinLinkView;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/embed/JoinLinkView;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/embed/JoinLinkView$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class io/github/kikin81/atproto/chat/bsky/embed/JoinLinkViewJoinLinkPreviewUnion : io/github/kikin81/atproto/runtime/OpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/embed/JoinLinkViewJoinLinkPreviewUnion$Companion;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/embed/JoinLinkViewJoinLinkPreviewUnion$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/embed/JoinLinkViewJoinLinkPreviewUnion$Unknown : io/github/kikin81/atproto/chat/bsky/embed/JoinLinkViewJoinLinkPreviewUnion, io/github/kikin81/atproto/runtime/UnknownOpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/embed/JoinLinkViewJoinLinkPreviewUnion$Unknown$Companion;
+	public fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/chat/bsky/embed/JoinLinkViewJoinLinkPreviewUnion$Unknown;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/embed/JoinLinkViewJoinLinkPreviewUnion$Unknown;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/embed/JoinLinkViewJoinLinkPreviewUnion$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getRaw ()Lkotlinx/serialization/json/JsonObject;
+	public fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/embed/JoinLinkViewJoinLinkPreviewUnion$Unknown$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/embed/JoinLinkViewJoinLinkPreviewUnionSerializer : io/github/kikin81/atproto/runtime/OpenUnionSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/embed/JoinLinkViewJoinLinkPreviewUnionSerializer;
+	public fun selectKnownDeserializer (Ljava/lang/String;)Lkotlinx/serialization/KSerializer;
+	public fun selectKnownSerializer (Lio/github/kikin81/atproto/chat/bsky/embed/JoinLinkViewJoinLinkPreviewUnion;)Lkotlinx/serialization/KSerializer;
+	public synthetic fun selectKnownSerializer (Lio/github/kikin81/atproto/runtime/OpenUnionMember;)Lkotlinx/serialization/KSerializer;
+	public fun unknownSerializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/embed/JoinLinkViewJoinLinkPreviewUnionUnknownSerializer : io/github/kikin81/atproto/runtime/UnknownMemberSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/embed/JoinLinkViewJoinLinkPreviewUnionUnknownSerializer;
+	public fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/chat/bsky/embed/JoinLinkViewJoinLinkPreviewUnion$Unknown;
+	public synthetic fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/runtime/UnknownOpenUnionMember;
+}
+
 public final class io/github/kikin81/atproto/chat/bsky/group/AddMembersRequest {
 	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/group/AddMembersRequest$Companion;
 	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
@@ -14104,6 +14378,33 @@ public final synthetic class io/github/kikin81/atproto/chat/bsky/group/DisableJo
 }
 
 public final class io/github/kikin81/atproto/chat/bsky/group/DisableJoinLinkResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/DisabledJoinLinkPreviewView : io/github/kikin81/atproto/chat/bsky/embed/JoinLinkViewJoinLinkPreviewUnion {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/group/DisabledJoinLinkPreviewView$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/group/DisabledJoinLinkPreviewView;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/group/DisabledJoinLinkPreviewView;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/group/DisabledJoinLinkPreviewView;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCode ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/group/DisabledJoinLinkPreviewView$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/group/DisabledJoinLinkPreviewView$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/group/DisabledJoinLinkPreviewView;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/group/DisabledJoinLinkPreviewView;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/DisabledJoinLinkPreviewView$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -14399,6 +14700,79 @@ public final class io/github/kikin81/atproto/chat/bsky/group/GroupServiceKt {
 	public static final fun listJoinRequestsPageFlow (Lio/github/kikin81/atproto/chat/bsky/group/GroupService;Lio/github/kikin81/atproto/chat/bsky/group/ListJoinRequestsRequest;)Lkotlinx/coroutines/flow/Flow;
 }
 
+public final class io/github/kikin81/atproto/chat/bsky/group/InvalidJoinLinkPreviewView : io/github/kikin81/atproto/chat/bsky/embed/JoinLinkViewJoinLinkPreviewUnion {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/group/InvalidJoinLinkPreviewView$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/group/InvalidJoinLinkPreviewView;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/group/InvalidJoinLinkPreviewView;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/group/InvalidJoinLinkPreviewView;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCode ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/group/InvalidJoinLinkPreviewView$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/group/InvalidJoinLinkPreviewView$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/group/InvalidJoinLinkPreviewView;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/group/InvalidJoinLinkPreviewView;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/InvalidJoinLinkPreviewView$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/JoinLinkPreviewView : io/github/kikin81/atproto/chat/bsky/embed/JoinLinkViewJoinLinkPreviewUnion {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/group/JoinLinkPreviewView$Companion;
+	public fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/ConvoView;Ljava/lang/String;Ljava/lang/String;JJLjava/lang/String;Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;ZLio/github/kikin81/atproto/chat/bsky/group/JoinLinkViewerState;)V
+	public synthetic fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/ConvoView;Ljava/lang/String;Ljava/lang/String;JJLjava/lang/String;Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;ZLio/github/kikin81/atproto/chat/bsky/group/JoinLinkViewerState;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Lio/github/kikin81/atproto/chat/bsky/group/JoinLinkViewerState;
+	public final fun component2 ()Lio/github/kikin81/atproto/chat/bsky/convo/ConvoView;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()J
+	public final fun component6 ()J
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;
+	public final fun component9 ()Z
+	public final fun copy (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/ConvoView;Ljava/lang/String;Ljava/lang/String;JJLjava/lang/String;Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;ZLio/github/kikin81/atproto/chat/bsky/group/JoinLinkViewerState;)Lio/github/kikin81/atproto/chat/bsky/group/JoinLinkPreviewView;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/group/JoinLinkPreviewView;Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/ConvoView;Ljava/lang/String;Ljava/lang/String;JJLjava/lang/String;Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;ZLio/github/kikin81/atproto/chat/bsky/group/JoinLinkViewerState;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/group/JoinLinkPreviewView;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCode ()Ljava/lang/String;
+	public final fun getConvo ()Lio/github/kikin81/atproto/chat/bsky/convo/ConvoView;
+	public final fun getConvoId ()Ljava/lang/String;
+	public final fun getJoinRule ()Ljava/lang/String;
+	public final fun getMemberCount ()J
+	public final fun getMemberLimit ()J
+	public final fun getName ()Ljava/lang/String;
+	public final fun getOwner ()Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;
+	public final fun getRequireApproval ()Z
+	public final fun getViewer ()Lio/github/kikin81/atproto/chat/bsky/group/JoinLinkViewerState;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/group/JoinLinkPreviewView$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/group/JoinLinkPreviewView$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/group/JoinLinkPreviewView;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/group/JoinLinkPreviewView;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/JoinLinkPreviewView$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
 public final class io/github/kikin81/atproto/chat/bsky/group/JoinLinkView {
 	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/group/JoinLinkView$Companion;
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -14431,6 +14805,71 @@ public final synthetic class io/github/kikin81/atproto/chat/bsky/group/JoinLinkV
 }
 
 public final class io/github/kikin81/atproto/chat/bsky/group/JoinLinkView$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/JoinLinkViewerState {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/group/JoinLinkViewerState$Companion;
+	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-G5DCnlA ()Ljava/lang/String;
+	public final fun copy-hp3wcX0 (Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/group/JoinLinkViewerState;
+	public static synthetic fun copy-hp3wcX0$default (Lio/github/kikin81/atproto/chat/bsky/group/JoinLinkViewerState;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/group/JoinLinkViewerState;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getRequestedAt-G5DCnlA ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/group/JoinLinkViewerState$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/group/JoinLinkViewerState$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/group/JoinLinkViewerState;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/group/JoinLinkViewerState;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/JoinLinkViewerState$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/JoinRequestConvoView {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/group/JoinRequestConvoView$Companion;
+	public fun <init> (Ljava/lang/String;JJLjava/lang/String;Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;Lio/github/kikin81/atproto/chat/bsky/group/JoinLinkViewerState;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()J
+	public final fun component3 ()J
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;
+	public final fun component6 ()Lio/github/kikin81/atproto/chat/bsky/group/JoinLinkViewerState;
+	public final fun copy (Ljava/lang/String;JJLjava/lang/String;Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;Lio/github/kikin81/atproto/chat/bsky/group/JoinLinkViewerState;)Lio/github/kikin81/atproto/chat/bsky/group/JoinRequestConvoView;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/group/JoinRequestConvoView;Ljava/lang/String;JJLjava/lang/String;Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;Lio/github/kikin81/atproto/chat/bsky/group/JoinLinkViewerState;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/group/JoinRequestConvoView;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConvoId ()Ljava/lang/String;
+	public final fun getMemberCount ()J
+	public final fun getMemberLimit ()J
+	public final fun getName ()Ljava/lang/String;
+	public final fun getOwner ()Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;
+	public final fun getViewer ()Lio/github/kikin81/atproto/chat/bsky/group/JoinLinkViewerState;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/group/JoinRequestConvoView$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/group/JoinRequestConvoView$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/group/JoinRequestConvoView;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/group/JoinRequestConvoView;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/JoinRequestConvoView$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 


### PR DESCRIPTION
## Summary

Resolves the overlay staleness flagged by **#165** for the three drifted `chat.bsky.convo` overlays, and adopts the upstream group **join-link** feature they now depend on.

Re-vendored to `bluesky-social/atproto@9b05af9`:

- **`chat.bsky.convo.defs`** — refreshed to main. `sendMessage`/`sendMessageBatch` were drifting _only_ on a stray `$type: com.atproto.lexicon.schema` wrapper (they'd been vendored from the network schema-record shape rather than raw GitHub source, which the drift detector's key-sorted canonicalization does not strip). `convo.defs` additionally picks up the new group-chat machinery (`convoRef`, `systemMessageView`, `systemMessageReferredUser`, member counts, join-request fields) while keeping reply support (`replyTo`/`replyRef`).
- **`chat.bsky.convo.sendMessage` / `sendMessageBatch`** — now byte-match main (`$type` dropped, `ReplyTargetNotFound` intact).

New overlays (the cascade the `defs` refresh pulled in):

- **`chat.bsky.embed.joinLink`** — new upstream lexicon referenced by `convo.defs`' refreshed message/messageView embed unions. Present in atproto main but **unpublished on-network** (`npx lex install` → `RecordNotFound`), so `removeWhenPublished=true` (retire once publishable).
- **`chat.bsky.group.defs`** — **pinned superset shadow**. Merges main's new join-link preview defs (`joinLinkPreviewView` / `disabledJoinLinkPreviewView` / `invalidJoinLinkPreviewView` / `joinLinkViewerState` / `joinRequestConvoView`, needed by `chat.bsky.embed.joinLink#view`) with our **still-on-network `groupPublicView`**, which main deleted alongside `chat.bsky.group.getGroupPublicInfo` even though both remain published on-network. Intentionally **not** byte-equal to main (it re-adds `groupPublicView`), so it will keep reading as _drifted_ in #165 by design — documented in the manifest `reason`.

## Why the superset shadow

Overlay merge is whole-document, overlay-wins. Main's `group.defs` removes `groupPublicView`, but our corpus's `getGroupPublicInfo` (still published on-network) references it. A straight copy of main's `group.defs` would break `getGroupPublicInfo` codegen. The superset keeps both worlds working until the network catches up.

## Verification

JVM-targeted (iOS-sim link is skipped on the author's CLT-only machine):

- ✅ `:generator:generateModels` — 169 documents, full cascade resolves
- ✅ `:generator:test`
- ✅ `:models:compileKotlinJvm` + `:models:jvmTest`
- ✅ Generated `JoinLink` / `JoinLinkView` / preview-view types **and** `GroupPublicView` / `GetGroupPublicInfoResponse` all emit — no conflict

## Effect on #165 (next weekly run)

| Overlay | New status |
|---|---|
| `convo.defs`, `sendMessage`, `sendMessageBatch` | in-sync ✅ |
| `chat.bsky.embed.joinLink` | not-yet-publishable, in-sync |
| `chat.bsky.group.defs` | drifted **by design** (superset) — retire manually once network publishes join-links & drops `getGroupPublicInfo` |