### PR TITLE
feat(lexicons): expand coverage — searchPostsV2 + 7 chat.bsky.* NSIDs

### DIFF
--- a/generator/lexicons.json
+++ b/generator/lexicons.json
@@ -44,6 +44,7 @@
     "app.bsky.feed.postgate",
     "app.bsky.feed.repost",
     "app.bsky.feed.searchPosts",
+    "app.bsky.feed.searchPostsV2",
     "app.bsky.feed.sendInteractions",
     "app.bsky.feed.threadgate",
     "app.bsky.graph.block",
@@ -351,6 +352,10 @@
     "app.bsky.feed.searchPosts": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.feed.searchPosts",
       "cid": "bafyreif3xl6jj27tktxmxr3gtmf74wuxj6y6xnoycs7cclvifh4ncsi6mi"
+    },
+    "app.bsky.feed.searchPostsV2": {
+      "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.feed.searchPostsV2",
+      "cid": "bafyreiemtjvwfo6xuab6vkwbji46d7wms5xdzad6vygjymmcqr326quwqu"
     },
     "app.bsky.feed.sendInteractions": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.feed.sendInteractions",

--- a/generator/lexicons.json
+++ b/generator/lexicons.json
@@ -95,6 +95,8 @@
     "app.bsky.video.getUploadLimits",
     "app.bsky.video.uploadVideo",
     "chat.bsky.actor.declaration",
+    "chat.bsky.actor.deleteAccount",
+    "chat.bsky.actor.getStatus",
     "chat.bsky.convo.acceptConvo",
     "chat.bsky.convo.addReaction",
     "chat.bsky.convo.deleteMessageForSelf",
@@ -104,6 +106,7 @@
     "chat.bsky.convo.getConvoMembers",
     "chat.bsky.convo.getLog",
     "chat.bsky.convo.getMessages",
+    "chat.bsky.convo.getUnreadCounts",
     "chat.bsky.convo.leaveConvo",
     "chat.bsky.convo.listConvoRequests",
     "chat.bsky.convo.listConvos",
@@ -126,10 +129,14 @@
     "chat.bsky.group.editJoinLink",
     "chat.bsky.group.enableJoinLink",
     "chat.bsky.group.getGroupPublicInfo",
+    "chat.bsky.group.getJoinLinkPreviews",
     "chat.bsky.group.listJoinRequests",
+    "chat.bsky.group.listMutualGroups",
     "chat.bsky.group.rejectJoinRequest",
     "chat.bsky.group.removeMembers",
     "chat.bsky.group.requestJoin",
+    "chat.bsky.group.updateJoinRequestsRead",
+    "chat.bsky.group.withdrawJoinRequest",
     "com.atproto.identity.resolveHandle",
     "com.atproto.identity.updateHandle",
     "com.atproto.label.queryLabels",
@@ -577,6 +584,14 @@
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/chat.bsky.actor.defs",
       "cid": "bafyreigiv5fo5iufd3ahma6tgtozm35xibvx276nhjsjwuvsvxh3zj7u7q"
     },
+    "chat.bsky.actor.deleteAccount": {
+      "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/chat.bsky.actor.deleteAccount",
+      "cid": "bafyreierykzslwmkkugpyio3yiaxguttd5his5i4ow7re7wzcbxfogerrq"
+    },
+    "chat.bsky.actor.getStatus": {
+      "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/chat.bsky.actor.getStatus",
+      "cid": "bafyreib7f6wo5xsnfz37ywggtvqbcuxigf325q6pezshyhzyp2n5pdlzhu"
+    },
     "chat.bsky.convo.acceptConvo": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/chat.bsky.convo.acceptConvo",
       "cid": "bafyreih2ob7rsibl3h3so356rcdo2fop3dosxkna75w2u45qflbtw2r7qm"
@@ -616,6 +631,10 @@
     "chat.bsky.convo.getMessages": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/chat.bsky.convo.getMessages",
       "cid": "bafyreif2fjad4zrbjwhbuk3ny7yfnv6sjyr6llrveh2dr4i2aovwe77yia"
+    },
+    "chat.bsky.convo.getUnreadCounts": {
+      "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/chat.bsky.convo.getUnreadCounts",
+      "cid": "bafyreibuu7abhy74gxfprerxpiimjit43fhcrrewe43zhili7rmr4crrsi"
     },
     "chat.bsky.convo.leaveConvo": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/chat.bsky.convo.leaveConvo",
@@ -709,9 +728,17 @@
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/chat.bsky.group.getGroupPublicInfo",
       "cid": "bafyreialxwym3ir4cext23izqt5nddbtjemvme6l3fgh5rz3h3j4sfynmy"
     },
+    "chat.bsky.group.getJoinLinkPreviews": {
+      "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/chat.bsky.group.getJoinLinkPreviews",
+      "cid": "bafyreigrglu52cdsrc7sxxflwoxr6eg6paw4zsd7ioy7kyue2kqfdjyqn4"
+    },
     "chat.bsky.group.listJoinRequests": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/chat.bsky.group.listJoinRequests",
       "cid": "bafyreigoj66wx3sx7nbav4ywxckk7ggjklxvy2w5tmmnrapib7nfpgh3ci"
+    },
+    "chat.bsky.group.listMutualGroups": {
+      "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/chat.bsky.group.listMutualGroups",
+      "cid": "bafyreihp23gsqmaie6uzouxfqi6zwhr3wqglqjblbcawkp6asirzmqq4oi"
     },
     "chat.bsky.group.rejectJoinRequest": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/chat.bsky.group.rejectJoinRequest",
@@ -724,6 +751,14 @@
     "chat.bsky.group.requestJoin": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/chat.bsky.group.requestJoin",
       "cid": "bafyreiatzqdp7zlnbqmbti6xt3orag7yqyuqr6tqzwzzp52gq7hlu3it6q"
+    },
+    "chat.bsky.group.updateJoinRequestsRead": {
+      "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/chat.bsky.group.updateJoinRequestsRead",
+      "cid": "bafyreieod4o3cdfkhev6tia63q6yrdk3pgwvrrpyxggswxpp6pzwjj2jyi"
+    },
+    "chat.bsky.group.withdrawJoinRequest": {
+      "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/chat.bsky.group.withdrawJoinRequest",
+      "cid": "bafyreicdn25bcyya4for6vtdhhkjaeyfbkldgaxqtqoh5hfwljbrxszezy"
     },
     "com.atproto.admin.defs": {
       "uri": "at://did:plc:6msi3pj7krzih5qxqtryxlzw/com.atproto.lexicon.schema/com.atproto.admin.defs",

--- a/models/api/models.api
+++ b/models/api/models.api
@@ -4269,6 +4269,8 @@ public final class io/github/kikin81/atproto/app/bsky/feed/FeedService {
 	public static synthetic fun getTimeline$default (Lio/github/kikin81/atproto/app/bsky/feed/FeedService;Lio/github/kikin81/atproto/app/bsky/feed/GetTimelineRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun searchPosts (Lio/github/kikin81/atproto/app/bsky/feed/SearchPostsRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun searchPosts$default (Lio/github/kikin81/atproto/app/bsky/feed/FeedService;Lio/github/kikin81/atproto/app/bsky/feed/SearchPostsRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun searchPostsV2 (Lio/github/kikin81/atproto/app/bsky/feed/SearchPostsV2Request;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun searchPostsV2$default (Lio/github/kikin81/atproto/app/bsky/feed/FeedService;Lio/github/kikin81/atproto/app/bsky/feed/SearchPostsV2Request;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun sendInteractions (Lio/github/kikin81/atproto/app/bsky/feed/SendInteractionsRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun sendInteractions$default (Lio/github/kikin81/atproto/app/bsky/feed/FeedService;Lio/github/kikin81/atproto/app/bsky/feed/SendInteractionsRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
@@ -6327,6 +6329,124 @@ public final synthetic class io/github/kikin81/atproto/app/bsky/feed/SearchPosts
 }
 
 public final class io/github/kikin81/atproto/app/bsky/feed/SearchPostsResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/SearchPostsV2Request {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/SearchPostsV2Request$Companion;
+	public synthetic fun <init> (Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/lang/Long;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/lang/Long;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Boolean;
+	public final fun component10 ()Ljava/util/List;
+	public final fun component11 ()Ljava/util/List;
+	public final fun component12 ()Ljava/lang/Boolean;
+	public final fun component13 ()Ljava/util/List;
+	public final fun component14 ()Ljava/lang/Boolean;
+	public final fun component15 ()Ljava/lang/Boolean;
+	public final fun component16 ()Ljava/lang/Boolean;
+	public final fun component17 ()Ljava/util/List;
+	public final fun component18 ()Ljava/util/List;
+	public final fun component19 ()Ljava/lang/Long;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component20 ()Ljava/util/List;
+	public final fun component21 ()Ljava/lang/String;
+	public final fun component22 ()Ljava/lang/String;
+	public final fun component23 ()Ljava/lang/Boolean;
+	public final fun component24-XX8z880 ()Ljava/lang/String;
+	public final fun component25 ()Ljava/lang/String;
+	public final fun component26 ()Ljava/lang/String;
+	public final fun component27-XX8z880 ()Ljava/lang/String;
+	public final fun component28 ()Ljava/lang/String;
+	public final fun component29 ()Ljava/util/List;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Ljava/util/List;
+	public final fun component6 ()Ljava/util/List;
+	public final fun component7 ()Ljava/util/List;
+	public final fun component8 ()Ljava/util/List;
+	public final fun component9 ()Ljava/util/List;
+	public final fun copy-OVukhxU (Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/lang/Long;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)Lio/github/kikin81/atproto/app/bsky/feed/SearchPostsV2Request;
+	public static synthetic fun copy-OVukhxU$default (Lio/github/kikin81/atproto/app/bsky/feed/SearchPostsV2Request;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/lang/Long;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/feed/SearchPostsV2Request;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAllTime ()Ljava/lang/Boolean;
+	public final fun getAuthors ()Ljava/util/List;
+	public final fun getCursor ()Ljava/lang/String;
+	public final fun getDomains ()Ljava/util/List;
+	public final fun getEmbeddedAtUris ()Ljava/util/List;
+	public final fun getExcludeAuthors ()Ljava/util/List;
+	public final fun getExcludeDomains ()Ljava/util/List;
+	public final fun getExcludeEmbeddedAtUris ()Ljava/util/List;
+	public final fun getExcludeHashtags ()Ljava/util/List;
+	public final fun getExcludeLanguages ()Ljava/util/List;
+	public final fun getExcludeMentions ()Ljava/util/List;
+	public final fun getExcludeReplies ()Ljava/lang/Boolean;
+	public final fun getExcludeUrls ()Ljava/util/List;
+	public final fun getFollowing ()Ljava/lang/Boolean;
+	public final fun getHasMedia ()Ljava/lang/Boolean;
+	public final fun getHasVideo ()Ljava/lang/Boolean;
+	public final fun getHashtags ()Ljava/util/List;
+	public final fun getLanguages ()Ljava/util/List;
+	public final fun getLimit ()Ljava/lang/Long;
+	public final fun getMentions ()Ljava/util/List;
+	public final fun getQuery ()Ljava/lang/String;
+	public final fun getQueryLanguage ()Ljava/lang/String;
+	public final fun getRepliesOnly ()Ljava/lang/Boolean;
+	public final fun getReplyParentUri-XX8z880 ()Ljava/lang/String;
+	public final fun getSince ()Ljava/lang/String;
+	public final fun getSort ()Ljava/lang/String;
+	public final fun getThreadRootUri-XX8z880 ()Ljava/lang/String;
+	public final fun getUntil ()Ljava/lang/String;
+	public final fun getUrls ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/feed/SearchPostsV2Request$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/feed/SearchPostsV2Request$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/feed/SearchPostsV2Request;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/feed/SearchPostsV2Request;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/SearchPostsV2Request$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/SearchPostsV2Response {
+	public static final field Companion Lio/github/kikin81/atproto/app/bsky/feed/SearchPostsV2Response$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/lang/Long;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/lang/Long;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/lang/Long;
+	public final fun component4 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;Ljava/lang/Long;Ljava/util/List;)Lio/github/kikin81/atproto/app/bsky/feed/SearchPostsV2Response;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/app/bsky/feed/SearchPostsV2Response;Ljava/lang/String;Ljava/util/List;Ljava/lang/Long;Ljava/util/List;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/feed/SearchPostsV2Response;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCursor ()Ljava/lang/String;
+	public final fun getDetectedQueryLanguages ()Ljava/util/List;
+	public final fun getHitsTotal ()Ljava/lang/Long;
+	public final fun getPosts ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/app/bsky/feed/SearchPostsV2Response$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/app/bsky/feed/SearchPostsV2Response$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/app/bsky/feed/SearchPostsV2Response;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/app/bsky/feed/SearchPostsV2Response;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/app/bsky/feed/SearchPostsV2Response$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 

--- a/models/api/models.api
+++ b/models/api/models.api
@@ -10525,6 +10525,15 @@ public final class io/github/kikin81/atproto/app/bsky/video/VideoService {
 	public static synthetic fun uploadVideo$default (Lio/github/kikin81/atproto/app/bsky/video/VideoService;[BLio/ktor/http/ContentType;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
+public final class io/github/kikin81/atproto/chat/bsky/actor/ActorService {
+	public fun <init> (Lio/github/kikin81/atproto/runtime/XrpcClient;Ljava/lang/String;)V
+	public synthetic fun <init> (Lio/github/kikin81/atproto/runtime/XrpcClient;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun deleteAccount (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun deleteAccount$default (Lio/github/kikin81/atproto/chat/bsky/actor/ActorService;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getStatus (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getStatus$default (Lio/github/kikin81/atproto/chat/bsky/actor/ActorService;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
 public final class io/github/kikin81/atproto/chat/bsky/actor/Declaration {
 	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/actor/Declaration$Companion;
 	public fun <init> (Lio/github/kikin81/atproto/runtime/AtField;Ljava/lang/String;)V
@@ -10555,6 +10564,26 @@ public final class io/github/kikin81/atproto/chat/bsky/actor/Declaration$Compani
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class io/github/kikin81/atproto/chat/bsky/actor/DeleteAccountResponse {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/actor/DeleteAccountResponse$Companion;
+	public fun <init> ()V
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/actor/DeleteAccountResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/actor/DeleteAccountResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/actor/DeleteAccountResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/actor/DeleteAccountResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/actor/DeleteAccountResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
 public final class io/github/kikin81/atproto/chat/bsky/actor/DirectConvoMember : io/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasicKindUnion {
 	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/actor/DirectConvoMember$Companion;
 	public fun <init> ()V
@@ -10572,6 +10601,37 @@ public final synthetic class io/github/kikin81/atproto/chat/bsky/actor/DirectCon
 }
 
 public final class io/github/kikin81/atproto/chat/bsky/actor/DirectConvoMember$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/actor/GetStatusResponse {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/actor/GetStatusResponse$Companion;
+	public fun <init> (ZZJ)V
+	public final fun component1 ()Z
+	public final fun component2 ()Z
+	public final fun component3 ()J
+	public final fun copy (ZZJ)Lio/github/kikin81/atproto/chat/bsky/actor/GetStatusResponse;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/actor/GetStatusResponse;ZZJILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/actor/GetStatusResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCanCreateGroups ()Z
+	public final fun getChatDisabled ()Z
+	public final fun getGroupMemberLimit ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/actor/GetStatusResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/actor/GetStatusResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/actor/GetStatusResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/actor/GetStatusResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/actor/GetStatusResponse$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -10877,6 +10937,8 @@ public final class io/github/kikin81/atproto/chat/bsky/convo/ConvoService {
 	public static synthetic fun getLog$default (Lio/github/kikin81/atproto/chat/bsky/convo/ConvoService;Lio/github/kikin81/atproto/chat/bsky/convo/GetLogRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun getMessages (Lio/github/kikin81/atproto/chat/bsky/convo/GetMessagesRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun getMessages$default (Lio/github/kikin81/atproto/chat/bsky/convo/ConvoService;Lio/github/kikin81/atproto/chat/bsky/convo/GetMessagesRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getUnreadCounts (Lio/github/kikin81/atproto/chat/bsky/convo/GetUnreadCountsRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getUnreadCounts$default (Lio/github/kikin81/atproto/chat/bsky/convo/ConvoService;Lio/github/kikin81/atproto/chat/bsky/convo/GetUnreadCountsRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun leaveConvo (Lio/github/kikin81/atproto/chat/bsky/convo/LeaveConvoRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun leaveConvo$default (Lio/github/kikin81/atproto/chat/bsky/convo/ConvoService;Lio/github/kikin81/atproto/chat/bsky/convo/LeaveConvoRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun listConvoRequests (Lio/github/kikin81/atproto/chat/bsky/convo/ListConvoRequestsRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -11594,6 +11656,64 @@ public final class io/github/kikin81/atproto/chat/bsky/convo/GetMessagesResponse
 	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/GetMessagesResponseMessagesUnionUnknownSerializer;
 	public fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/chat/bsky/convo/GetMessagesResponseMessagesUnion$Unknown;
 	public synthetic fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/runtime/UnknownOpenUnionMember;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/GetUnreadCountsRequest {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/GetUnreadCountsRequest$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Boolean;)V
+	public synthetic fun <init> (Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Boolean;
+	public final fun copy (Ljava/lang/Boolean;)Lio/github/kikin81/atproto/chat/bsky/convo/GetUnreadCountsRequest;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/GetUnreadCountsRequest;Ljava/lang/Boolean;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/GetUnreadCountsRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getIncludeGroupChats ()Ljava/lang/Boolean;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/convo/GetUnreadCountsRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/GetUnreadCountsRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/convo/GetUnreadCountsRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/convo/GetUnreadCountsRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/GetUnreadCountsRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/GetUnreadCountsResponse {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/convo/GetUnreadCountsResponse$Companion;
+	public fun <init> (JJ)V
+	public final fun component1 ()J
+	public final fun component2 ()J
+	public final fun copy (JJ)Lio/github/kikin81/atproto/chat/bsky/convo/GetUnreadCountsResponse;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/convo/GetUnreadCountsResponse;JJILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/convo/GetUnreadCountsResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUnreadAcceptedConvos ()J
+	public final fun getUnreadRequestConvos ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/convo/GetUnreadCountsResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/convo/GetUnreadCountsResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/convo/GetUnreadCountsResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/convo/GetUnreadCountsResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/convo/GetUnreadCountsResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/github/kikin81/atproto/chat/bsky/convo/GroupConvo : io/github/kikin81/atproto/chat/bsky/convo/ConvoViewKindUnion {
@@ -14725,7 +14845,7 @@ public final class io/github/kikin81/atproto/chat/bsky/group/DisableJoinLinkResp
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class io/github/kikin81/atproto/chat/bsky/group/DisabledJoinLinkPreviewView : io/github/kikin81/atproto/chat/bsky/embed/JoinLinkViewJoinLinkPreviewUnion {
+public final class io/github/kikin81/atproto/chat/bsky/group/DisabledJoinLinkPreviewView : io/github/kikin81/atproto/chat/bsky/embed/JoinLinkViewJoinLinkPreviewUnion, io/github/kikin81/atproto/chat/bsky/group/GetJoinLinkPreviewsResponseJoinLinkPreviewsUnion {
 	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/group/DisabledJoinLinkPreviewView$Companion;
 	public fun <init> (Ljava/lang/String;)V
 	public final fun component1 ()Ljava/lang/String;
@@ -14975,6 +15095,100 @@ public final class io/github/kikin81/atproto/chat/bsky/group/GetGroupPublicInfoR
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class io/github/kikin81/atproto/chat/bsky/group/GetJoinLinkPreviewsRequest {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/group/GetJoinLinkPreviewsRequest$Companion;
+	public fun <init> (Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lio/github/kikin81/atproto/chat/bsky/group/GetJoinLinkPreviewsRequest;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/group/GetJoinLinkPreviewsRequest;Ljava/util/List;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/group/GetJoinLinkPreviewsRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCodes ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/group/GetJoinLinkPreviewsRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/group/GetJoinLinkPreviewsRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/group/GetJoinLinkPreviewsRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/group/GetJoinLinkPreviewsRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/GetJoinLinkPreviewsRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/GetJoinLinkPreviewsResponse {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/group/GetJoinLinkPreviewsResponse$Companion;
+	public fun <init> (Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lio/github/kikin81/atproto/chat/bsky/group/GetJoinLinkPreviewsResponse;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/group/GetJoinLinkPreviewsResponse;Ljava/util/List;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/group/GetJoinLinkPreviewsResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getJoinLinkPreviews ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/group/GetJoinLinkPreviewsResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/group/GetJoinLinkPreviewsResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/group/GetJoinLinkPreviewsResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/group/GetJoinLinkPreviewsResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/GetJoinLinkPreviewsResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class io/github/kikin81/atproto/chat/bsky/group/GetJoinLinkPreviewsResponseJoinLinkPreviewsUnion : io/github/kikin81/atproto/runtime/OpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/group/GetJoinLinkPreviewsResponseJoinLinkPreviewsUnion$Companion;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/GetJoinLinkPreviewsResponseJoinLinkPreviewsUnion$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/GetJoinLinkPreviewsResponseJoinLinkPreviewsUnion$Unknown : io/github/kikin81/atproto/chat/bsky/group/GetJoinLinkPreviewsResponseJoinLinkPreviewsUnion, io/github/kikin81/atproto/runtime/UnknownOpenUnionMember {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/group/GetJoinLinkPreviewsResponseJoinLinkPreviewsUnion$Unknown$Companion;
+	public fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/chat/bsky/group/GetJoinLinkPreviewsResponseJoinLinkPreviewsUnion$Unknown;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/group/GetJoinLinkPreviewsResponseJoinLinkPreviewsUnion$Unknown;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/group/GetJoinLinkPreviewsResponseJoinLinkPreviewsUnion$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getRaw ()Lkotlinx/serialization/json/JsonObject;
+	public fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/GetJoinLinkPreviewsResponseJoinLinkPreviewsUnion$Unknown$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/GetJoinLinkPreviewsResponseJoinLinkPreviewsUnionSerializer : io/github/kikin81/atproto/runtime/OpenUnionSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/group/GetJoinLinkPreviewsResponseJoinLinkPreviewsUnionSerializer;
+	public fun selectKnownDeserializer (Ljava/lang/String;)Lkotlinx/serialization/KSerializer;
+	public fun selectKnownSerializer (Lio/github/kikin81/atproto/chat/bsky/group/GetJoinLinkPreviewsResponseJoinLinkPreviewsUnion;)Lkotlinx/serialization/KSerializer;
+	public synthetic fun selectKnownSerializer (Lio/github/kikin81/atproto/runtime/OpenUnionMember;)Lkotlinx/serialization/KSerializer;
+	public fun unknownSerializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/GetJoinLinkPreviewsResponseJoinLinkPreviewsUnionUnknownSerializer : io/github/kikin81/atproto/runtime/UnknownMemberSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/group/GetJoinLinkPreviewsResponseJoinLinkPreviewsUnionUnknownSerializer;
+	public fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/chat/bsky/group/GetJoinLinkPreviewsResponseJoinLinkPreviewsUnion$Unknown;
+	public synthetic fun construct (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/github/kikin81/atproto/runtime/UnknownOpenUnionMember;
+}
+
 public final class io/github/kikin81/atproto/chat/bsky/group/GroupPublicView {
 	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/group/GroupPublicView$Companion;
 	public fun <init> (JLjava/lang/String;Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;Z)V
@@ -15029,22 +15243,32 @@ public final class io/github/kikin81/atproto/chat/bsky/group/GroupService {
 	public static synthetic fun enableJoinLink$default (Lio/github/kikin81/atproto/chat/bsky/group/GroupService;Lio/github/kikin81/atproto/chat/bsky/group/EnableJoinLinkRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun getGroupPublicInfo (Lio/github/kikin81/atproto/chat/bsky/group/GetGroupPublicInfoRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun getGroupPublicInfo$default (Lio/github/kikin81/atproto/chat/bsky/group/GroupService;Lio/github/kikin81/atproto/chat/bsky/group/GetGroupPublicInfoRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getJoinLinkPreviews (Lio/github/kikin81/atproto/chat/bsky/group/GetJoinLinkPreviewsRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getJoinLinkPreviews$default (Lio/github/kikin81/atproto/chat/bsky/group/GroupService;Lio/github/kikin81/atproto/chat/bsky/group/GetJoinLinkPreviewsRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun listJoinRequests (Lio/github/kikin81/atproto/chat/bsky/group/ListJoinRequestsRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun listJoinRequests$default (Lio/github/kikin81/atproto/chat/bsky/group/GroupService;Lio/github/kikin81/atproto/chat/bsky/group/ListJoinRequestsRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun listMutualGroups (Lio/github/kikin81/atproto/chat/bsky/group/ListMutualGroupsRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun listMutualGroups$default (Lio/github/kikin81/atproto/chat/bsky/group/GroupService;Lio/github/kikin81/atproto/chat/bsky/group/ListMutualGroupsRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun rejectJoinRequest (Lio/github/kikin81/atproto/chat/bsky/group/RejectJoinRequestRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun rejectJoinRequest$default (Lio/github/kikin81/atproto/chat/bsky/group/GroupService;Lio/github/kikin81/atproto/chat/bsky/group/RejectJoinRequestRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun removeMembers (Lio/github/kikin81/atproto/chat/bsky/group/RemoveMembersRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun removeMembers$default (Lio/github/kikin81/atproto/chat/bsky/group/GroupService;Lio/github/kikin81/atproto/chat/bsky/group/RemoveMembersRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun requestJoin (Lio/github/kikin81/atproto/chat/bsky/group/RequestJoinRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun requestJoin$default (Lio/github/kikin81/atproto/chat/bsky/group/GroupService;Lio/github/kikin81/atproto/chat/bsky/group/RequestJoinRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun updateJoinRequestsRead (Lio/github/kikin81/atproto/chat/bsky/group/UpdateJoinRequestsReadRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun updateJoinRequestsRead$default (Lio/github/kikin81/atproto/chat/bsky/group/GroupService;Lio/github/kikin81/atproto/chat/bsky/group/UpdateJoinRequestsReadRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun withdrawJoinRequest (Lio/github/kikin81/atproto/chat/bsky/group/WithdrawJoinRequestRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun withdrawJoinRequest$default (Lio/github/kikin81/atproto/chat/bsky/group/GroupService;Lio/github/kikin81/atproto/chat/bsky/group/WithdrawJoinRequestRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class io/github/kikin81/atproto/chat/bsky/group/GroupServiceKt {
 	public static final fun listJoinRequestsFlow (Lio/github/kikin81/atproto/chat/bsky/group/GroupService;Lio/github/kikin81/atproto/chat/bsky/group/ListJoinRequestsRequest;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun listJoinRequestsPageFlow (Lio/github/kikin81/atproto/chat/bsky/group/GroupService;Lio/github/kikin81/atproto/chat/bsky/group/ListJoinRequestsRequest;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun listMutualGroupsFlow (Lio/github/kikin81/atproto/chat/bsky/group/GroupService;Lio/github/kikin81/atproto/chat/bsky/group/ListMutualGroupsRequest;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun listMutualGroupsPageFlow (Lio/github/kikin81/atproto/chat/bsky/group/GroupService;Lio/github/kikin81/atproto/chat/bsky/group/ListMutualGroupsRequest;)Lkotlinx/coroutines/flow/Flow;
 }
 
-public final class io/github/kikin81/atproto/chat/bsky/group/InvalidJoinLinkPreviewView : io/github/kikin81/atproto/chat/bsky/embed/JoinLinkViewJoinLinkPreviewUnion {
+public final class io/github/kikin81/atproto/chat/bsky/group/InvalidJoinLinkPreviewView : io/github/kikin81/atproto/chat/bsky/embed/JoinLinkViewJoinLinkPreviewUnion, io/github/kikin81/atproto/chat/bsky/group/GetJoinLinkPreviewsResponseJoinLinkPreviewsUnion {
 	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/group/InvalidJoinLinkPreviewView$Companion;
 	public fun <init> (Ljava/lang/String;)V
 	public final fun component1 ()Ljava/lang/String;
@@ -15071,7 +15295,7 @@ public final class io/github/kikin81/atproto/chat/bsky/group/InvalidJoinLinkPrev
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class io/github/kikin81/atproto/chat/bsky/group/JoinLinkPreviewView : io/github/kikin81/atproto/chat/bsky/embed/JoinLinkViewJoinLinkPreviewUnion {
+public final class io/github/kikin81/atproto/chat/bsky/group/JoinLinkPreviewView : io/github/kikin81/atproto/chat/bsky/embed/JoinLinkViewJoinLinkPreviewUnion, io/github/kikin81/atproto/chat/bsky/group/GetJoinLinkPreviewsResponseJoinLinkPreviewsUnion {
 	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/group/JoinLinkPreviewView$Companion;
 	public fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/ConvoView;Ljava/lang/String;Ljava/lang/String;JJLjava/lang/String;Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;ZLio/github/kikin81/atproto/chat/bsky/group/JoinLinkViewerState;)V
 	public synthetic fun <init> (Ljava/lang/String;Lio/github/kikin81/atproto/chat/bsky/convo/ConvoView;Ljava/lang/String;Ljava/lang/String;JJLjava/lang/String;Lio/github/kikin81/atproto/chat/bsky/actor/ProfileViewBasic;ZLio/github/kikin81/atproto/chat/bsky/group/JoinLinkViewerState;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -15310,6 +15534,68 @@ public final class io/github/kikin81/atproto/chat/bsky/group/ListJoinRequestsRes
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class io/github/kikin81/atproto/chat/bsky/group/ListMutualGroupsRequest {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/group/ListMutualGroupsRequest$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/Long;
+	public final fun component3-UyB9Nic ()Ljava/lang/String;
+	public final fun copy-N-huOdQ (Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/group/ListMutualGroupsRequest;
+	public static synthetic fun copy-N-huOdQ$default (Lio/github/kikin81/atproto/chat/bsky/group/ListMutualGroupsRequest;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/group/ListMutualGroupsRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCursor ()Ljava/lang/String;
+	public final fun getLimit ()Ljava/lang/Long;
+	public final fun getSubject-UyB9Nic ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/group/ListMutualGroupsRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/group/ListMutualGroupsRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/group/ListMutualGroupsRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/group/ListMutualGroupsRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/ListMutualGroupsRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/ListMutualGroupsResponse {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/group/ListMutualGroupsResponse$Companion;
+	public fun <init> (Ljava/util/List;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/util/List;Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/group/ListMutualGroupsResponse;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/group/ListMutualGroupsResponse;Ljava/util/List;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/group/ListMutualGroupsResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConvos ()Ljava/util/List;
+	public final fun getCursor ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/group/ListMutualGroupsResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/group/ListMutualGroupsResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/group/ListMutualGroupsResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/group/ListMutualGroupsResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/ListMutualGroupsResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
 public final class io/github/kikin81/atproto/chat/bsky/group/RejectJoinRequestRequest {
 	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/group/RejectJoinRequestRequest$Companion;
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -15469,6 +15755,100 @@ public final synthetic class io/github/kikin81/atproto/chat/bsky/group/RequestJo
 }
 
 public final class io/github/kikin81/atproto/chat/bsky/group/RequestJoinResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/UpdateJoinRequestsReadRequest {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/group/UpdateJoinRequestsReadRequest$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/group/UpdateJoinRequestsReadRequest;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/group/UpdateJoinRequestsReadRequest;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/group/UpdateJoinRequestsReadRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConvoId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/group/UpdateJoinRequestsReadRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/group/UpdateJoinRequestsReadRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/group/UpdateJoinRequestsReadRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/group/UpdateJoinRequestsReadRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/UpdateJoinRequestsReadRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/UpdateJoinRequestsReadResponse {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/group/UpdateJoinRequestsReadResponse$Companion;
+	public fun <init> ()V
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/group/UpdateJoinRequestsReadResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/group/UpdateJoinRequestsReadResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/group/UpdateJoinRequestsReadResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/group/UpdateJoinRequestsReadResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/UpdateJoinRequestsReadResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/WithdrawJoinRequestRequest {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/group/WithdrawJoinRequestRequest$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/github/kikin81/atproto/chat/bsky/group/WithdrawJoinRequestRequest;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/chat/bsky/group/WithdrawJoinRequestRequest;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/chat/bsky/group/WithdrawJoinRequestRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConvoId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/group/WithdrawJoinRequestRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/group/WithdrawJoinRequestRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/group/WithdrawJoinRequestRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/group/WithdrawJoinRequestRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/WithdrawJoinRequestRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/WithdrawJoinRequestResponse {
+	public static final field Companion Lio/github/kikin81/atproto/chat/bsky/group/WithdrawJoinRequestResponse$Companion;
+	public fun <init> ()V
+}
+
+public final synthetic class io/github/kikin81/atproto/chat/bsky/group/WithdrawJoinRequestResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/chat/bsky/group/WithdrawJoinRequestResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/chat/bsky/group/WithdrawJoinRequestResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/chat/bsky/group/WithdrawJoinRequestResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/chat/bsky/group/WithdrawJoinRequestResponse$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 

--- a/models/src/commonTest/kotlin/io/github/kikin81/atproto/app/bsky/feed/FeedServiceTest.kt
+++ b/models/src/commonTest/kotlin/io/github/kikin81/atproto/app/bsky/feed/FeedServiceTest.kt
@@ -3,6 +3,7 @@ package io.github.kikin81.atproto.app.bsky.feed
 import io.github.kikin81.atproto.runtime.AtField
 import io.github.kikin81.atproto.runtime.AtIdentifier
 import io.github.kikin81.atproto.runtime.AtUri
+import io.github.kikin81.atproto.runtime.Language
 import io.github.kikin81.atproto.test.MockXrpcFixture
 import io.ktor.http.HttpMethod
 import kotlinx.coroutines.test.runTest
@@ -51,6 +52,50 @@ class FeedServiceTest {
         assertNotNull(url)
         assertContains(url, "/xrpc/app.bsky.feed.describeFeedGenerator")
         assertEquals("did:web:feed.test", response.did.raw)
+    }
+
+    @Test
+    fun searchPostsV2SerializesRepeatedFilterParamsAndDecodesQueryLanguages() = runTest {
+        fixture.respondWith(
+            """
+            {
+              "posts": [],
+              "cursor": "next",
+              "hitsTotal": 42,
+              "detectedQueryLanguages": ["ja", "ko"]
+            }
+            """.trimIndent(),
+        )
+
+        val response = FeedService(fixture.client).searchPostsV2(
+            SearchPostsV2Request(
+                query = "kotlin",
+                sort = "top",
+                limit = 25,
+                authors = listOf(AtIdentifier("alice.test"), AtIdentifier("bob.test")),
+                hashtags = listOf("kmp"),
+                languages = listOf(Language("ja")),
+                hasVideo = true,
+            ),
+        )
+
+        assertEquals(HttpMethod.Get, fixture.capturedMethod)
+        val url = fixture.capturedUrl
+        assertNotNull(url)
+        assertContains(url, "/xrpc/app.bsky.feed.searchPostsV2")
+        assertContains(url, "query=kotlin")
+        assertContains(url, "sort=top")
+        assertContains(url, "limit=25")
+        // Array params repeat the key rather than joining — both authors survive.
+        assertContains(url, "authors=alice.test")
+        assertContains(url, "authors=bob.test")
+        assertContains(url, "hashtags=kmp")
+        assertContains(url, "languages=ja")
+        assertContains(url, "hasVideo=true")
+        assertEquals("next", response.cursor)
+        assertEquals(42L, response.hitsTotal)
+        assertEquals(listOf("ja", "ko"), response.detectedQueryLanguages)
+        assertEquals(emptyList(), response.posts)
     }
 
     @Test

--- a/models/src/commonTest/kotlin/io/github/kikin81/atproto/chat/bsky/actor/ActorServiceTest.kt
+++ b/models/src/commonTest/kotlin/io/github/kikin81/atproto/chat/bsky/actor/ActorServiceTest.kt
@@ -1,0 +1,72 @@
+package io.github.kikin81.atproto.chat.bsky.actor
+
+import io.github.kikin81.atproto.test.MockXrpcFixture
+import io.ktor.http.HttpMethod
+import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class ActorServiceTest {
+
+    private lateinit var fixture: MockXrpcFixture
+
+    @BeforeTest
+    fun setup() {
+        fixture = MockXrpcFixture()
+    }
+
+    private fun service() = ActorService(fixture.client)
+
+    private fun assertChatProxyApplied() {
+        // chat.bsky.* services route through the bsky chat appview by default.
+        assertEquals(
+            "did:web:api.bsky.chat#bsky_chat",
+            fixture.capturedHeaders["atproto-proxy"],
+        )
+    }
+
+    @Test
+    fun getStatusIsGetWithoutParamsAndDecodesViewerChatState() = runTest {
+        fixture.respondWith(
+            """{"chatDisabled":false,"canCreateGroups":true,"groupMemberLimit":100}""",
+        )
+
+        val response = service().getStatus()
+
+        assertEquals(HttpMethod.Get, fixture.capturedMethod)
+        val url = fixture.capturedUrl
+        assertNotNull(url)
+        assertContains(url, "/xrpc/chat.bsky.actor.getStatus")
+        assertChatProxyApplied()
+        assertEquals(false, response.chatDisabled)
+        assertEquals(true, response.canCreateGroups)
+        assertEquals(100L, response.groupMemberLimit)
+    }
+
+    @Test
+    fun deleteAccountIsPostWithoutBody() = runTest {
+        fixture.respondWith("{}")
+
+        service().deleteAccount()
+
+        assertEquals(HttpMethod.Post, fixture.capturedMethod)
+        val url = fixture.capturedUrl
+        assertNotNull(url)
+        assertContains(url, "/xrpc/chat.bsky.actor.deleteAccount")
+        assertChatProxyApplied()
+    }
+
+    @Test
+    fun methodProxyOverrideWins() = runTest {
+        fixture.respondWith(
+            """{"chatDisabled":false,"canCreateGroups":true,"groupMemberLimit":100}""",
+        )
+
+        service().getStatus(proxy = "did:web:custom#svc")
+
+        assertEquals("did:web:custom#svc", fixture.capturedHeaders["atproto-proxy"])
+    }
+}

--- a/models/src/commonTest/kotlin/io/github/kikin81/atproto/chat/bsky/convo/ConvoServiceTest.kt
+++ b/models/src/commonTest/kotlin/io/github/kikin81/atproto/chat/bsky/convo/ConvoServiceTest.kt
@@ -7,6 +7,7 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 
 class ConvoServiceTest {
@@ -26,6 +27,36 @@ class ConvoServiceTest {
             "did:web:api.bsky.chat#bsky_chat",
             fixture.capturedHeaders["atproto-proxy"],
         )
+    }
+
+    @Test
+    fun getUnreadCountsIsGetWithOptionalGroupFlagAndSplitCounts() = runTest {
+        fixture.respondWith("""{"unreadAcceptedConvos":7,"unreadRequestConvos":2}""")
+
+        val response = service().getUnreadCounts(
+            GetUnreadCountsRequest(includeGroupChats = true),
+        )
+
+        assertEquals(HttpMethod.Get, fixture.capturedMethod)
+        val url = fixture.capturedUrl
+        assertNotNull(url)
+        assertContains(url, "/xrpc/chat.bsky.convo.getUnreadCounts")
+        assertContains(url, "includeGroupChats=true")
+        assertChatProxyApplied()
+        assertEquals(7L, response.unreadAcceptedConvos)
+        assertEquals(2L, response.unreadRequestConvos)
+    }
+
+    @Test
+    fun getUnreadCountsOmitsTheGroupFlagWhenUnset() = runTest {
+        fixture.respondWith("""{"unreadAcceptedConvos":0,"unreadRequestConvos":0}""")
+
+        service().getUnreadCounts()
+
+        val url = fixture.capturedUrl
+        assertNotNull(url)
+        assertContains(url, "/xrpc/chat.bsky.convo.getUnreadCounts")
+        assertFalse(url.contains("includeGroupChats"))
     }
 
     @Test

--- a/models/src/commonTest/kotlin/io/github/kikin81/atproto/chat/bsky/group/GroupServiceTest.kt
+++ b/models/src/commonTest/kotlin/io/github/kikin81/atproto/chat/bsky/group/GroupServiceTest.kt
@@ -9,6 +9,7 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
+import kotlin.test.assertIs
 import kotlin.test.assertNotNull
 
 class GroupServiceTest {
@@ -266,6 +267,105 @@ class GroupServiceTest {
         assertChatProxyApplied()
         assertEquals(5L, response.group.memberCount)
         assertEquals("My Group", response.group.name)
+    }
+
+    // ---- join-link previews / mutual groups ------------------------------
+
+    @Test
+    fun getJoinLinkPreviewsDecodesEachUnionMemberAndFallsBackOnUnknown() = runTest {
+        // One of each known member, plus a $type the SDK has never seen — the
+        // open union must degrade to Unknown rather than failing the response.
+        fixture.respondWith(
+            """{"joinLinkPreviews":[""" +
+                """{"${'$'}type":"chat.bsky.group.defs#joinLinkPreviewView",""" +
+                """"code":"abc123","convoId":"3kconvo","joinRule":"open",""" +
+                """"memberCount":5,"memberLimit":100,"name":"My Group",""" +
+                """"owner":{"did":"did:plc:alice"},"requireApproval":false},""" +
+                """{"${'$'}type":"chat.bsky.group.defs#disabledJoinLinkPreviewView","code":"dead01"},""" +
+                """{"${'$'}type":"chat.bsky.group.defs#invalidJoinLinkPreviewView","code":"bogus1"},""" +
+                """{"${'$'}type":"chat.bsky.group.defs#futureJoinLinkPreviewView","code":"new001"}]}""",
+        )
+
+        val response = service().getJoinLinkPreviews(
+            GetJoinLinkPreviewsRequest(codes = listOf("abc123", "dead01", "bogus1", "new001")),
+        )
+
+        assertEquals(HttpMethod.Get, fixture.capturedMethod)
+        val url = fixture.capturedUrl
+        assertNotNull(url)
+        assertContains(url, "/xrpc/chat.bsky.group.getJoinLinkPreviews")
+        // Array param repeats the key — all four codes survive the round trip.
+        assertContains(url, "codes=abc123")
+        assertContains(url, "codes=new001")
+        assertChatProxyApplied()
+
+        val previews = response.joinLinkPreviews
+        assertEquals(4, previews.size)
+        val known = previews[0]
+        assertIs<JoinLinkPreviewView>(known)
+        assertEquals("My Group", known.name)
+        assertEquals(5L, known.memberCount)
+        assertEquals(Did("did:plc:alice"), known.owner.did)
+        assertIs<DisabledJoinLinkPreviewView>(previews[1])
+        assertIs<InvalidJoinLinkPreviewView>(previews[2])
+        val unknown = previews[3]
+        assertIs<GetJoinLinkPreviewsResponseJoinLinkPreviewsUnion.Unknown>(unknown)
+        assertEquals("chat.bsky.group.defs#futureJoinLinkPreviewView", unknown.type)
+    }
+
+    @Test
+    fun listMutualGroupsIsGetWithSubjectAndPaginationParams() = runTest {
+        fixture.respondWith("""{"cursor":"next","convos":[$convoJson]}""")
+
+        val response = service().listMutualGroups(
+            ListMutualGroupsRequest(subject = Did("did:plc:bob"), limit = 10, cursor = "abc"),
+        )
+
+        assertEquals(HttpMethod.Get, fixture.capturedMethod)
+        val url = fixture.capturedUrl
+        assertNotNull(url)
+        assertContains(url, "/xrpc/chat.bsky.group.listMutualGroups")
+        assertContains(url, "subject=did%3Aplc%3Abob")
+        assertContains(url, "limit=10")
+        assertContains(url, "cursor=abc")
+        assertChatProxyApplied()
+        assertEquals("next", response.cursor)
+        assertEquals(1, response.convos.size)
+        assertEquals("3kconvo", response.convos[0].id)
+    }
+
+    // ---- join-request procedures -----------------------------------------
+
+    @Test
+    fun updateJoinRequestsReadPostsConvoId() = runTest {
+        fixture.respondWith("{}")
+
+        service().updateJoinRequestsRead(UpdateJoinRequestsReadRequest(convoId = "3kconvo"))
+
+        assertEquals(HttpMethod.Post, fixture.capturedMethod)
+        val url = fixture.capturedUrl
+        assertNotNull(url)
+        assertContains(url, "/xrpc/chat.bsky.group.updateJoinRequestsRead")
+        assertChatProxyApplied()
+        val body = fixture.capturedBody
+        assertNotNull(body)
+        assertContains(body, "3kconvo")
+    }
+
+    @Test
+    fun withdrawJoinRequestPostsConvoId() = runTest {
+        fixture.respondWith("{}")
+
+        service().withdrawJoinRequest(WithdrawJoinRequestRequest(convoId = "3kconvo"))
+
+        assertEquals(HttpMethod.Post, fixture.capturedMethod)
+        val url = fixture.capturedUrl
+        assertNotNull(url)
+        assertContains(url, "/xrpc/chat.bsky.group.withdrawJoinRequest")
+        assertChatProxyApplied()
+        val body = fixture.capturedBody
+        assertNotNull(body)
+        assertContains(body, "3kconvo")
     }
 
     @Test


### PR DESCRIPTION
Closes 8 of the coverage gaps listed in #128. Every NSID here resolved on-network, so all of it is manifest-only — no overlays added.

## What landed

**`app.bsky.feed.searchPostsV2`** (`89bbdb50`) — the V2 post search. Same shape as v1 plus a much wider filter surface: `authors`/`excludeAuthors`, `hashtags`, `languages`, `domains`, `urls`, `mentions`, `embeddedAtUris` arrays, `since`/`until` windows, `hasMedia`/`hasVideo`/`following`/`repliesOnly` flags, `threadRootUri`, and `allTime` to search the full index rather than the recent window. Response adds `hitsTotal` and `detectedQueryLanguages`. Value classes resolved as expected — `AtIdentifier`, `AtUri`, `Uri`, `Language`.

**7 `chat.bsky.*` NSIDs** (`96c76904`):

| NSID | What it does |
|---|---|
| `convo.getUnreadCounts` | Unread counts split by status; optional `includeGroupChats` |
| `group.getJoinLinkPreviews` | Batch join-code lookup returning an open union of joinLink / disabled / invalid preview views |
| `group.listMutualGroups` | Groups shared with an actor, paginated |
| `group.updateJoinRequestsRead` | Owner marks join requests read |
| `group.withdrawJoinRequest` | Requester withdraws a pending request |
| `actor.getStatus` | Viewer chat state — `chatDisabled`, `canCreateGroups`, `groupMemberLimit` |
| `actor.deleteAccount` | Deletes the chat account |

## Overlay interaction — verified clean

`getJoinLinkPreviews` refs three `chat.bsky.group.defs` members, and that NSID is served by the vendored superset overlay whose staleness signal is muted by `expectDrift`. Rather than trust the manifest note, I diffed vendored against on-network: `groupPublicView` is the only local addition and no shared def differs in content. Nothing is shadowed.

## Deliberately excluded

**`chat.bsky.actor.exportAccountData`** — the 8th chat NSID upstream, and it **cannot be generated today**. Its output is `application/jsonl` with no schema; the generator only special-cases non-JSON *input* encodings (the raw-bytes path used by `uploadBlob`). There's no output equivalent, so it emits no service method, no request, no response — nothing at all. Confirmed it's the encoding and not a bad install: `deleteAccount` generates fine off `application/json` with an empty schema. Listing it would add a silent no-op manifest entry, so it stays out and stays visible in the drift report as a real gap. Raw/streaming response support is the prerequisite.

**`app.bsky.graph.searchStarterPacksV2`** — on GitHub main but not published on-network (`RecordNotFound`), so it would need a vendored overlay. Its only benefit over v1 is richer hydration (`starterPackView` instead of `starterPackViewBasic`, plus `hitsTotal`), which saves a `getStarterPack` round-trip per result but unlocks nothing new. Not worth reversing the overlay cleanup from #176 for a latency optimization — parked until it publishes.

**`site.standard.*`** — out of scope. All six are records/objects with zero queries or procedures, published by a third-party authority (`did:plc:re3ebnp5v7ffagz6rb6xfei4`), for a publishing spec Bluesky doesn't own.

## Verification

```
models     tests= 36 failures/errors=0   (+9)
runtime    tests= 97 failures/errors=0
generator  tests=138 failures/errors=0
oauth      tests= 63 failures/errors=0
```

10 new service tests across `FeedServiceTest`, `ConvoServiceTest`, `GroupServiceTest`, and a new `ActorServiceTest` for `chat.bsky.actor` — covering union decode including the `Unknown` forward-compat fallback on an unseen `$type`, repeated array-param encoding, chat proxy application and per-method override, and procedure bodies.

`:models:apiCheck` passes. One thing that reads oddly in the `models.api` diff: three `-`/`+` line pairs on the preview views look like removals but aren't — those classes now implement *both* the existing embed union and the new one, which is additive.

iOS simulator tests not run locally (no Xcode on this machine); CI covers them.

Refs #128