### PR TITLE
chore(lexicons): bump @atproto/lex to 0.3.0

### DIFF
--- a/generator/lexicons.json
+++ b/generator/lexicons.json
@@ -148,7 +148,7 @@
   "resolutions": {
     "app.bsky.actor.defs": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.actor.defs",
-      "cid": "bafyreiel3mr6hz7g4wy5l6pkrwqh7affgluhfszvrrduc7p66os5cfkqdq"
+      "cid": "bafyreielcp7ccfxuvtdthry5qqdqmvcqo5wx3shkuz32xd5rlypmhw6ufa"
     },
     "app.bsky.actor.getPreferences": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.actor.getPreferences",
@@ -208,7 +208,7 @@
     },
     "app.bsky.draft.defs": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.draft.defs",
-      "cid": "bafyreihdczcc26i65izy6xwpwjgwhm36kqxa6ouytgwdjrugdn3vp3bb5i"
+      "cid": "bafyreiewy3wgajj4al6xifjc2e5gpg4yyj4laf2gl7pe3liekulfzxnlcu"
     },
     "app.bsky.draft.deleteDraft": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.draft.deleteDraft",
@@ -228,7 +228,11 @@
     },
     "app.bsky.embed.external": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.embed.external",
-      "cid": "bafyreiblxmpzgwg4fbr45b4xzts3h4k72k7cdnrxy2ub2w5d7mnwzznkwi"
+      "cid": "bafyreigwach36azu4xg3jvcmb6fe53umfln3wkuj5srqsvcjaypa6rw534"
+    },
+    "app.bsky.embed.gallery": {
+      "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.embed.gallery",
+      "cid": "bafyreia4tixag4sadkirfo63qfma6fz3ifbqanify4e6ce6swkl5lwjnfq"
     },
     "app.bsky.embed.images": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.embed.images",
@@ -236,11 +240,11 @@
     },
     "app.bsky.embed.record": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.embed.record",
-      "cid": "bafyreigdtmu53blwxoygphg5zh5zpmlftz64c3jyqpv2yqpx3nrichkyla"
+      "cid": "bafyreia7yq4c6rqkz32fjf6gj5rcvxsirguducn545s3dvls7qutnn2ali"
     },
     "app.bsky.embed.recordWithMedia": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.embed.recordWithMedia",
-      "cid": "bafyreia7jrw2p73egm7vrunssgzeyj2rwmk3s4dymfhgzcavxjfaje3qfi"
+      "cid": "bafyreidszvpeqf7copdmowm4ln4eyhahlqxktlvootjjjdmtkwy6s62jya"
     },
     "app.bsky.embed.video": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.embed.video",
@@ -248,7 +252,7 @@
     },
     "app.bsky.feed.defs": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.feed.defs",
-      "cid": "bafyreiadwvxawxifsnm7ae6l56aq23qs7ndih7npgs6pxmkoin7gi3k6pu"
+      "cid": "bafyreibg2zvz4n25vtd5yfqlodqra72s4h4lz7vwdexoutv3523wbw6jca"
     },
     "app.bsky.feed.describeFeedGenerator": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.feed.describeFeedGenerator",
@@ -324,7 +328,7 @@
     },
     "app.bsky.feed.post": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.feed.post",
-      "cid": "bafyreidgbehqwweghrrddfu6jgj7lyr6fwhzgazhirnszdb5lvr7iynkiy"
+      "cid": "bafyreia7rgxu7467phwpcgzaw62l5bzmxufkpikrc5zm4q3xhjmuhq4pti"
     },
     "app.bsky.feed.postgate": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.feed.postgate",
@@ -488,7 +492,7 @@
     },
     "app.bsky.notification.defs": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.notification.defs",
-      "cid": "bafyreickbpnayydlyfakliahgf23jjuesllh6qrslyofk5yz5xizjavhui"
+      "cid": "bafyreifzktxnol5rafjoznauk5j7ub2gsxxm7qjskg3vqmcgn6krrsz55u"
     },
     "app.bsky.notification.getPreferences": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.notification.getPreferences",
@@ -516,7 +520,7 @@
     },
     "app.bsky.notification.putPreferencesV2": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.notification.putPreferencesV2",
-      "cid": "bafyreid3bgb3cyflm3gohbfy5tuz5vy7ufyqzdycro3kbdnxsfeiz7xtba"
+      "cid": "bafyreiefun5klfddbnd7gfodnlcbn7ing45qo6lbmsahau7qgw4zlgv42i"
     },
     "app.bsky.notification.registerPush": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.notification.registerPush",
@@ -552,11 +556,11 @@
     },
     "chat.bsky.actor.declaration": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/chat.bsky.actor.declaration",
-      "cid": "bafyreihvdkojcsn3la75cyx23uvaacrycwa23c564t44knnf4tfg7grdua"
+      "cid": "bafyreih4ivey4vqreb2ebujlt7iranqyizxkv5kpm3ksdlgkinkgcu53pu"
     },
     "chat.bsky.actor.defs": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/chat.bsky.actor.defs",
-      "cid": "bafyreickicbqqlrufpuy63sheyz2wpr23lfpr3snvbykvidpth5sye7vfa"
+      "cid": "bafyreigiv5fo5iufd3ahma6tgtozm35xibvx276nhjsjwuvsvxh3zj7u7q"
     },
     "chat.bsky.convo.acceptConvo": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/chat.bsky.convo.acceptConvo",
@@ -568,7 +572,7 @@
     },
     "chat.bsky.convo.defs": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/chat.bsky.convo.defs",
-      "cid": "bafyreif46wyhygr4akuqtfb2rliraocrhk3echog4ahmskfomsqjo5uxmi"
+      "cid": "bafyreibpb3r5pqc3yrjslx7ntfl5vvgdlgqanuwbcvq3q7sfhayi75x7uu"
     },
     "chat.bsky.convo.deleteMessageForSelf": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/chat.bsky.convo.deleteMessageForSelf",
@@ -584,15 +588,15 @@
     },
     "chat.bsky.convo.getConvoForMembers": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/chat.bsky.convo.getConvoForMembers",
-      "cid": "bafyreicpn5gbykpm3hvkartgl3k2tx7fyigbn3coohyi2g247afojpnr3a"
+      "cid": "bafyreicheufh7jkrstr6hgpggylildyh3k5tihbh5747dumqe5nabp24fi"
     },
     "chat.bsky.convo.getLog": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/chat.bsky.convo.getLog",
-      "cid": "bafyreih4jq547al4wee2izwgaq4cmfac4wjopym3y5mx3hjrs5czo6ojly"
+      "cid": "bafyreicc4wwkmh5rskpzyriwad4lte64rk2w7vnzzzofy6tnhbisxsint4"
     },
     "chat.bsky.convo.getMessages": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/chat.bsky.convo.getMessages",
-      "cid": "bafyreicut6yabxeefbl2hkk3zz2q7zdovy2l4wv4qykgcjxjgathjp54u4"
+      "cid": "bafyreif2fjad4zrbjwhbuk3ny7yfnv6sjyr6llrveh2dr4i2aovwe77yia"
     },
     "chat.bsky.convo.leaveConvo": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/chat.bsky.convo.leaveConvo",
@@ -600,15 +604,15 @@
     },
     "chat.bsky.convo.listConvoRequests": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/chat.bsky.convo.listConvoRequests",
-      "cid": "bafyreignpgx772kqtsf5tqhitvahyrxbdch5rg62zppfnm4ls2fmpiizau"
+      "cid": "bafyreieoce2dsrg6czlm7tkfi7glxjvqh6wwvfq777s5zxi6hyzqjeqo3e"
     },
     "chat.bsky.convo.listConvos": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/chat.bsky.convo.listConvos",
-      "cid": "bafyreigf3hvxzfz5xckh6pb4rk7afuufbt2gprxnbqible4oeackscpsdq"
+      "cid": "bafyreifxh52sx6i7vrlj2xi5h3yd56dmawkplcfdsfiu4npou6rutz4pge"
     },
     "chat.bsky.convo.lockConvo": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/chat.bsky.convo.lockConvo",
-      "cid": "bafyreiattmdxh63p2fkjbefqoehje7kfu34pi5cckgmggnyhrrtmcbc3ja"
+      "cid": "bafyreidnrgfxtyg233wfvasho34p34k2tiekrpiticcl4sau7k2masydby"
     },
     "chat.bsky.convo.muteConvo": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/chat.bsky.convo.muteConvo",
@@ -620,15 +624,15 @@
     },
     "chat.bsky.convo.sendMessage": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/chat.bsky.convo.sendMessage",
-      "cid": "bafyreihtjzavhhwg5mw6fq2pbev22cqgqs7mqi22trv2jzzyaym5auoyhq"
+      "cid": "bafyreih7yu45wtptd7qjg6iomrugxucfw7zkkz7ijjj7o3bddee3od2q3m"
     },
     "chat.bsky.convo.sendMessageBatch": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/chat.bsky.convo.sendMessageBatch",
-      "cid": "bafyreigpxeuskx4sapps6m77juy44h6ynmxm3cl5eclztdzpgwrb37l7wm"
+      "cid": "bafyreifvinecphums77xvuuspqgjkgfa7cpre3zavtrkh5tffmi643q2rq"
     },
     "chat.bsky.convo.unlockConvo": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/chat.bsky.convo.unlockConvo",
-      "cid": "bafyreihymhdnjqemo6ivpwseqf64bgae6qgfcwhz36ozehuilkdxx3tf24"
+      "cid": "bafyreiaind2trvtuo2bgqupx4acxx5vvfhvvo4xwencwcf2trnrithwkya"
     },
     "chat.bsky.convo.unmuteConvo": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/chat.bsky.convo.unmuteConvo",
@@ -642,41 +646,45 @@
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/chat.bsky.convo.updateRead",
       "cid": "bafyreihba5bopb5vnlqqvtavipybqgemp6itwrz4xysnp6yi6iow5ntnv4"
     },
+    "chat.bsky.embed.joinLink": {
+      "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/chat.bsky.embed.joinLink",
+      "cid": "bafyreib3z65a2myai4hc55vxa7woue4bmelo2a4dlgnawps746w3l2y72q"
+    },
     "chat.bsky.group.addMembers": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/chat.bsky.group.addMembers",
-      "cid": "bafyreidz4it2vt6aryamffurawefazntxepyvfgkwbcqdjjc4c3h6qtsem"
+      "cid": "bafyreiftelalu5yc3zctgch7req6syovskusqgma5vyyd4elas5rs47tvy"
     },
     "chat.bsky.group.approveJoinRequest": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/chat.bsky.group.approveJoinRequest",
-      "cid": "bafyreif2gatuzapbhqwfv6j2fdwocnkb2whsxoagek25s7byirpslyw5pa"
+      "cid": "bafyreicykc372f7ebk7c3wrco75wgox3poyop7w3duovvn2piqzsvhzthq"
     },
     "chat.bsky.group.createGroup": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/chat.bsky.group.createGroup",
-      "cid": "bafyreifujsn7jyf26dmvsapfy4pfqifj57zxx3jeipcve2ubqhztv4pm24"
+      "cid": "bafyreicpqjbpipx4mxby5mujguw2rwpewycm2h6ybbdiycdnghxqgertju"
     },
     "chat.bsky.group.createJoinLink": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/chat.bsky.group.createJoinLink",
-      "cid": "bafyreic2r6qjbm3x677iup4ldjuvyyud3o3gma62xyshyaul5iv3b4gllu"
+      "cid": "bafyreicxjzsyjrqbkwd7vztmaxstgulx5naln55gsppix27pjnoz5okv7i"
     },
     "chat.bsky.group.defs": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/chat.bsky.group.defs",
-      "cid": "bafyreidzaadxqcphdzsw2alge3sjhhqbysasjhethrpne3hskpt5zkkhbe"
+      "cid": "bafyreiexck6gwns5nesq44mqgsikwrjkgplz33cemxaq365xwdcxeoqjje"
     },
     "chat.bsky.group.disableJoinLink": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/chat.bsky.group.disableJoinLink",
-      "cid": "bafyreibn73w5rothrl7yoqyl52sk7lmxghkkhyjlyqvlwyj5lanqefcyce"
+      "cid": "bafyreiholtxhmuqku64fkv6rjl2rn3jyicutkcuieoviys3zdzx6lh43n4"
     },
     "chat.bsky.group.editGroup": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/chat.bsky.group.editGroup",
-      "cid": "bafyreifbijqfi6xn2eikn2uwd6nc4q3chw2grup7wdt3lujdpd2fyvemvi"
+      "cid": "bafyreifwwj2mzridii6sm6wlc5sxgu7g6k67bijvylus4jnbvfcup7ecfe"
     },
     "chat.bsky.group.editJoinLink": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/chat.bsky.group.editJoinLink",
-      "cid": "bafyreidoctndxfcpgek3cuwbm3eawm6lmzw4rinyl6fvty63gypekfjzqq"
+      "cid": "bafyreiafmbnein4xpbr76jzofk53ut6u5opeuwyorilkhpe3u2kzgavlde"
     },
     "chat.bsky.group.enableJoinLink": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/chat.bsky.group.enableJoinLink",
-      "cid": "bafyreih2bxrn5okcduaqyrqye63cqjomceag7mh6uproralortxomd7pnu"
+      "cid": "bafyreib45q6ccuobjlws7sysjojabo6gvww6wlgy7dif5ejkoasb23l7su"
     },
     "chat.bsky.group.getGroupPublicInfo": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/chat.bsky.group.getGroupPublicInfo",
@@ -684,19 +692,19 @@
     },
     "chat.bsky.group.listJoinRequests": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/chat.bsky.group.listJoinRequests",
-      "cid": "bafyreiaqwkeq3hyflrcetnxzgznf5t2kqfkhyk4a37ac3pmwcmlsnyydw4"
+      "cid": "bafyreigoj66wx3sx7nbav4ywxckk7ggjklxvy2w5tmmnrapib7nfpgh3ci"
     },
     "chat.bsky.group.rejectJoinRequest": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/chat.bsky.group.rejectJoinRequest",
-      "cid": "bafyreiaen4jmy467wurzsuugx5k6vidp5bxnztwfu7323nkroaj6kwldmi"
+      "cid": "bafyreiaztaygpnfglcldsdbh5dunovp2nz3kenetahycpymoxxrxkafiha"
     },
     "chat.bsky.group.removeMembers": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/chat.bsky.group.removeMembers",
-      "cid": "bafyreictig3qsep2iwigxkn3stdfzrqnwad2kxvqb35n3o4lfjihmp3qzq"
+      "cid": "bafyreidfkumfvrtsseaavuhs2lfblcsmrjbkeaeojh2u576jze5xrfcasy"
     },
     "chat.bsky.group.requestJoin": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/chat.bsky.group.requestJoin",
-      "cid": "bafyreid44ifkqtpefyqig2qhwbsutgybc7pbevzwtgxhkxlikhtqi5t4t4"
+      "cid": "bafyreiatzqdp7zlnbqmbti6xt3orag7yqyuqr6tqzwzzp52gq7hlu3it6q"
     },
     "com.atproto.admin.defs": {
       "uri": "at://did:plc:6msi3pj7krzih5qxqtryxlzw/com.atproto.lexicon.schema/com.atproto.admin.defs",

--- a/generator/package-lock.json
+++ b/generator/package-lock.json
@@ -8,20 +8,20 @@
       "name": "kikinlex-atproto-generator-lexicons",
       "version": "0.0.0",
       "dependencies": {
-        "@atproto/lex": "0.1.7"
+        "@atproto/lex": "0.3.0"
       }
     },
     "node_modules/@atproto-labs/did-resolver": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@atproto-labs/did-resolver/-/did-resolver-0.3.4.tgz",
-      "integrity": "sha512-nBECoVG59NfbYthayxfR0s1dLFVdN+RKMaL0p0uaNX/U1SAETksN6Yydmr4oWOKSkyyU3GO9XZeo1yzwHnRcZw==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@atproto-labs/did-resolver/-/did-resolver-0.3.5.tgz",
+      "integrity": "sha512-0dMM+hj40VQiD/EJhlC1UMQgPXRwKeqM7NgJte7fVuYMv5b3P0W6+Lu3iDumHULcSjMmMXxJZzoi3i493Y0gCA==",
       "license": "MIT",
       "dependencies": {
-        "@atproto-labs/fetch": "^0.3.3",
-        "@atproto-labs/pipe": "^0.2.3",
-        "@atproto-labs/simple-store": "^0.4.3",
-        "@atproto-labs/simple-store-memory": "^0.2.3",
-        "@atproto/did": "^0.5.3",
+        "@atproto-labs/fetch": "^0.3.4",
+        "@atproto-labs/pipe": "^0.2.4",
+        "@atproto-labs/simple-store": "^0.4.4",
+        "@atproto-labs/simple-store-memory": "^0.2.4",
+        "@atproto/did": "^0.5.4",
         "zod": "^3.23.8"
       },
       "engines": {
@@ -29,42 +29,42 @@
       }
     },
     "node_modules/@atproto-labs/fetch": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@atproto-labs/fetch/-/fetch-0.3.3.tgz",
-      "integrity": "sha512-2gABLf0VEI86Sxo6YhGKQYK1tGhTZ4y+3TrCWputnupEZxuS/hw6+pFw9ceXZ3v9nnMNthzsAEcaAQ3V/tXsqg==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@atproto-labs/fetch/-/fetch-0.3.4.tgz",
+      "integrity": "sha512-YxXwi8HMk2HHDd5rljPGqxZ8bSeU78sFNz511Y222D0FraEq98p2r1ifkIgI23KQOfy0k0VzafeJAiGDh1CvfQ==",
       "license": "MIT",
       "dependencies": {
-        "@atproto-labs/pipe": "^0.2.3"
+        "@atproto-labs/pipe": "^0.2.4"
       },
       "engines": {
         "node": ">=22"
       }
     },
     "node_modules/@atproto-labs/pipe": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@atproto-labs/pipe/-/pipe-0.2.3.tgz",
-      "integrity": "sha512-hsjkaKGdhEGKhXuOOfIeYyZSQZfw007AXQJak/QTd9pLY1wHUJG85a9+u13xoMeav95gHkBRzswti7+kqsxgdw==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@atproto-labs/pipe/-/pipe-0.2.4.tgz",
+      "integrity": "sha512-n67jCcrC+ouAeO10cWkpPzzLMlDi/lDCU30Us+LGqhOPhT6c4t5ASdBLQi9W3jUQtRzQBt3G9zipF+xKWNvVbw==",
       "license": "MIT",
       "engines": {
         "node": ">=22"
       }
     },
     "node_modules/@atproto-labs/simple-store": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@atproto-labs/simple-store/-/simple-store-0.4.3.tgz",
-      "integrity": "sha512-ML1HAEtQIixkcU4FCGbZtAkoHTfmXDi63tNVuSSPG/cVUKyrUURg6Cr1bcfvbbkMTwRj9abEwa3JZR7UUYi4Ew==",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@atproto-labs/simple-store/-/simple-store-0.4.4.tgz",
+      "integrity": "sha512-3YH03xg99ZUS6Fq/6jcKRiZwUbzDb58xmS7ibg0y4+dukwrHa92cV/md76RpQJkAo9KYBvwLETdvF6fNtwIoGw==",
       "license": "MIT",
       "engines": {
         "node": ">=22"
       }
     },
     "node_modules/@atproto-labs/simple-store-memory": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@atproto-labs/simple-store-memory/-/simple-store-memory-0.2.3.tgz",
-      "integrity": "sha512-RtL48op8Db/QFNbW+9Y+Os6DOMqysOkoG5QelTZ0qcZt/j0pUBY8v2zSr5/faVJ5Y30h1cONxMydV48tVWf8pg==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@atproto-labs/simple-store-memory/-/simple-store-memory-0.2.4.tgz",
+      "integrity": "sha512-xAAUlOP9etqP9GGmJPq9gY1bRuJlZFdsC6wtAJSwUwMTwLRdenR7s8Qg5nxhbth5XL1XOtGABoD59NW3p+sl4A==",
       "license": "MIT",
       "dependencies": {
-        "@atproto-labs/simple-store": "^0.4.3",
+        "@atproto-labs/simple-store": "^0.4.4",
         "lru-cache": "^10.2.0"
       },
       "engines": {
@@ -72,14 +72,14 @@
       }
     },
     "node_modules/@atproto/common": {
-      "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/@atproto/common/-/common-0.6.5.tgz",
-      "integrity": "sha512-D3JWWRVTbwxFI2eXqbTqHUi+RXXIupQCyWIQIm1dV/2b0tvSrlRsZQglKRYkIJnIbO5F+dlvdn8KfPGpZlpi9A==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@atproto/common/-/common-0.7.2.tgz",
+      "integrity": "sha512-D43QVEnSgWhzEoelJTWouPrwdjfHPAe5xVEc5RtsA6OTKEPaEJN0LSFd495ZtanMrvvC+KrgW8Tk02C8kvp45A==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/common-web": "^0.5.3",
-        "@atproto/lex-cbor": "^0.1.3",
-        "@atproto/lex-data": "^0.1.4",
+        "@atproto/common-web": "^0.5.6",
+        "@atproto/lex-cbor": "^0.1.4",
+        "@atproto/lex-data": "^0.1.5",
         "multiformats": "^13.0.0",
         "pino": "^10.3.1"
       },
@@ -88,14 +88,14 @@
       }
     },
     "node_modules/@atproto/common-web": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@atproto/common-web/-/common-web-0.5.3.tgz",
-      "integrity": "sha512-FkMhOcNv1y7r5984+zXB+uMN4zJ4QFLEbZrYyQo6bNCf/Kfav/pEHXXENlaZEOweq2NYXf+tr2giMssBuM9u5A==",
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/@atproto/common-web/-/common-web-0.5.6.tgz",
+      "integrity": "sha512-5Y4MIK9dpkJPiKiE6u7iEHitxj+g3aAU2GfGL686JlKE2zDKD4y18BJb+uVek6nXQKb5XOdNVvw+7BHarpn8Fw==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/lex-data": "^0.1.4",
-        "@atproto/lex-json": "^0.1.3",
-        "@atproto/syntax": "^0.6.4",
+        "@atproto/lex-data": "^0.1.5",
+        "@atproto/lex-json": "^0.1.4",
+        "@atproto/syntax": "^0.7.2",
         "zod": "^3.23.8"
       },
       "engines": {
@@ -103,9 +103,9 @@
       }
     },
     "node_modules/@atproto/crypto": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@atproto/crypto/-/crypto-0.5.3.tgz",
-      "integrity": "sha512-Ea5VwU+ofVXrm4BWpTa7gI9kz7A6NwPpCY6r0f5k8UJpNq0GDHSb1F5MdsFDVNnSK5bEI7DIMNZwspkNsAKOgA==",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@atproto/crypto/-/crypto-0.5.4.tgz",
+      "integrity": "sha512-UR0BkuYNYuFtw+dA+y/oPPxzX0SWRnGJ+1Cfh/jGP1BvjRUyezK3omjpeLms5fYrXbM9vnfX+ckJFJqkBgLOdw==",
       "license": "MIT",
       "dependencies": {
         "@noble/curves": "^1.7.0",
@@ -117,9 +117,9 @@
       }
     },
     "node_modules/@atproto/did": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@atproto/did/-/did-0.5.3.tgz",
-      "integrity": "sha512-nKcdu5qB9iNJFaBeQOQUJ+6mA1npFcZ3DmD0xB+etkMRd/3UvOQql/CvcMZaYzl+eGoVs1JDdEsvoZz+idfhaw==",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@atproto/did/-/did-0.5.4.tgz",
+      "integrity": "sha512-BlnwQ+obL+4ZA71KH/EzZ3TY+cpSxnLiUI85mjBJIQwvDF/oN2sQA18wIj9jpduviIt2b/cMtlJuzHjzBkfXvw==",
       "license": "MIT",
       "dependencies": {
         "zod": "^3.23.8"
@@ -129,17 +129,17 @@
       }
     },
     "node_modules/@atproto/lex": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/@atproto/lex/-/lex-0.1.7.tgz",
-      "integrity": "sha512-BynDCIZ3kKalhRcj2lCTW5+ksKmfTOgUVYHi9Z1VqYnAfW8ZaA9MKdN1OBZvitDJzx1qMbmGS+JMszm8yFs5gQ==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@atproto/lex/-/lex-0.3.0.tgz",
+      "integrity": "sha512-Ir5f60NrCScDMZ2JGoxUHOQm+h6XlsDSykk0HzET8/qEeHTLwnI+MJIlBwB64eBoqGQ72qAEoMc8L+bJil+huA==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/lex-builder": "^0.1.5",
-        "@atproto/lex-client": "^0.2.1",
-        "@atproto/lex-data": "^0.1.4",
-        "@atproto/lex-installer": "^0.1.4",
-        "@atproto/lex-json": "^0.1.3",
-        "@atproto/lex-schema": "^0.1.6",
+        "@atproto/lex-builder": "^0.1.8",
+        "@atproto/lex-client": "^0.3.0",
+        "@atproto/lex-data": "^0.1.5",
+        "@atproto/lex-installer": "^0.1.9",
+        "@atproto/lex-json": "^0.1.4",
+        "@atproto/lex-schema": "^0.2.2",
         "tslib": "^2.8.1",
         "yargs": "^18.0.0"
       },
@@ -152,13 +152,13 @@
       }
     },
     "node_modules/@atproto/lex-builder": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/@atproto/lex-builder/-/lex-builder-0.1.5.tgz",
-      "integrity": "sha512-wh4nOGD0NuXBbRfrb4XBQZruuboRZs+rfhv2yWCR2zeEAWEqVU2+hVVNdQPDfa+rkghXENF31JIKftbz9NF6Ww==",
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/@atproto/lex-builder/-/lex-builder-0.1.8.tgz",
+      "integrity": "sha512-GYWisNom/J1MmFeSgMIFUgEj8yVKnvuJfyX1FwNKCczwfAunEdMy2Iiolq3JZNjWmH8uCtCWj7dg2GwQuEos7Q==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/lex-document": "^0.1.3",
-        "@atproto/lex-schema": "^0.1.6",
+        "@atproto/lex-document": "^0.1.6",
+        "@atproto/lex-schema": "^0.2.2",
         "prettier": "^3.2.5",
         "ts-morph": "^27.0.0",
         "tslib": "^2.8.1"
@@ -168,12 +168,12 @@
       }
     },
     "node_modules/@atproto/lex-cbor": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@atproto/lex-cbor/-/lex-cbor-0.1.3.tgz",
-      "integrity": "sha512-L9g6X8DAus+CrgrxwKehn5EUjsYuuySmUttkaHngXAT9+QOIsGqe7Bdcfd2FBZxomFjCamp5hFrN5M4hrGpdNA==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@atproto/lex-cbor/-/lex-cbor-0.1.4.tgz",
+      "integrity": "sha512-1reaooZfNFunJn2Fz21Up7iFQBPZlifQKlBsRvQoLG67mv43nmH4dZWgnGLD54ShCu8dyZ8Y6Wgh7BCg+2gRSw==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/lex-data": "^0.1.4",
+        "@atproto/lex-data": "^0.1.5",
         "cborg": "^4.5.8",
         "tslib": "^2.8.1"
       },
@@ -182,14 +182,14 @@
       }
     },
     "node_modules/@atproto/lex-client": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@atproto/lex-client/-/lex-client-0.2.1.tgz",
-      "integrity": "sha512-b/LXpLt3HZZEfItruCcPpHUbzoo+LjoOp0GetlTuHX0UnJYqzk4zLg5qSMTDo4JoHU4hFO1+26R6cg986ZvUAg==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@atproto/lex-client/-/lex-client-0.3.0.tgz",
+      "integrity": "sha512-P+S3hWdIIOgNTun7J42dvxSyCkQog3Q2ShTjvcwP761TqiRex7zDWaRAaT9gvCy6I4pRuNdBCStysjSMlJeSdg==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/lex-data": "^0.1.4",
-        "@atproto/lex-json": "^0.1.3",
-        "@atproto/lex-schema": "^0.1.6",
+        "@atproto/lex-data": "^0.1.5",
+        "@atproto/lex-json": "^0.1.4",
+        "@atproto/lex-schema": "^0.2.2",
         "tslib": "^2.8.1"
       },
       "engines": {
@@ -197,14 +197,13 @@
       }
     },
     "node_modules/@atproto/lex-data": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@atproto/lex-data/-/lex-data-0.1.4.tgz",
-      "integrity": "sha512-f9U95sk0zUtxHktvK59peU+Shd0cIUYV68p//GS7sfdkAxUIeaspvX6CY+Quv9Oa4aozmsXI52SjaNn1wuU8RQ==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@atproto/lex-data/-/lex-data-0.1.5.tgz",
+      "integrity": "sha512-TEM6GHuYpNm4O90LjNgbYq1Gmcr875S+BHrDxkg4PB5w/nlsz4HlbkGQG/WP/xbIV5O8TF5nNHDpCZ5ezTRrFA==",
       "license": "MIT",
       "dependencies": {
         "multiformats": "^13.0.0",
         "tslib": "^2.8.1",
-        "uint8arrays": "^5.0.0",
         "unicode-segmenter": "^0.14.0"
       },
       "engines": {
@@ -212,12 +211,12 @@
       }
     },
     "node_modules/@atproto/lex-document": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@atproto/lex-document/-/lex-document-0.1.3.tgz",
-      "integrity": "sha512-29NHO3dLlrJCBc7Fh9A0o7ZH2HAvhojmwR9kF1sEL+4GwMg0W/1JfMnF38aA/dT0ytFuZyryK0oCkYCoMVqHNw==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@atproto/lex-document/-/lex-document-0.1.6.tgz",
+      "integrity": "sha512-Yxc6LJ8tE0cntQ35ewagGbl7HOMX4jRkuEQ3ct+I43LKJBQPSk02rlwTY9A7SR/ULptN4Dn7XVqskEntWmCjWA==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/lex-schema": "^0.1.6",
+        "@atproto/lex-schema": "^0.2.2",
         "core-js": "^3",
         "tslib": "^2.8.1"
       },
@@ -226,18 +225,18 @@
       }
     },
     "node_modules/@atproto/lex-installer": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@atproto/lex-installer/-/lex-installer-0.1.4.tgz",
-      "integrity": "sha512-H6AhjPPYbH+6sJ9xNY6zrA1t2IVdze8idk6SgJqQnGESL+v3bblVsfYsx394DveEnQ7pO2sikKwkxZ9emBnBbQ==",
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/@atproto/lex-installer/-/lex-installer-0.1.9.tgz",
+      "integrity": "sha512-9PdApXnwtBRGty0muK/t5CUHv18nBtkut5Q5ibDcBhYKrsVmBAVNCXLqMreC2kbZf3q5L4+IfqtqMejmAZw2Mg==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/lex-builder": "^0.1.5",
-        "@atproto/lex-cbor": "^0.1.3",
-        "@atproto/lex-data": "^0.1.4",
-        "@atproto/lex-document": "^0.1.3",
-        "@atproto/lex-resolver": "^0.1.4",
-        "@atproto/lex-schema": "^0.1.6",
-        "@atproto/syntax": "^0.6.4",
+        "@atproto/lex-builder": "^0.1.8",
+        "@atproto/lex-cbor": "^0.1.4",
+        "@atproto/lex-data": "^0.1.5",
+        "@atproto/lex-document": "^0.1.6",
+        "@atproto/lex-resolver": "^0.2.2",
+        "@atproto/lex-schema": "^0.2.2",
+        "@atproto/syntax": "^0.7.2",
         "tslib": "^2.8.1"
       },
       "engines": {
@@ -245,12 +244,12 @@
       }
     },
     "node_modules/@atproto/lex-json": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@atproto/lex-json/-/lex-json-0.1.3.tgz",
-      "integrity": "sha512-Ch2w9bCLFOwWINFFxpZo6DBW7+ZxkehciU3P8N94gSyENLe3/5WWXHdHvkiH7EXZrpI7fKY8nVWn4GIL0ttqxw==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@atproto/lex-json/-/lex-json-0.1.4.tgz",
+      "integrity": "sha512-ENR2cWkVrES+UL6TovbCRdX9BJOyHHJUS8jYx3Lxp3j4vEphjn/u+DW7bWloST2O8ID2OuVlt6+28ftNEEjmQQ==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/lex-data": "^0.1.4",
+        "@atproto/lex-data": "^0.1.5",
         "tslib": "^2.8.1"
       },
       "engines": {
@@ -258,19 +257,19 @@
       }
     },
     "node_modules/@atproto/lex-resolver": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@atproto/lex-resolver/-/lex-resolver-0.1.4.tgz",
-      "integrity": "sha512-Q114oD+M3mF0owQDds28r7IY+7H7/ajknceXMLtgwUQ9j9Oeqwrgl3iH0Kbl5vzxfrq8ZPYqFyqzRppr7RsSXQ==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@atproto/lex-resolver/-/lex-resolver-0.2.2.tgz",
+      "integrity": "sha512-/7rm1bq2me4ptNoPWOrWmlmzRSPhxbcm3BaeD0V8+OzJ5VKBrYHxqp8BBZTzqgVSmwF+TqANctUG4c/y0hkigw==",
       "license": "MIT",
       "dependencies": {
-        "@atproto-labs/did-resolver": "^0.3.4",
-        "@atproto/crypto": "^0.5.3",
-        "@atproto/lex-client": "^0.2.1",
-        "@atproto/lex-data": "^0.1.4",
-        "@atproto/lex-document": "^0.1.3",
-        "@atproto/lex-schema": "^0.1.6",
-        "@atproto/repo": "^0.10.3",
-        "@atproto/syntax": "^0.6.4",
+        "@atproto-labs/did-resolver": "^0.3.5",
+        "@atproto/crypto": "^0.5.4",
+        "@atproto/lex-client": "^0.3.0",
+        "@atproto/lex-data": "^0.1.5",
+        "@atproto/lex-document": "^0.1.6",
+        "@atproto/lex-schema": "^0.2.2",
+        "@atproto/repo": "^0.10.6",
+        "@atproto/syntax": "^0.7.2",
         "tslib": "^2.8.1"
       },
       "engines": {
@@ -278,13 +277,13 @@
       }
     },
     "node_modules/@atproto/lex-schema": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/@atproto/lex-schema/-/lex-schema-0.1.6.tgz",
-      "integrity": "sha512-4AMwaB0HumrQuaXmYQDHeeZGKj8x6ACiIb8fX96Y0ZZaiM/JUmgZl0LTl/1kbQ7cGPfG+NoGsiuz1iJuFhTjxw==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@atproto/lex-schema/-/lex-schema-0.2.2.tgz",
+      "integrity": "sha512-UFK0EH8pw31dvL27aoZ5K78z+UMiD3ybIgkCyd7Idm267KM1IpycerTDeABqo4CYP3/IAnzjGpQaUaVc12bELA==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/lex-data": "^0.1.4",
-        "@atproto/syntax": "^0.6.4",
+        "@atproto/lex-data": "^0.1.5",
+        "@atproto/syntax": "^0.7.2",
         "@standard-schema/spec": "^1.1.0",
         "tslib": "^2.8.1"
       },
@@ -293,17 +292,17 @@
       }
     },
     "node_modules/@atproto/repo": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@atproto/repo/-/repo-0.10.3.tgz",
-      "integrity": "sha512-Zk4xWtE/Mrf1+dAUwJLnWbeYwnvLMXF102mewzhPwsVkU63LsYO6nP9e5d4nqW/ClFDg9WKXo8zAv4792OnZNw==",
+      "version": "0.10.6",
+      "resolved": "https://registry.npmjs.org/@atproto/repo/-/repo-0.10.6.tgz",
+      "integrity": "sha512-ayX/ieAni4ZMbpdu6VMOCYIjzT8HctCQtcSBWWR8eoynsGZ6FzK/Lln6bH8i0wAj8vPV2pcecd57d33YsahRcQ==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/common": "^0.6.5",
-        "@atproto/common-web": "^0.5.3",
-        "@atproto/crypto": "^0.5.3",
-        "@atproto/lex-cbor": "^0.1.3",
-        "@atproto/lex-data": "^0.1.4",
-        "@atproto/syntax": "^0.6.4",
+        "@atproto/common": "^0.7.2",
+        "@atproto/common-web": "^0.5.6",
+        "@atproto/crypto": "^0.5.4",
+        "@atproto/lex-cbor": "^0.1.4",
+        "@atproto/lex-data": "^0.1.5",
+        "@atproto/syntax": "^0.7.2",
         "varint": "^6.0.0",
         "zod": "^3.23.8"
       },
@@ -312,9 +311,9 @@
       }
     },
     "node_modules/@atproto/syntax": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/@atproto/syntax/-/syntax-0.6.4.tgz",
-      "integrity": "sha512-ELgpShRGMF65cvLXcoMCZFL0HBzy67yz/Nlhox3yOtTh120B09KjjvZYXhMysVog3nUJqv2EW5rf1VRYCeM/hw==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@atproto/syntax/-/syntax-0.7.2.tgz",
+      "integrity": "sha512-tZ1Tr0R9pK4bI4Zs69t29cjMlCFQvRNBeNkqJC5pGeNuCt64D0eoF7s/AlqeVmYppClmQ0xJquggGgsMDP6j7w==",
       "license": "MIT",
       "dependencies": {
         "iso-datestring-validator": "^2.2.2",
@@ -619,9 +618,9 @@
       "license": "MIT"
     },
     "node_modules/prettier": {
-      "version": "3.9.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.4.tgz",
-      "integrity": "sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg==",
+      "version": "3.9.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.5.tgz",
+      "integrity": "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg==",
       "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"

--- a/generator/package.json
+++ b/generator/package.json
@@ -4,6 +4,6 @@
   "private": true,
   "description": "Pins the @atproto/lex release whose lexicon JSON is consumed by :generator. Not published.",
   "dependencies": {
-    "@atproto/lex": "0.1.7"
+    "@atproto/lex": "0.3.0"
   }
 }

--- a/models/api/models.api
+++ b/models/api/models.api
@@ -84,18 +84,20 @@ public final class io/github/kikin81/atproto/app/bsky/actor/BskyAppProgressGuide
 public final class io/github/kikin81/atproto/app/bsky/actor/BskyAppStatePref : io/github/kikin81/atproto/app/bsky/actor/GetPreferencesResponsePreferencesUnion, io/github/kikin81/atproto/app/bsky/actor/PutPreferencesRequestPreferencesUnion {
 	public static final field Companion Lio/github/kikin81/atproto/app/bsky/actor/BskyAppStatePref$Companion;
 	public fun <init> ()V
-	public fun <init> (Lio/github/kikin81/atproto/app/bsky/actor/BskyAppProgressGuide;Ljava/util/List;Ljava/util/List;)V
-	public synthetic fun <init> (Lio/github/kikin81/atproto/app/bsky/actor/BskyAppProgressGuide;Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lio/github/kikin81/atproto/app/bsky/actor/BskyAppProgressGuide;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;)V
+	public synthetic fun <init> (Lio/github/kikin81/atproto/app/bsky/actor/BskyAppProgressGuide;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lio/github/kikin81/atproto/app/bsky/actor/BskyAppProgressGuide;
-	public final fun component2 ()Ljava/util/List;
+	public final fun component2 ()Ljava/lang/Boolean;
 	public final fun component3 ()Ljava/util/List;
-	public final fun copy (Lio/github/kikin81/atproto/app/bsky/actor/BskyAppProgressGuide;Ljava/util/List;Ljava/util/List;)Lio/github/kikin81/atproto/app/bsky/actor/BskyAppStatePref;
-	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/actor/BskyAppStatePref;Lio/github/kikin81/atproto/app/bsky/actor/BskyAppProgressGuide;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/actor/BskyAppStatePref;
+	public final fun component4 ()Ljava/util/List;
+	public final fun copy (Lio/github/kikin81/atproto/app/bsky/actor/BskyAppProgressGuide;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;)Lio/github/kikin81/atproto/app/bsky/actor/BskyAppStatePref;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/actor/BskyAppStatePref;Lio/github/kikin81/atproto/app/bsky/actor/BskyAppProgressGuide;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/actor/BskyAppStatePref;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getActiveProgressGuide ()Lio/github/kikin81/atproto/app/bsky/actor/BskyAppProgressGuide;
 	public final fun getNuxs ()Ljava/util/List;
 	public final fun getQueuedNudges ()Ljava/util/List;
 	public fun hashCode ()I
+	public final fun isBetaUser ()Ljava/lang/Boolean;
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -971,11 +973,14 @@ public final class io/github/kikin81/atproto/app/bsky/actor/ProfileAssociatedAct
 
 public final class io/github/kikin81/atproto/app/bsky/actor/ProfileAssociatedChat {
 	public static final field Companion Lio/github/kikin81/atproto/app/bsky/actor/ProfileAssociatedChat$Companion;
-	public fun <init> (Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/actor/ProfileAssociatedChat;
-	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/actor/ProfileAssociatedChat;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/actor/ProfileAssociatedChat;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/actor/ProfileAssociatedChat;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/actor/ProfileAssociatedChat;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/actor/ProfileAssociatedChat;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAllowGroupInvites ()Ljava/lang/String;
 	public final fun getAllowIncoming ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -1770,16 +1775,21 @@ public final class io/github/kikin81/atproto/app/bsky/actor/VerificationState$Co
 
 public final class io/github/kikin81/atproto/app/bsky/actor/VerificationView {
 	public static final field Companion Lio/github/kikin81/atproto/app/bsky/actor/VerificationView$Companion;
-	public synthetic fun <init> (Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1-DnBUIck ()Ljava/lang/String;
 	public final fun component2 ()Z
 	public final fun component3-UyB9Nic ()Ljava/lang/String;
-	public final fun component4-GUXd3rc ()Ljava/lang/String;
-	public final fun copy-ZPm9goA (Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/actor/VerificationView;
-	public static synthetic fun copy-ZPm9goA$default (Lio/github/kikin81/atproto/app/bsky/actor/VerificationView;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/actor/VerificationView;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5-LcUzKSo ()Ljava/lang/String;
+	public final fun component6-GUXd3rc ()Ljava/lang/String;
+	public final fun copy-RLho6hE (Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/actor/VerificationView;
+	public static synthetic fun copy-RLho6hE$default (Lio/github/kikin81/atproto/app/bsky/actor/VerificationView;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/actor/VerificationView;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCreatedAt-DnBUIck ()Ljava/lang/String;
 	public final fun getIssuer-UyB9Nic ()Ljava/lang/String;
+	public final fun getIssuerDisplayName ()Ljava/lang/String;
+	public final fun getIssuerHandle-LcUzKSo ()Ljava/lang/String;
 	public final fun getUri-GUXd3rc ()Ljava/lang/String;
 	public fun hashCode ()I
 	public final fun isValid ()Z
@@ -2253,7 +2263,74 @@ public final class io/github/kikin81/atproto/app/bsky/draft/DraftEmbedExternal$C
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class io/github/kikin81/atproto/app/bsky/draft/DraftEmbedImage {
+public final class io/github/kikin81/atproto/app/bsky/draft/DraftEmbedGallery {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedGallery$Companion;
+	public fun <init> (Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedGallery;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedGallery;Ljava/util/List;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedGallery;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getItems ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/draft/DraftEmbedGallery$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedGallery$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedGallery;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedGallery;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/draft/DraftEmbedGallery$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class io/github/kikin81/atproto/app/bsky/draft/DraftEmbedGalleryItemsUnion : io/github/kikin81/atproto/runtime/OpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedGalleryItemsUnion$Companion;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/draft/DraftEmbedGalleryItemsUnion$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/draft/DraftEmbedGalleryItemsUnion$Unknown : io/github/kikin81/atproto/app/bsky/draft/DraftEmbedGalleryItemsUnion, io/github/kikin81/atproto/runtime/UnknownOpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedGalleryItemsUnion$Unknown$Companion;
+	public fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedGalleryItemsUnion$Unknown;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedGalleryItemsUnion$Unknown;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedGalleryItemsUnion$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getRaw ()Lkotlinx/serialization/json/JsonObject;
+	public fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/draft/DraftEmbedGalleryItemsUnion$Unknown$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/draft/DraftEmbedGalleryItemsUnionSerializer : io/github/kikin81/atproto/runtime/OpenUnionSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedGalleryItemsUnionSerializer;
+	public fun selectKnownDeserializer (Ljava/lang/String;)Lkotlinx/serialization/KSerializer;
+	public fun selectKnownSerializer (Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedGalleryItemsUnion;)Lkotlinx/serialization/KSerializer;
+	public synthetic fun selectKnownSerializer (Lio/github/kikin81/atproto/runtime/OpenUnionMember;)Lkotlinx/serialization/KSerializer;
+	public fun unknownSerializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/draft/DraftEmbedGalleryItemsUnionUnknownSerializer : io/github/kikin81/atproto/runtime/UnknownMemberSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedGalleryItemsUnionUnknownSerializer;
+	public fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedGalleryItemsUnion$Unknown;
+	public synthetic fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/runtime/UnknownOpenUnionMember;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/draft/DraftEmbedImage : io/github/kikin81/atproto/app/bsky/draft/DraftEmbedGalleryItemsUnion {
 	public static final field Companion Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedImage$Companion;
 	public fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedLocalRef;)V
 	public synthetic fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedLocalRef;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -2471,18 +2548,20 @@ public final class io/github/kikin81/atproto/app/bsky/draft/DraftInput$Companion
 
 public final class io/github/kikin81/atproto/app/bsky/draft/DraftPost {
 	public static final field Companion Lio/github/kikin81/atproto/app/bsky/draft/DraftPost$Companion;
-	public fun <init> (Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lio/github/kikin81/atproto/app/bsky/draft/DraftPostLabelsUnion;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lio/github/kikin81/atproto/app/bsky/draft/DraftPostLabelsUnion;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/util/List;Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedGallery;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lio/github/kikin81/atproto/app/bsky/draft/DraftPostLabelsUnion;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/util/List;Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedGallery;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lio/github/kikin81/atproto/app/bsky/draft/DraftPostLabelsUnion;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/util/List;
-	public final fun component2 ()Ljava/util/List;
+	public final fun component2 ()Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedGallery;
 	public final fun component3 ()Ljava/util/List;
 	public final fun component4 ()Ljava/util/List;
-	public final fun component5 ()Lio/github/kikin81/atproto/app/bsky/draft/DraftPostLabelsUnion;
-	public final fun component6 ()Ljava/lang/String;
-	public final fun copy (Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lio/github/kikin81/atproto/app/bsky/draft/DraftPostLabelsUnion;Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/draft/DraftPost;
-	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/draft/DraftPost;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lio/github/kikin81/atproto/app/bsky/draft/DraftPostLabelsUnion;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/draft/DraftPost;
+	public final fun component5 ()Ljava/util/List;
+	public final fun component6 ()Lio/github/kikin81/atproto/app/bsky/draft/DraftPostLabelsUnion;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun copy (Ljava/util/List;Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedGallery;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lio/github/kikin81/atproto/app/bsky/draft/DraftPostLabelsUnion;Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/draft/DraftPost;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/draft/DraftPost;Ljava/util/List;Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedGallery;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lio/github/kikin81/atproto/app/bsky/draft/DraftPostLabelsUnion;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/draft/DraftPost;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getEmbedExternals ()Ljava/util/List;
+	public final fun getEmbedGallery ()Lio/github/kikin81/atproto/app/bsky/draft/DraftEmbedGallery;
 	public final fun getEmbedImages ()Ljava/util/List;
 	public final fun getEmbedRecords ()Ljava/util/List;
 	public final fun getEmbedVideos ()Ljava/util/List;
@@ -2509,18 +2588,20 @@ public final class io/github/kikin81/atproto/app/bsky/draft/DraftPost$Companion 
 
 public final class io/github/kikin81/atproto/app/bsky/draft/DraftPostInput {
 	public static final field Companion Lio/github/kikin81/atproto/app/bsky/draft/DraftPostInput$Companion;
-	public fun <init> (Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;)V
-	public synthetic fun <init> (Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;)V
+	public synthetic fun <init> (Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lio/github/kikin81/atproto/runtime/AtField;
 	public final fun component2 ()Lio/github/kikin81/atproto/runtime/AtField;
 	public final fun component3 ()Lio/github/kikin81/atproto/runtime/AtField;
 	public final fun component4 ()Lio/github/kikin81/atproto/runtime/AtField;
 	public final fun component5 ()Lio/github/kikin81/atproto/runtime/AtField;
-	public final fun component6 ()Ljava/lang/String;
-	public final fun copy (Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/draft/DraftPostInput;
-	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/draft/DraftPostInput;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/draft/DraftPostInput;
+	public final fun component6 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun copy (Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/draft/DraftPostInput;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/draft/DraftPostInput;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/draft/DraftPostInput;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getEmbedExternals ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun getEmbedGallery ()Lio/github/kikin81/atproto/runtime/AtField;
 	public final fun getEmbedImages ()Lio/github/kikin81/atproto/runtime/AtField;
 	public final fun getEmbedRecords ()Lio/github/kikin81/atproto/runtime/AtField;
 	public final fun getEmbedVideos ()Lio/github/kikin81/atproto/runtime/AtField;
@@ -2896,17 +2977,50 @@ public final class io/github/kikin81/atproto/app/bsky/embed/External$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class io/github/kikin81/atproto/app/bsky/embed/ExternalColorRGB {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/embed/ExternalColorRGB$Companion;
+	public fun <init> (JJJ)V
+	public final fun component1 ()J
+	public final fun component2 ()J
+	public final fun component3 ()J
+	public final fun copy (JJJ)Lio/github/kikin81/atproto/app/bsky/embed/ExternalColorRGB;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/embed/ExternalColorRGB;JJJILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/embed/ExternalColorRGB;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getB ()J
+	public final fun getG ()J
+	public final fun getR ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/embed/ExternalColorRGB$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/embed/ExternalColorRGB$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/embed/ExternalColorRGB;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/embed/ExternalColorRGB;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/ExternalColorRGB$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
 public final class io/github/kikin81/atproto/app/bsky/embed/ExternalExternal {
 	public static final field Companion Lio/github/kikin81/atproto/app/bsky/embed/ExternalExternal$Companion;
-	public synthetic fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public synthetic fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Lio/github/kikin81/atproto/runtime/AtField;
-	public final fun component3 ()Ljava/lang/String;
-	public final fun component4-jMNtXP8 ()Ljava/lang/String;
-	public final fun copy-2RW-_b8 (Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/embed/ExternalExternal;
-	public static synthetic fun copy-2RW-_b8$default (Lio/github/kikin81/atproto/app/bsky/embed/ExternalExternal;Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/embed/ExternalExternal;
+	public synthetic fun <init> (Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lio/github/kikin81/atproto/runtime/AtField;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5-jMNtXP8 ()Ljava/lang/String;
+	public final fun copy-d7gggOk (Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/embed/ExternalExternal;
+	public static synthetic fun copy-d7gggOk$default (Lio/github/kikin81/atproto/app/bsky/embed/ExternalExternal;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/embed/ExternalExternal;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAssociatedRefs ()Lio/github/kikin81/atproto/runtime/AtField;
 	public final fun getDescription ()Ljava/lang/String;
 	public final fun getThumb ()Lio/github/kikin81/atproto/runtime/AtField;
 	public final fun getTitle ()Ljava/lang/String;
@@ -2959,18 +3073,32 @@ public final class io/github/kikin81/atproto/app/bsky/embed/ExternalView$Compani
 
 public final class io/github/kikin81/atproto/app/bsky/embed/ExternalViewExternal {
 	public static final field Companion Lio/github/kikin81/atproto/app/bsky/embed/ExternalViewExternal$Companion;
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component2-Eo6btPk ()Ljava/lang/String;
-	public final fun component3 ()Ljava/lang/String;
-	public final fun component4-jMNtXP8 ()Ljava/lang/String;
-	public final fun copy-gl96lsk (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/embed/ExternalViewExternal;
-	public static synthetic fun copy-gl96lsk$default (Lio/github/kikin81/atproto/app/bsky/embed/ExternalViewExternal;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/embed/ExternalViewExternal;
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/Long;Lio/github/kikin81/atproto/app/bsky/embed/ExternalViewExternalSource;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/Long;Lio/github/kikin81/atproto/app/bsky/embed/ExternalViewExternalSource;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component10-G5DCnlA ()Ljava/lang/String;
+	public final fun component11-jMNtXP8 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3-G5DCnlA ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/util/List;
+	public final fun component6 ()Ljava/lang/Long;
+	public final fun component7 ()Lio/github/kikin81/atproto/app/bsky/embed/ExternalViewExternalSource;
+	public final fun component8-Eo6btPk ()Ljava/lang/String;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy-TiLV5vE (Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/Long;Lio/github/kikin81/atproto/app/bsky/embed/ExternalViewExternalSource;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/embed/ExternalViewExternal;
+	public static synthetic fun copy-TiLV5vE$default (Lio/github/kikin81/atproto/app/bsky/embed/ExternalViewExternal;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/Long;Lio/github/kikin81/atproto/app/bsky/embed/ExternalViewExternalSource;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/embed/ExternalViewExternal;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAssociatedProfiles ()Ljava/util/List;
+	public final fun getAssociatedRefs ()Ljava/util/List;
+	public final fun getCreatedAt-G5DCnlA ()Ljava/lang/String;
 	public final fun getDescription ()Ljava/lang/String;
+	public final fun getLabels ()Ljava/util/List;
+	public final fun getReadingTime ()Ljava/lang/Long;
+	public final fun getSource ()Lio/github/kikin81/atproto/app/bsky/embed/ExternalViewExternalSource;
 	public final fun getThumb-Eo6btPk ()Ljava/lang/String;
 	public final fun getTitle ()Ljava/lang/String;
+	public final fun getUpdatedAt-G5DCnlA ()Ljava/lang/String;
 	public final fun getUri-jMNtXP8 ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -2988,6 +3116,77 @@ public final synthetic class io/github/kikin81/atproto/app/bsky/embed/ExternalVi
 }
 
 public final class io/github/kikin81/atproto/app/bsky/embed/ExternalViewExternal$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/ExternalViewExternalSource {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/embed/ExternalViewExternalSource$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/embed/ExternalViewExternalSourceTheme;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/embed/ExternalViewExternalSourceTheme;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2-Eo6btPk ()Ljava/lang/String;
+	public final fun component3 ()Lio/github/kikin81/atproto/app/bsky/embed/ExternalViewExternalSourceTheme;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5-jMNtXP8 ()Ljava/lang/String;
+	public final fun copy-ruPNdvU (Ljava/lang/String;Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/embed/ExternalViewExternalSourceTheme;Ljava/lang/String;Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/embed/ExternalViewExternalSource;
+	public static synthetic fun copy-ruPNdvU$default (Lio/github/kikin81/atproto/app/bsky/embed/ExternalViewExternalSource;Ljava/lang/String;Ljava/lang/String;Lio/github/kikin81/atproto/app/bsky/embed/ExternalViewExternalSourceTheme;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/embed/ExternalViewExternalSource;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getIcon-Eo6btPk ()Ljava/lang/String;
+	public final fun getTheme ()Lio/github/kikin81/atproto/app/bsky/embed/ExternalViewExternalSourceTheme;
+	public final fun getTitle ()Ljava/lang/String;
+	public final fun getUri-jMNtXP8 ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/embed/ExternalViewExternalSource$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/embed/ExternalViewExternalSource$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/embed/ExternalViewExternalSource;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/embed/ExternalViewExternalSource;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/ExternalViewExternalSource$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/ExternalViewExternalSourceTheme {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/embed/ExternalViewExternalSourceTheme$Companion;
+	public fun <init> ()V
+	public fun <init> (Lio/github/kikin81/atproto/app/bsky/embed/ExternalColorRGB;Lio/github/kikin81/atproto/app/bsky/embed/ExternalColorRGB;Lio/github/kikin81/atproto/app/bsky/embed/ExternalColorRGB;Lio/github/kikin81/atproto/app/bsky/embed/ExternalColorRGB;)V
+	public synthetic fun <init> (Lio/github/kikin81/atproto/app/bsky/embed/ExternalColorRGB;Lio/github/kikin81/atproto/app/bsky/embed/ExternalColorRGB;Lio/github/kikin81/atproto/app/bsky/embed/ExternalColorRGB;Lio/github/kikin81/atproto/app/bsky/embed/ExternalColorRGB;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lio/github/kikin81/atproto/app/bsky/embed/ExternalColorRGB;
+	public final fun component2 ()Lio/github/kikin81/atproto/app/bsky/embed/ExternalColorRGB;
+	public final fun component3 ()Lio/github/kikin81/atproto/app/bsky/embed/ExternalColorRGB;
+	public final fun component4 ()Lio/github/kikin81/atproto/app/bsky/embed/ExternalColorRGB;
+	public final fun copy (Lio/github/kikin81/atproto/app/bsky/embed/ExternalColorRGB;Lio/github/kikin81/atproto/app/bsky/embed/ExternalColorRGB;Lio/github/kikin81/atproto/app/bsky/embed/ExternalColorRGB;Lio/github/kikin81/atproto/app/bsky/embed/ExternalColorRGB;)Lio/github/kikin81/atproto/app/bsky/embed/ExternalViewExternalSourceTheme;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/embed/ExternalViewExternalSourceTheme;Lio/github/kikin81/atproto/app/bsky/embed/ExternalColorRGB;Lio/github/kikin81/atproto/app/bsky/embed/ExternalColorRGB;Lio/github/kikin81/atproto/app/bsky/embed/ExternalColorRGB;Lio/github/kikin81/atproto/app/bsky/embed/ExternalColorRGB;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/embed/ExternalViewExternalSourceTheme;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAccentForegroundRGB ()Lio/github/kikin81/atproto/app/bsky/embed/ExternalColorRGB;
+	public final fun getAccentRGB ()Lio/github/kikin81/atproto/app/bsky/embed/ExternalColorRGB;
+	public final fun getBackgroundRGB ()Lio/github/kikin81/atproto/app/bsky/embed/ExternalColorRGB;
+	public final fun getForegroundRGB ()Lio/github/kikin81/atproto/app/bsky/embed/ExternalColorRGB;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/embed/ExternalViewExternalSourceTheme$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/embed/ExternalViewExternalSourceTheme$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/embed/ExternalViewExternalSourceTheme;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/embed/ExternalViewExternalSourceTheme;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/embed/ExternalViewExternalSourceTheme$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -3089,7 +3288,7 @@ public final class io/github/kikin81/atproto/app/bsky/embed/GalleryItemsUnionUnk
 	public synthetic fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/runtime/UnknownOpenUnionMember;
 }
 
-public final class io/github/kikin81/atproto/app/bsky/embed/GalleryView : io/github/kikin81/atproto/app/bsky/embed/RecordWithMediaViewMediaUnion, io/github/kikin81/atproto/app/bsky/feed/PostViewEmbedUnion {
+public final class io/github/kikin81/atproto/app/bsky/embed/GalleryView : io/github/kikin81/atproto/app/bsky/embed/RecordViewRecordEmbedsUnion, io/github/kikin81/atproto/app/bsky/embed/RecordWithMediaViewMediaUnion, io/github/kikin81/atproto/app/bsky/feed/PostViewEmbedUnion {
 	public static final field Companion Lio/github/kikin81/atproto/app/bsky/embed/GalleryView$Companion;
 	public fun <init> (Ljava/util/List;)V
 	public final fun component1 ()Ljava/util/List;
@@ -10286,6 +10485,26 @@ public final class io/github/kikin81/atproto/chat/bsky/actor/GroupConvoMember$Co
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class io/github/kikin81/atproto/chat/bsky/actor/PastGroupConvoMember : io/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasicKindUnion {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/actor/PastGroupConvoMember$Companion;
+	public fun <init> ()V
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/actor/PastGroupConvoMember$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/actor/PastGroupConvoMember$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/actor/PastGroupConvoMember;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/actor/PastGroupConvoMember;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/actor/PastGroupConvoMember$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
 public final class io/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic {
 	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic$Companion;
 	public synthetic fun <init> (Lio/github/kikin81/atproto/app/bsky/actor/ProfileAssociated;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasicKindUnion;Ljava/util/List;Lio/github/kikin81/atproto/app/bsky/actor/VerificationState;Lio/github/kikin81/atproto/app/bsky/actor/ViewerState;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -10579,8 +10798,6 @@ public final class io/github/kikin81/atproto/chat/bsky/convo/ConvoServiceKt {
 	public static synthetic fun logFlow$default (Lio/github/kikin81/atproto/chat/bsky/convo/ConvoService;Lio/github/kikin81/atproto/chat/bsky/convo/GetLogRequest;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun logPageFlow (Lio/github/kikin81/atproto/chat/bsky/convo/ConvoService;Lio/github/kikin81/atproto/chat/bsky/convo/GetLogRequest;)Lkotlinx/coroutines/flow/Flow;
 	public static synthetic fun logPageFlow$default (Lio/github/kikin81/atproto/chat/bsky/convo/ConvoService;Lio/github/kikin81/atproto/chat/bsky/convo/GetLogRequest;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
-	public static final fun messagesFlow (Lio/github/kikin81/atproto/chat/bsky/convo/ConvoService;Lio/github/kikin81/atproto/chat/bsky/convo/GetMessagesRequest;)Lkotlinx/coroutines/flow/Flow;
-	public static final fun messagesPageFlow (Lio/github/kikin81/atproto/chat/bsky/convo/ConvoService;Lio/github/kikin81/atproto/chat/bsky/convo/GetMessagesRequest;)Lkotlinx/coroutines/flow/Flow;
 }
 
 public final class io/github/kikin81/atproto/chat/bsky/convo/ConvoView : io/github/kikin81/atproto/chat/bsky/convo/ListConvoRequestsResponseRequestsUnion {
@@ -11189,15 +11406,17 @@ public final class io/github/kikin81/atproto/chat/bsky/convo/GetMessagesRequest$
 
 public final class io/github/kikin81/atproto/chat/bsky/convo/GetMessagesResponse {
 	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/GetMessagesResponse$Companion;
-	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/util/List;
-	public final fun copy (Ljava/lang/String;Ljava/util/List;)Lio/github/kikin81/atproto/chat/bsky/convo/GetMessagesResponse;
-	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/GetMessagesResponse;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/GetMessagesResponse;
+	public final fun component3 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;Ljava/util/List;)Lio/github/kikin81/atproto/chat/bsky/convo/GetMessagesResponse;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/GetMessagesResponse;Ljava/lang/String;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/GetMessagesResponse;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCursor ()Ljava/lang/String;
 	public final fun getMessages ()Ljava/util/List;
+	public final fun getRelatedProfiles ()Ljava/util/List;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -11461,19 +11680,21 @@ public final class io/github/kikin81/atproto/chat/bsky/convo/ListConvoRequestsRe
 public final class io/github/kikin81/atproto/chat/bsky/convo/ListConvosRequest {
 	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/ListConvosRequest$Companion;
 	public fun <init> ()V
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/Long;
 	public final fun component4 ()Ljava/lang/String;
 	public final fun component5 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/ListConvosRequest;
-	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/ListConvosRequest;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/ListConvosRequest;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/convo/ListConvosRequest;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/ListConvosRequest;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/ListConvosRequest;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCursor ()Ljava/lang/String;
 	public final fun getKind ()Ljava/lang/String;
 	public final fun getLimit ()Ljava/lang/Long;
+	public final fun getLockStatus ()Ljava/lang/String;
 	public final fun getReadState ()Ljava/lang/String;
 	public final fun getStatus ()Ljava/lang/String;
 	public fun hashCode ()I
@@ -12398,7 +12619,7 @@ public final class io/github/kikin81/atproto/chat/bsky/convo/LogReadConvoMessage
 	public synthetic fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/runtime/UnknownOpenUnionMember;
 }
 
-public final class io/github/kikin81/atproto/chat/bsky/convo/LogReadJoinRequests {
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogReadJoinRequests : io/github/kikin81/atproto/chat/bsky/convo/GetLogResponseLogsUnion {
 	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/LogReadJoinRequests$Companion;
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
 	public final fun component1 ()Ljava/lang/String;
@@ -12700,7 +12921,7 @@ public final class io/github/kikin81/atproto/chat/bsky/convo/LogUnmuteConvo$Comp
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class io/github/kikin81/atproto/chat/bsky/convo/LogWithdrawIncomingJoinRequest {
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogWithdrawIncomingJoinRequest : io/github/kikin81/atproto/chat/bsky/convo/GetLogResponseLogsUnion {
 	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/LogWithdrawIncomingJoinRequest$Companion;
 	public fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;Ljava/lang/String;)V
 	public final fun component1 ()Ljava/lang/String;
@@ -12731,7 +12952,7 @@ public final class io/github/kikin81/atproto/chat/bsky/convo/LogWithdrawIncoming
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class io/github/kikin81/atproto/chat/bsky/convo/LogWithdrawOutgoingJoinRequest {
+public final class io/github/kikin81/atproto/chat/bsky/convo/LogWithdrawOutgoingJoinRequest : io/github/kikin81/atproto/chat/bsky/convo/GetLogResponseLogsUnion {
 	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/LogWithdrawOutgoingJoinRequest$Companion;
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
 	public final fun component1 ()Ljava/lang/String;
@@ -14131,11 +14352,14 @@ public final class io/github/kikin81/atproto/chat/bsky/group/AddMembersRequest$C
 
 public final class io/github/kikin81/atproto/chat/bsky/group/AddMembersResponse {
 	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/group/AddMembersResponse$Companion;
-	public fun <init> (Lio/github/kikin81/atproto/chat/bsky/convo/ConvoView;)V
-	public final fun component1 ()Lio/github/kikin81/atproto/chat/bsky/convo/ConvoView;
-	public final fun copy (Lio/github/kikin81/atproto/chat/bsky/convo/ConvoView;)Lio/github/kikin81/atproto/chat/bsky/group/AddMembersResponse;
-	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/group/AddMembersResponse;Lio/github/kikin81/atproto/chat/bsky/convo/ConvoView;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/group/AddMembersResponse;
+	public fun <init> (Ljava/util/List;Lio/github/kikin81/atproto/chat/bsky/convo/ConvoView;)V
+	public synthetic fun <init> (Ljava/util/List;Lio/github/kikin81/atproto/chat/bsky/convo/ConvoView;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Lio/github/kikin81/atproto/chat/bsky/convo/ConvoView;
+	public final fun copy (Ljava/util/List;Lio/github/kikin81/atproto/chat/bsky/convo/ConvoView;)Lio/github/kikin81/atproto/chat/bsky/group/AddMembersResponse;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/group/AddMembersResponse;Ljava/util/List;Lio/github/kikin81/atproto/chat/bsky/convo/ConvoView;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/group/AddMembersResponse;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAddedMembers ()Ljava/util/List;
 	public final fun getConvo ()Lio/github/kikin81/atproto/chat/bsky/convo/ConvoView;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -14836,7 +15060,7 @@ public final class io/github/kikin81/atproto/chat/bsky/group/JoinLinkViewerState
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class io/github/kikin81/atproto/chat/bsky/group/JoinRequestConvoView {
+public final class io/github/kikin81/atproto/chat/bsky/group/JoinRequestConvoView : io/github/kikin81/atproto/chat/bsky/convo/ListConvoRequestsResponseRequestsUnion {
 	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/group/JoinRequestConvoView$Companion;
 	public fun <init> (Ljava/lang/String;JJLjava/lang/String;Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;Lio/github/kikin81/atproto/chat/bsky/group/JoinLinkViewerState;)V
 	public final fun component1 ()Ljava/lang/String;
@@ -14873,7 +15097,7 @@ public final class io/github/kikin81/atproto/chat/bsky/group/JoinRequestConvoVie
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class io/github/kikin81/atproto/chat/bsky/group/JoinRequestView : io/github/kikin81/atproto/chat/bsky/convo/ListConvoRequestsResponseRequestsUnion {
+public final class io/github/kikin81/atproto/chat/bsky/group/JoinRequestView {
 	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/group/JoinRequestView$Companion;
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;


### PR DESCRIPTION
## Lexicon corpus update

Bumps `@atproto/lex` from `0.1.7` to `0.3.0`.

### lexicons.json changes

**Added** (2):
- `app.bsky.embed.gallery`
- `chat.bsky.embed.joinLink`

**Removed** (0):
- _(none)_

**Updated** (34):
- `app.bsky.actor.defs`
- `app.bsky.draft.defs`
- `app.bsky.embed.external`
- `app.bsky.embed.record`
- `app.bsky.embed.recordWithMedia`
- `app.bsky.feed.defs`
- `app.bsky.feed.post`
- `app.bsky.notification.defs`
- `app.bsky.notification.putPreferencesV2`
- `chat.bsky.actor.declaration`
- `chat.bsky.actor.defs`
- `chat.bsky.convo.defs`
- `chat.bsky.convo.getConvoForMembers`
- `chat.bsky.convo.getLog`
- `chat.bsky.convo.getMessages`
- `chat.bsky.convo.listConvoRequests`
- `chat.bsky.convo.listConvos`
- `chat.bsky.convo.lockConvo`
- `chat.bsky.convo.sendMessage`
- `chat.bsky.convo.sendMessageBatch`
- _…and 14 more_

### What reviewers should check

- [ ] CI passes (generator regeneration, runtime tests, sample APK build)
- [ ] Skim the generator golden-file diff if any generator logic was affected
- [ ] Verify no new lexicon references are missing Kotlin types (compile failure in `:models`)

### Release impact

If this PR merges with only additive changes (new types, new fields), expect a `feat:` release. If it removes or renames anything, expect a `BREAKING CHANGE:` release — update the PR title to `feat!: bump @atproto/lex to <version>` before merging.