### PR TITLE
fix(generator): drift detector reads resolutions, not just the opt-in array

### DIFF
--- a/generator/src/main/kotlin/io/github/kikin81/atproto/generator/tools/LexiconDriftDetect.kt
+++ b/generator/src/main/kotlin/io/github/kikin81/atproto/generator/tools/LexiconDriftDetect.kt
@@ -20,10 +20,15 @@ import kotlin.system.exitProcess
 /**
  * Detects upstream lexicon drift against `generator/lexicons.json`.
  *
- * Compares NSIDs declared in this repo's manifest against the
+ * Compares NSIDs covered by this repo's manifest against the
  * `bluesky-social/atproto` upstream lexicon corpus at main, and reports:
- *   - new upstream NSIDs not yet in our manifest (coverage gap)
+ *   - new upstream NSIDs we don't cover at all (coverage gap)
  *   - manifest NSIDs no longer present upstream (deprecations / renames)
+ *
+ * "Covered" spans both manifest sections: the `lexicons` opt-in array *and*
+ * the `resolutions` lockfile, which pins the transitive closure `lex install`
+ * walked to. A transitively-resolved NSID is installed and generated just like
+ * an opted-in one, so it is not a gap.
  *
  * Runnable locally (prints a markdown report to stdout) and from
  * `.github/workflows/lexicon-drift-detect.yaml` (writes `has_drift`,
@@ -48,8 +53,21 @@ internal data class TreeResponse(
 internal data class TreeEntry(val path: String, val type: String = "")
 
 @Serializable
-internal data class Manifest(val lexicons: List<String> = emptyList())
+internal data class Manifest(
+    val lexicons: List<String> = emptyList(),
+    val resolutions: Map<String, ResolutionRef> = emptyMap(),
+)
 
+@Serializable
+internal data class ResolutionRef(val uri: String = "", val cid: String = "")
+
+/**
+ * Every NSID upstream publishes, including `*.defs` documents.
+ *
+ * This is the set to diff *manifest* NSIDs against — the manifest may name a
+ * `*.defs` document explicitly (nothing opted-in refs it), and stripping defs
+ * from only one side of that difference would report it missing forever.
+ */
 internal fun parseUpstreamNsids(treeJson: String): Set<String> {
     val parsed = json.decodeFromString<TreeResponse>(treeJson)
     if (parsed.truncated) {
@@ -63,11 +81,32 @@ internal fun parseUpstreamNsids(treeJson: String): Set<String> {
         .map {
             it.path.removePrefix("lexicons/").removeSuffix(".json").replace('/', '.')
         }
-        .filterNot { it.endsWith(".defs") }
         .toSet()
 }
 
+/**
+ * Upstream NSIDs that are plausible opt-in targets.
+ *
+ * `*.defs` documents are never opted into directly — they arrive transitively
+ * as refs of whatever names them — so listing one as a coverage gap is always
+ * noise. Applies to the "new upstream" side of the diff only.
+ */
+internal fun optInCandidates(upstream: Set<String>): Set<String> = upstream.filterNot { it.endsWith(".defs") }.toSet()
+
+/** NSIDs explicitly opted into via the manifest's `lexicons` array. */
 internal fun parseManifestNsids(manifestJson: String): Set<String> = json.decodeFromString<Manifest>(manifestJson).lexicons.toSet()
+
+/**
+ * NSIDs pinned in the manifest's `resolutions` lockfile.
+ *
+ * A superset of the `lexicons` array: `lex install` walks refs and pins every
+ * document it resolves, so transitive dependencies (`app.bsky.embed.images`
+ * via `app.bsky.feed.post`, `com.atproto.repo.strongRef`, the `*.defs`
+ * documents) land here without ever being opted into. They are installed,
+ * generated, and published — reporting them as a coverage gap is a false
+ * positive, so the "new upstream" diff subtracts them.
+ */
+internal fun parseResolvedNsids(manifestJson: String): Set<String> = json.decodeFromString<Manifest>(manifestJson).resolutions.keys
 
 @Serializable
 internal data class OverlayManifestRef(val overlays: List<OverlayRef> = emptyList())
@@ -116,6 +155,7 @@ internal fun renderReport(
     removedNsids: Set<String>,
     now: OffsetDateTime,
     overlayCount: Int = 0,
+    transitiveCount: Int = 0,
 ): String = buildString {
     appendLine(
         "_Generated ${timestampFormatter.format(now)} by " +
@@ -132,6 +172,14 @@ internal fun renderReport(
         appendLine(
             "_($overlayCount NSID(s) handled by overlays — excluded here; " +
                 "see the `overlay-stale` tracking issue.)_",
+        )
+        appendLine()
+    }
+    if (transitiveCount > 0) {
+        appendLine(
+            "_($transitiveCount NSID(s) covered transitively via `resolutions` " +
+                "— installed and generated without being opted into, so " +
+                "excluded here.)_",
         )
         appendLine()
     }
@@ -264,9 +312,18 @@ public fun main(args: Array<String>) {
     }
 
     val upstream = parseUpstreamNsids(fetchUpstreamTree(System.getenv("GITHUB_TOKEN")))
-    val manifest = parseManifestNsids(Files.readString(manifestPath))
-    val newNsids = upstream - manifest - overlayNsids
-    val removedNsids = manifest - upstream
+    val manifestJson = Files.readString(manifestPath)
+    val declared = parseManifestNsids(manifestJson)
+    // `resolutions` pins everything lex install walked to, so it already
+    // contains `declared`; the difference is what we cover transitively.
+    val resolved = parseResolvedNsids(manifestJson)
+    val transitive = resolved - declared
+
+    val newNsids = optInCandidates(upstream) - declared - resolved - overlayNsids
+    // Diffed against the unfiltered upstream set: the manifest names a few
+    // `*.defs` documents directly, and those exist upstream.
+    val removedNsids = declared - upstream
+
     val hasDrift = newNsids.isNotEmpty() || removedNsids.isNotEmpty()
     val body =
         renderReport(
@@ -274,6 +331,7 @@ public fun main(args: Array<String>) {
             removedNsids,
             OffsetDateTime.now(ZoneOffset.UTC),
             overlayNsids.size,
+            transitive.size,
         )
 
     println(body)

--- a/generator/src/main/kotlin/io/github/kikin81/atproto/generator/tools/LexiconDriftDetect.kt
+++ b/generator/src/main/kotlin/io/github/kikin81/atproto/generator/tools/LexiconDriftDetect.kt
@@ -52,6 +52,18 @@ internal data class TreeResponse(
 @Serializable
 internal data class TreeEntry(val path: String, val type: String = "")
 
+/**
+ * The `generator/lexicons.json` manifest.
+ *
+ * @property lexicons NSIDs explicitly opted into.
+ * @property resolutions Pinned NSID -> `at://` URI + CID lockfile, a superset
+ *   of [lexicons]: `lex install` walks refs and pins every document it
+ *   resolves, so transitive dependencies (`app.bsky.embed.images` via
+ *   `app.bsky.feed.post`, `com.atproto.repo.strongRef`, the `*.defs`
+ *   documents) land here without ever being opted into. They are installed,
+ *   generated, and published — reporting one as a coverage gap is a false
+ *   positive, so the "new upstream" diff subtracts these too.
+ */
 @Serializable
 internal data class Manifest(
     val lexicons: List<String> = emptyList(),
@@ -60,6 +72,8 @@ internal data class Manifest(
 
 @Serializable
 internal data class ResolutionRef(val uri: String = "", val cid: String = "")
+
+internal fun parseManifest(manifestJson: String): Manifest = json.decodeFromString<Manifest>(manifestJson)
 
 /**
  * Every NSID upstream publishes, including `*.defs` documents.
@@ -92,21 +106,6 @@ internal fun parseUpstreamNsids(treeJson: String): Set<String> {
  * noise. Applies to the "new upstream" side of the diff only.
  */
 internal fun optInCandidates(upstream: Set<String>): Set<String> = upstream.filterNot { it.endsWith(".defs") }.toSet()
-
-/** NSIDs explicitly opted into via the manifest's `lexicons` array. */
-internal fun parseManifestNsids(manifestJson: String): Set<String> = json.decodeFromString<Manifest>(manifestJson).lexicons.toSet()
-
-/**
- * NSIDs pinned in the manifest's `resolutions` lockfile.
- *
- * A superset of the `lexicons` array: `lex install` walks refs and pins every
- * document it resolves, so transitive dependencies (`app.bsky.embed.images`
- * via `app.bsky.feed.post`, `com.atproto.repo.strongRef`, the `*.defs`
- * documents) land here without ever being opted into. They are installed,
- * generated, and published — reporting them as a coverage gap is a false
- * positive, so the "new upstream" diff subtracts them.
- */
-internal fun parseResolvedNsids(manifestJson: String): Set<String> = json.decodeFromString<Manifest>(manifestJson).resolutions.keys
 
 @Serializable
 internal data class OverlayManifestRef(val overlays: List<OverlayRef> = emptyList())
@@ -312,11 +311,11 @@ public fun main(args: Array<String>) {
     }
 
     val upstream = parseUpstreamNsids(fetchUpstreamTree(System.getenv("GITHUB_TOKEN")))
-    val manifestJson = Files.readString(manifestPath)
-    val declared = parseManifestNsids(manifestJson)
+    val manifest = parseManifest(Files.readString(manifestPath))
+    val declared = manifest.lexicons.toSet()
     // `resolutions` pins everything lex install walked to, so it already
     // contains `declared`; the difference is what we cover transitively.
-    val resolved = parseResolvedNsids(manifestJson)
+    val resolved = manifest.resolutions.keys
     val transitive = resolved - declared
 
     val newNsids = optInCandidates(upstream) - declared - resolved - overlayNsids

--- a/generator/src/test/kotlin/io/github/kikin81/atproto/generator/tools/LexiconDriftDetectTest.kt
+++ b/generator/src/test/kotlin/io/github/kikin81/atproto/generator/tools/LexiconDriftDetectTest.kt
@@ -168,15 +168,15 @@ class LexiconDriftDetectTest {
     }
 
     @Test
-    fun `parseManifestNsids reads the lexicons array only`() {
+    fun `parseManifest reads the opt-in lexicons array`() {
         assertEquals(
-            setOf("app.bsky.feed.getTimeline", "com.atproto.repo.createRecord"),
-            parseManifestNsids(MANIFEST_WITH_TRANSITIVE),
+            listOf("app.bsky.feed.getTimeline", "com.atproto.repo.createRecord"),
+            parseManifest(MANIFEST_WITH_TRANSITIVE).lexicons,
         )
     }
 
     @Test
-    fun `parseResolvedNsids reads every pinned NSID including transitive ones`() {
+    fun `parseManifest reads every pinned NSID including transitive ones`() {
         assertEquals(
             setOf(
                 "app.bsky.feed.getTimeline",
@@ -184,15 +184,18 @@ class LexiconDriftDetectTest {
                 "app.bsky.embed.images",
                 "app.bsky.feed.defs",
             ),
-            parseResolvedNsids(MANIFEST_WITH_TRANSITIVE),
+            parseManifest(MANIFEST_WITH_TRANSITIVE).resolutions.keys,
         )
     }
 
     @Test
-    fun `parseResolvedNsids returns empty for a manifest with no resolutions`() {
+    fun `parseManifest tolerates a manifest with no resolutions`() {
         val payload = """{"version": 1, "lexicons": ["app.bsky.feed.post"]}"""
 
-        assertEquals(emptySet(), parseResolvedNsids(payload))
+        val manifest = parseManifest(payload)
+
+        assertEquals(listOf("app.bsky.feed.post"), manifest.lexicons)
+        assertEquals(emptySet(), manifest.resolutions.keys)
     }
 
     @Test
@@ -205,8 +208,9 @@ class LexiconDriftDetectTest {
             "app.bsky.embed.images",
             "app.bsky.graph.follow",
         )
-        val declared = parseManifestNsids(MANIFEST_WITH_TRANSITIVE)
-        val resolved = parseResolvedNsids(MANIFEST_WITH_TRANSITIVE)
+        val manifest = parseManifest(MANIFEST_WITH_TRANSITIVE)
+        val declared = manifest.lexicons.toSet()
+        val resolved = manifest.resolutions.keys
 
         val newNsids = optInCandidates(upstream) - declared - resolved
 

--- a/generator/src/test/kotlin/io/github/kikin81/atproto/generator/tools/LexiconDriftDetectTest.kt
+++ b/generator/src/test/kotlin/io/github/kikin81/atproto/generator/tools/LexiconDriftDetectTest.kt
@@ -11,6 +11,37 @@ class LexiconDriftDetectTest {
 
     private val fixedNow: OffsetDateTime = OffsetDateTime.parse("2026-05-14T12:00:00Z")
 
+    private companion object {
+        /** Two opted-in NSIDs; resolutions additionally pins two transitive ones. */
+        const val MANIFEST_WITH_TRANSITIVE = """
+            {
+              "version": 1,
+              "lexicons": [
+                "app.bsky.feed.getTimeline",
+                "com.atproto.repo.createRecord"
+              ],
+              "resolutions": {
+                "app.bsky.feed.getTimeline": {
+                  "uri": "at://did:plc:xxx/com.atproto.lexicon.schema/app.bsky.feed.getTimeline",
+                  "cid": "bafy1"
+                },
+                "com.atproto.repo.createRecord": {
+                  "uri": "at://did:plc:xxx/com.atproto.lexicon.schema/com.atproto.repo.createRecord",
+                  "cid": "bafy2"
+                },
+                "app.bsky.embed.images": {
+                  "uri": "at://did:plc:xxx/com.atproto.lexicon.schema/app.bsky.embed.images",
+                  "cid": "bafy3"
+                },
+                "app.bsky.feed.defs": {
+                  "uri": "at://did:plc:xxx/com.atproto.lexicon.schema/app.bsky.feed.defs",
+                  "cid": "bafy4"
+                }
+              }
+            }
+        """
+    }
+
     @Test
     fun `isSubscription matches the upstream subscribe prefix on leaves`() {
         assertTrue(isSubscription("com.atproto.sync.subscribeRepos"))
@@ -104,7 +135,9 @@ class LexiconDriftDetectTest {
     }
 
     @Test
-    fun `parseUpstreamNsids skips defs files and non-lexicon paths`() {
+    fun `parseUpstreamNsids skips non-lexicon paths but keeps defs documents`() {
+        // defs are kept here so the removed-side diff can match a manifest that
+        // names one directly; the new-side strips them via optInCandidates.
         val payload = """
             {
               "tree": [
@@ -117,31 +150,109 @@ class LexiconDriftDetectTest {
             }
         """.trimIndent()
 
-        assertEquals(setOf("app.bsky.feed.getTimeline"), parseUpstreamNsids(payload))
+        assertEquals(
+            setOf("app.bsky.feed.getTimeline", "app.bsky.feed.defs"),
+            parseUpstreamNsids(payload),
+        )
     }
 
     @Test
-    fun `parseManifestNsids reads the lexicons array and ignores resolutions`() {
-        val payload = """
-            {
-              "version": 1,
-              "lexicons": [
-                "app.bsky.feed.getTimeline",
-                "com.atproto.repo.createRecord"
-              ],
-              "resolutions": {
-                "app.bsky.feed.getTimeline": {
-                  "uri": "at://did:plc:xxx/com.atproto.lexicon.schema/app.bsky.feed.getTimeline",
-                  "cid": "bafy..."
-                }
-              }
-            }
-        """.trimIndent()
+    fun `optInCandidates drops defs documents`() {
+        val upstream = setOf(
+            "app.bsky.feed.getTimeline",
+            "app.bsky.feed.defs",
+            "app.bsky.embed.defs",
+        )
 
+        assertEquals(setOf("app.bsky.feed.getTimeline"), optInCandidates(upstream))
+    }
+
+    @Test
+    fun `parseManifestNsids reads the lexicons array only`() {
         assertEquals(
             setOf("app.bsky.feed.getTimeline", "com.atproto.repo.createRecord"),
-            parseManifestNsids(payload),
+            parseManifestNsids(MANIFEST_WITH_TRANSITIVE),
         )
+    }
+
+    @Test
+    fun `parseResolvedNsids reads every pinned NSID including transitive ones`() {
+        assertEquals(
+            setOf(
+                "app.bsky.feed.getTimeline",
+                "com.atproto.repo.createRecord",
+                "app.bsky.embed.images",
+                "app.bsky.feed.defs",
+            ),
+            parseResolvedNsids(MANIFEST_WITH_TRANSITIVE),
+        )
+    }
+
+    @Test
+    fun `parseResolvedNsids returns empty for a manifest with no resolutions`() {
+        val payload = """{"version": 1, "lexicons": ["app.bsky.feed.post"]}"""
+
+        assertEquals(emptySet(), parseResolvedNsids(payload))
+    }
+
+    @Test
+    fun `transitively resolved NSIDs are not reported as a coverage gap`() {
+        // app.bsky.embed.images is pinned in resolutions via app.bsky.feed.post
+        // without being opted into — it is installed and generated, not a gap.
+        val upstream = setOf(
+            "app.bsky.feed.getTimeline",
+            "com.atproto.repo.createRecord",
+            "app.bsky.embed.images",
+            "app.bsky.graph.follow",
+        )
+        val declared = parseManifestNsids(MANIFEST_WITH_TRANSITIVE)
+        val resolved = parseResolvedNsids(MANIFEST_WITH_TRANSITIVE)
+
+        val newNsids = optInCandidates(upstream) - declared - resolved
+
+        assertEquals(setOf("app.bsky.graph.follow"), newNsids)
+    }
+
+    @Test
+    fun `a manifest defs entry that exists upstream is not reported as removed`() {
+        // The manifest may name a defs document directly. Diffing against the
+        // unfiltered upstream set keeps it from reading missing forever.
+        val upstream = setOf("app.bsky.feed.post", "app.bsky.video.defs")
+        val declared = setOf("app.bsky.feed.post", "app.bsky.video.defs")
+
+        assertEquals(emptySet(), declared - upstream)
+    }
+
+    @Test
+    fun `a manifest NSID genuinely absent upstream is still reported as removed`() {
+        val upstream = setOf("app.bsky.feed.post", "app.bsky.video.defs")
+        val declared = setOf(
+            "app.bsky.feed.post",
+            "app.bsky.video.defs",
+            "chat.bsky.group.getGroupPublicInfo",
+        )
+
+        assertEquals(setOf("chat.bsky.group.getGroupPublicInfo"), declared - upstream)
+    }
+
+    @Test
+    fun `renderReport notes the transitive exclusion count`() {
+        val body = renderReport(
+            emptySet(),
+            emptySet(),
+            fixedNow,
+            overlayCount = 0,
+            transitiveCount = 21,
+        )
+
+        assertContains(body, "_(21 NSID(s) covered transitively via `resolutions`")
+    }
+
+    @Test
+    fun `renderReport omits the transitive note when nothing is excluded`() {
+        val body = renderReport(emptySet(), emptySet(), fixedNow)
+
+        assertFalse(body.contains("covered transitively"))
     }
 
     @Test


### PR DESCRIPTION
## Problem

`LexiconDriftDetect` diffed upstream against the `lexicons` array in `generator/lexicons.json` and never parsed `resolutions`:

```kotlin
internal data class Manifest(val lexicons: List<String> = emptyList())
```

`lex install` pins the entire transitive closure it walks, so an NSID reached through a ref lands in `resolutions` without ever being opted into. It's installed, generated and published like any other — but to the detector it looked like a coverage gap, every single run.

Two structural false-positive classes fell out of that, both visible in #128:

**Transitive-only NSIDs reported as "new upstream" forever (6).** `app.bsky.embed.{external,images,record,video}`, `app.bsky.richtext.facet`, `com.atproto.repo.strongRef` — all six have generated models in `models/build/generated/source/lexicon/` today. (21 NSIDs are transitive-only; the `.defs` filter incidentally hid the other 15.)

**Every manifest `*.defs` entry reported as "missing from upstream".** `parseUpstreamNsids` applied `filterNot { it.endsWith(".defs") }` to the *upstream* side only, so the 3 defs documents the manifest names directly — `app.bsky.{bookmark,draft,video}.defs` — could never match. All three exist upstream (verified via the GitHub contents API). Being one-sided, a filter meant as a proxy for "transitive deps aren't opt-ins" corrupted the opposite direction of the diff.

## Fix

- Model `resolutions` on `Manifest`; add `parseResolvedNsids()` alongside `parseManifestNsids()`.
- Split the upstream set. `parseUpstreamNsids` now returns everything upstream publishes; the new `optInCandidates()` strips `.defs` and is applied to the new-upstream side only — defs are never opted into directly, so listing one as a gap is always noise.
- Diff accordingly:

```kotlin
val newNsids = optInCandidates(upstream) - declared - resolved - overlayNsids
val removedNsids = declared - upstream   // unfiltered: manifest defs exist upstream
```

- Report notes the transitive exclusion count, mirroring the existing overlay line, so the number is self-explaining next time.

## Verification

Live run against `bluesky-social/atproto@main`:

| | before | after |
|---|---|---|
| New upstream NSIDs | 216 | **210** |
| Missing from upstream | 4 | **1** |

The single survivor is the real one: `chat.bsky.group.getGroupPublicInfo` genuinely 404s upstream and is what the remaining `chat.bsky.group.defs` overlay exists to serve. Grepping the fresh report for all 9 phantoms returns nothing; every genuinely-uncovered NSID is still listed.

`:generator:test` — 138 tests, 0 failures. `LexiconDriftDetectTest` 11 → 19: two tests asserted the old behavior and were rewritten, new cases pin the transitive exclusion, the defs round-trip in both directions, and the report note.

## Note

This does **not** touch `expectDrift` on `chat.bsky.group.defs` or the overlay-staleness job — separate blind spot, separate follow-up.

Refs #128