### PR TITLE
feat(lexicons): add com.atproto.server.getServiceAuth

### DIFF
--- a/generator/lexicons.json
+++ b/generator/lexicons.json
@@ -140,6 +140,7 @@
     "com.atproto.server.createSession",
     "com.atproto.server.deleteSession",
     "com.atproto.server.describeServer",
+    "com.atproto.server.getServiceAuth",
     "com.atproto.server.getSession",
     "com.atproto.server.refreshSession",
     "com.atproto.sync.getLatestCommit",
@@ -793,6 +794,10 @@
     "com.atproto.server.describeServer": {
       "uri": "at://did:plc:6msi3pj7krzih5qxqtryxlzw/com.atproto.lexicon.schema/com.atproto.server.describeServer",
       "cid": "bafyreidjve4qbhebxzppq23ogsto6luddd63mmn7a57rmml6qi3yf7n3ee"
+    },
+    "com.atproto.server.getServiceAuth": {
+      "uri": "at://did:plc:6msi3pj7krzih5qxqtryxlzw/com.atproto.lexicon.schema/com.atproto.server.getServiceAuth",
+      "cid": "bafyreigjuxsvldkifmwzdrzvziq2ldomzoqizsv5umwgumjv77ld56wxyi"
     },
     "com.atproto.server.getSession": {
       "uri": "at://did:plc:6msi3pj7krzih5qxqtryxlzw/com.atproto.lexicon.schema/com.atproto.server.getSession",

--- a/models/api/models.api
+++ b/models/api/models.api
@@ -17201,6 +17201,65 @@ public final class io/github/kikin81/atproto/com/atproto/server/DescribeServerRe
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class io/github/kikin81/atproto/com/atproto/server/GetServiceAuthRequest {
+	public static final field Companion Lio/github/kikin81/atproto/com/atproto/server/GetServiceAuthRequest$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-UyB9Nic ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/Long;
+	public final fun component3-PFGiv5M ()Ljava/lang/String;
+	public final fun copy-XFUoR_8 (Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;)Lio/github/kikin81/atproto/com/atproto/server/GetServiceAuthRequest;
+	public static synthetic fun copy-XFUoR_8$default (Lio/github/kikin81/atproto/com/atproto/server/GetServiceAuthRequest;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/com/atproto/server/GetServiceAuthRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAud-UyB9Nic ()Ljava/lang/String;
+	public final fun getExp ()Ljava/lang/Long;
+	public final fun getLxm-PFGiv5M ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/com/atproto/server/GetServiceAuthRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/com/atproto/server/GetServiceAuthRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/com/atproto/server/GetServiceAuthRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/com/atproto/server/GetServiceAuthRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/server/GetServiceAuthRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/server/GetServiceAuthResponse {
+	public static final field Companion Lio/github/kikin81/atproto/com/atproto/server/GetServiceAuthResponse$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/github/kikin81/atproto/com/atproto/server/GetServiceAuthResponse;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/com/atproto/server/GetServiceAuthResponse;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/com/atproto/server/GetServiceAuthResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getToken ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/com/atproto/server/GetServiceAuthResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/com/atproto/server/GetServiceAuthResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/com/atproto/server/GetServiceAuthResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/com/atproto/server/GetServiceAuthResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/com/atproto/server/GetServiceAuthResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
 public final class io/github/kikin81/atproto/com/atproto/server/GetSessionResponse {
 	public static final field Companion Lio/github/kikin81/atproto/com/atproto/server/GetSessionResponse$Companion;
 	public synthetic fun <init> (Ljava/lang/Boolean;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -17365,6 +17424,8 @@ public final class io/github/kikin81/atproto/com/atproto/server/ServerService {
 	public static synthetic fun createSession$default (Lio/github/kikin81/atproto/com/atproto/server/ServerService;Lio/github/kikin81/atproto/com/atproto/server/CreateSessionRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun describeServer (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun describeServer$default (Lio/github/kikin81/atproto/com/atproto/server/ServerService;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getServiceAuth (Lio/github/kikin81/atproto/com/atproto/server/GetServiceAuthRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getServiceAuth$default (Lio/github/kikin81/atproto/com/atproto/server/ServerService;Lio/github/kikin81/atproto/com/atproto/server/GetServiceAuthRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun getSession (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun getSession$default (Lio/github/kikin81/atproto/com/atproto/server/ServerService;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun refreshSession (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;


### PR DESCRIPTION
Allowlists `com.atproto.server.getServiceAuth` in `generator/lexicons.json` so `npx lex install` fetches it, plus the resulting `models/api/models.api` dump.

## Why

`getServiceAuth` mints a short-lived signed JWT bound to an audience DID and an optional lexicon method. It is the entry point for any flow authenticating against a service other than the user's own PDS.

The concrete driver is Bluesky video upload: `app.bsky.video.uploadVideo` will not accept a body without a service-auth bearer token for `video.bsky.app`. The `app.bsky.video.*` lexicons were already allowlisted (`defs`, `getJobStatus`, `getUploadLimits`, `uploadVideo`) — this was the one missing piece.

## Generated surface

```kotlin
ServerService.getServiceAuth(request: GetServiceAuthRequest, proxy: String? = null): GetServiceAuthResponse

data class GetServiceAuthRequest(val aud: Did, val exp: Long? = null, val lxm: Nsid? = null)
data class GetServiceAuthResponse(val token: String)
```

Typed `Did` / `Nsid` come through from the lexicon `format` fields.

## Notes

- **Installs cleanly from the on-network registry** — no `overlay-lexicons` entry needed. It resolved and locked on the first `npx lex install`.
- **`models.api` diff is purely additive.** No removals, no changed signatures on existing members — a clean minor bump.

## Verification

- `npx lex install --ci` → exit 0 (was failing "manifest is out of date" before the lockfile entry)
- `./gradlew :models:jvmTest :models:apiCheck :runtime:jvmTest :generator:test` → green
- `./gradlew spotlessCheck --no-build-cache --rerun-tasks --no-daemon` → green (cold, since a warm daemon has masked ktlint drift in this repo before)
- Published `:models` + `:runtime` to mavenLocal and compiled a downstream consumer against the exact call shape the video-upload work needs. Confirmed the check discriminates: the same file fails with `Unresolved reference 'GetServiceAuthRequest'` against the published 9.7.5.

`:models:linkDebugTestIosSimulatorArm64` fails locally on an `atomicfu` klib cache error — verified **pre-existing** by reproducing it on a clean `main` with this branch stashed. Not touched by this change.

Refs: nubecita-uu6c.1