### PR TITLE
fix(oauth): make a terminal invalid_grant sticky and unreplayable

### DIFF
--- a/oauth/src/main/kotlin/io/github/kikin81/atproto/oauth/DpopAuthProvider.kt
+++ b/oauth/src/main/kotlin/io/github/kikin81/atproto/oauth/DpopAuthProvider.kt
@@ -405,12 +405,15 @@ class DpopAuthProvider(
             sessionStore.save(session)
         }
     }
-
-    private companion object {
-        const val INVALID_GRANT = "invalid_grant"
-        const val TERMINAL_MESSAGE = "Refresh token revoked (invalid_grant) — terminal for this session"
-    }
 }
+
+// File-level rather than a `private companion object`: a `const val` in a
+// companion still compiles to a PUBLIC static field on the enclosing class, so
+// the companion form leaked both constants into the published ABI and failed
+// binary-compatibility-validator. Top-level private consts land on the file
+// class as private statics instead.
+private const val INVALID_GRANT = "invalid_grant"
+private const val TERMINAL_MESSAGE = "Refresh token revoked (invalid_grant) — terminal for this session"
 
 @Serializable
 internal data class TokenResponse(

--- a/oauth/src/main/kotlin/io/github/kikin81/atproto/oauth/DpopAuthProvider.kt
+++ b/oauth/src/main/kotlin/io/github/kikin81/atproto/oauth/DpopAuthProvider.kt
@@ -67,6 +67,20 @@ class DpopAuthProvider(
 
     private val refreshMutex = Mutex()
 
+    /**
+     * Latches once a refresh is terminally rejected (`invalid_grant`) and the
+     * session is cleared. Written and read under [refreshMutex].
+     *
+     * The in-memory [session] is deliberately NOT mutated on failure, so
+     * neither dedup check in [refreshTokensSingleFlight] can tell a terminal
+     * failure apart from "nothing has happened yet": `rotatedWhileWaiting`
+     * sees unchanged tokens, and [adoptStoredSessionIfRotated] sees an empty
+     * store and reports "no rotation". Without this latch every coalesced
+     * waiter re-POSTs the dead refresh token and duplicate-clears, and any
+     * later nonce rotation re-saves the dead session over the cleared store.
+     */
+    private var sessionTerminallyExpired = false
+
     @Volatile
     private var pdsNonce: String? = session.pdsNonce
 
@@ -148,6 +162,12 @@ class DpopAuthProvider(
         observedRefreshToken: String,
     ): Boolean {
         refreshMutex.withLock {
+            // A prior waiter already proved this refresh token dead. Replaying
+            // it would re-trip reuse detection and duplicate the clear; the
+            // terminal outcome is shared across the coalesced set, exactly as
+            // a successful rotation is.
+            if (sessionTerminallyExpired) throw OAuthSessionExpiredException(TERMINAL_MESSAGE)
+
             val rotatedWhileWaiting =
                 session.accessToken != observedAccessToken ||
                     session.refreshToken != observedRefreshToken
@@ -214,24 +234,53 @@ class DpopAuthProvider(
 
     private suspend fun refreshTokens(): Boolean {
         val response = postRefreshForm(failureContext = "")
+        if (response.status == HttpStatusCode.OK) return applyRefreshResponse(response)
+
+        // Classify before deciding to retry: an HTTP body can only be consumed
+        // once, and both the nonce-retry decision and the terminal split need
+        // the `error` field.
+        val error = parseErrorField(response)
 
         // A rotated DPoP-Nonce on a 401/400 is a recoverable use_dpop_nonce
         // signal — retry once with the new nonce (not a token rejection).
+        //
+        // An explicit `invalid_grant` is terminal even when the server ALSO
+        // rotated a nonce: retrying would re-POST the refresh token the server
+        // just rejected, and replaying a single-use refresh token is precisely
+        // what trips AT Proto reuse detection. Classify first, retry second.
         val nonceHeader = response.headers["DPoP-Nonce"]
         val isNonceRetryStatus =
             response.status == HttpStatusCode.Unauthorized ||
                 response.status == HttpStatusCode.BadRequest
-        val canRetryWithNonce = isNonceRetryStatus && nonceHeader != null
+        val canRetryWithNonce = error != INVALID_GRANT && isNonceRetryStatus && nonceHeader != null
         if (canRetryWithNonce) {
             signer.calibrateClockFromHeader(response.headers["Date"]?.toString())
             authServerNonce = nonceHeader
             return refreshTokensWithNonce()
         }
 
-        return applyRefreshResponse(response)
+        failRefresh(response.status, error)
     }
 
-    private suspend fun refreshTokensWithNonce(): Boolean = applyRefreshResponse(postRefreshForm(failureContext = " (nonce retry)"))
+    private suspend fun refreshTokensWithNonce(): Boolean {
+        val response = postRefreshForm(failureContext = " (nonce retry)")
+        if (response.status == HttpStatusCode.OK) return applyRefreshResponse(response)
+        failRefresh(response.status, parseErrorField(response))
+    }
+
+    /**
+     * Reads the response body and extracts the OAuth `error` field (RFC 6749
+     * §5.2). Returns `null` for an unparseable body (proxy/captive-portal HTML),
+     * which the caller must treat as transient rather than as a rejection.
+     */
+    private suspend fun parseErrorField(response: HttpResponse): String? {
+        // bodyAsText() is a suspend call — must not sit inside runCatching,
+        // which would swallow CancellationException. Only the parse is guarded.
+        val body = response.bodyAsText()
+        return runCatching {
+            json.parseToJsonElement(body).jsonObject["error"]?.jsonPrimitive?.content
+        }.getOrNull()
+    }
 
     private suspend fun postRefreshForm(failureContext: String): HttpResponse {
         val proof = signer.sign(
@@ -269,9 +318,8 @@ class DpopAuthProvider(
         e is UnresolvedAddressException ||
         e is ConnectTimeoutException
 
+    /** Callers guarantee [response] is HTTP 200; non-OK goes to [failRefresh]. */
     private suspend fun applyRefreshResponse(response: HttpResponse): Boolean {
-        if (response.status != HttpStatusCode.OK) failRefresh(response)
-
         val tokenResponse = json.decodeFromString(TokenResponse.serializer(), response.bodyAsText())
         session = session.copy(
             accessToken = tokenResponse.access_token,
@@ -322,19 +370,16 @@ class DpopAuthProvider(
      * request with real connectivity can refresh cleanly. This is what keeps a
      * flaky connection from silently signing the user out.
      */
-    private suspend fun failRefresh(response: HttpResponse): Nothing {
-        // Read the body first (a suspend call — must not be inside runCatching, which
-        // would swallow CancellationException); only the pure JSON parse is guarded.
-        val body = response.bodyAsText()
-        val error = runCatching {
-            json.parseToJsonElement(body).jsonObject["error"]?.jsonPrimitive?.content
-        }.getOrNull()
-        if (error == "invalid_grant") {
+    private suspend fun failRefresh(status: HttpStatusCode, error: String?): Nothing {
+        if (error == INVALID_GRANT) {
+            // Latch BEFORE clearing so any waiter that acquires the mutex next
+            // short-circuits instead of replaying this now-dead token.
+            sessionTerminallyExpired = true
             sessionStore.clear()
-            throw OAuthSessionExpiredException("Refresh token revoked (invalid_grant, HTTP ${response.status})")
+            throw OAuthSessionExpiredException("Refresh token revoked (invalid_grant, HTTP $status)")
         }
         throw OAuthRefreshFailedException(
-            "Refresh failed (HTTP ${response.status}${error?.let { ", error=$it" } ?: ""})",
+            "Refresh failed (HTTP $status${error?.let { ", error=$it" } ?: ""})",
         )
     }
 
@@ -349,10 +394,21 @@ class DpopAuthProvider(
      */
     private suspend fun persistNonces() {
         refreshMutex.withLock {
+            // Once the session is terminally expired the store has been cleared
+            // and this instance's in-memory copy holds a dead refresh token.
+            // Saving it would resurrect the cleared session — and because every
+            // request 401s with a rotated nonce after a logout, that happens on
+            // the very next request, re-arming the reuse-detection loop.
+            if (sessionTerminallyExpired) return
             adoptStoredSessionIfRotated()
             session = session.copy(authServerNonce = authServerNonce, pdsNonce = pdsNonce)
             sessionStore.save(session)
         }
+    }
+
+    private companion object {
+        const val INVALID_GRANT = "invalid_grant"
+        const val TERMINAL_MESSAGE = "Refresh token revoked (invalid_grant) — terminal for this session"
     }
 }
 

--- a/oauth/src/test/kotlin/io/github/kikin81/atproto/oauth/DpopAuthProviderTest.kt
+++ b/oauth/src/test/kotlin/io/github/kikin81/atproto/oauth/DpopAuthProviderTest.kt
@@ -25,13 +25,21 @@ class DpopAuthProviderTest {
 
     private val jsonHeaders = headersOf(HttpHeaders.ContentType, "application/json")
 
+    // A fresh channel per response: ByteReadChannel is consumed on read, so a
+    // shared instance would surface as an empty body on the second call.
+    private fun invalidGrantBody() = ByteReadChannel("""{"error":"invalid_grant","error_description":"token has been revoked"}""")
+
     private class InMemorySessionStore : OAuthSessionStore {
         var session: OAuthSession? = null
+        var clearCalls = 0
+        var saveCalls = 0
         override suspend fun load(): OAuthSession? = session
         override suspend fun save(session: OAuthSession) {
+            saveCalls++
             this.session = session
         }
         override suspend fun clear() {
+            clearCalls++
             session = null
         }
     }
@@ -619,6 +627,115 @@ class DpopAuthProviderTest {
             "pre-send failures must state the refresh token was not consumed, got: ${failure.message}",
         )
         assertNotNull(store.session, "a pre-send failure must not clear the session")
+    }
+
+    @Test
+    fun coalescedWaitersDoNotReplayADeadTokenAfterTerminalInvalidGrant() = runTest {
+        // Regression for #164 §1. failRefresh clears the store but deliberately
+        // leaves the in-memory session intact, so neither dedup check can see
+        // that a prior waiter already failed terminally: `rotatedWhileWaiting`
+        // reads unchanged tokens and adoptStoredSessionIfRotated reads an empty
+        // store and reports "no rotation". The waiter then re-POSTs the dead
+        // refresh token — a replay, which is exactly what AT Proto reuse
+        // detection revokes on — and duplicate-clears.
+        var tokenCalls = 0
+        val refreshClient = HttpClient(
+            MockEngine { _ ->
+                tokenCalls++
+                respond(invalidGrantBody(), HttpStatusCode.BadRequest, jsonHeaders)
+            },
+        )
+        val (provider, store) = fixtureWithExpiredToken(refreshClient)
+
+        listOf(
+            async { runCatching { provider.onUnauthorized(emptyMap()) } },
+            async { runCatching { provider.onUnauthorized(emptyMap()) } },
+        ).awaitAll()
+
+        assertEquals(1, tokenCalls, "the dead refresh token must be POSTed once for the whole coalesced set")
+        assertEquals(1, store.clearCalls, "the session must be cleared exactly once")
+    }
+
+    @Test
+    fun aNonceRotationAfterTerminalClearDoesNotResurrectTheClearedSession() = runTest {
+        // Regression for #164 §4. persistNonces() saved unconditionally, so the
+        // first 401 carrying a rotated DPoP-Nonce after a terminal clear wrote
+        // the dead session back to the store. Once the token is dead EVERY
+        // request 401s and the PDS rotates nonces routinely, so this fired on
+        // the very next request — re-arming the logout loop.
+        val refreshClient = HttpClient(
+            MockEngine { _ -> respond(invalidGrantBody(), HttpStatusCode.BadRequest, jsonHeaders) },
+        )
+        // The access token here is OPAQUE, not an expired JWT, on purpose: it
+        // makes isAccessTokenExpired() return false so the second
+        // onUnauthorized returns right after persistNonces() instead of running
+        // another refresh. With an expired JWT that follow-up refresh clears the
+        // store a second time and masks the resurrect — the assertion would then
+        // pass against unfixed code and prove nothing.
+        val (provider, store) = fixtureWithOpaqueToken(refreshClient)
+
+        assertFailsWith<OAuthSessionExpiredException> { provider.onUnauthorized(emptyMap()) }
+        assertNull(store.session, "precondition: the terminal invalid_grant must have cleared the store")
+        val savesBefore = store.saveCalls
+
+        provider.onUnauthorized(mapOf("DPoP-Nonce" to "rotated-nonce"))
+
+        assertEquals(savesBefore, store.saveCalls, "a cleared session must never be re-saved")
+        assertNull(store.session, "a cleared session must stay cleared — never re-save a dead refresh token")
+    }
+
+    /**
+     * Companion to [fixtureWithExpiredToken] whose access token is opaque, so
+     * `isAccessTokenExpired()` cannot fire and `onUnauthorized` exercises only
+     * the nonce branches plus the explicit fall-through refresh.
+     */
+    private fun fixtureWithOpaqueToken(refreshClient: HttpClient): Pair<DpopAuthProvider, InMemorySessionStore> {
+        val signer = DpopSigner.generate()
+        val exported = signer.exportKeyPair()
+        val store = InMemorySessionStore()
+        val session = OAuthSession(
+            accessToken = "opaque-not-a-jwt",
+            refreshToken = "rt_dead",
+            did = "did:plc:x",
+            handle = "x.test",
+            pdsUrl = "https://pds.test",
+            tokenEndpoint = "https://auth.test/token",
+            clientId = "https://app.test/meta.json",
+            dpopPrivateKey = exported.privateKeyEncoded,
+            dpopPublicKey = exported.publicKeyEncoded,
+            pdsNonce = "old-nonce",
+        )
+        store.session = session
+        return DpopAuthProvider(session, signer, store, refreshClient) to store
+    }
+
+    @Test
+    fun invalidGrantCarryingANonceHeaderIsTerminalRatherThanRetried() = runTest {
+        // Regression for #164 §5. The nonce-retry gate keyed only on
+        // (401|400) + a DPoP-Nonce header, never on the body, so a rejection
+        // that also rotated a nonce was misread as `use_dpop_nonce` and the
+        // just-rejected refresh token was replayed. Production stacks show the
+        // clear arriving via refreshTokensWithNonce, i.e. through this branch.
+        var tokenCalls = 0
+        val refreshClient = HttpClient(
+            MockEngine { _ ->
+                tokenCalls++
+                respond(
+                    invalidGrantBody(),
+                    HttpStatusCode.BadRequest,
+                    headersOf(
+                        HttpHeaders.ContentType to listOf("application/json"),
+                        "DPoP-Nonce" to listOf("rotated-nonce-$tokenCalls"),
+                    ),
+                )
+            },
+        )
+        val (provider, store) = fixtureWithExpiredToken(refreshClient)
+
+        assertFailsWith<OAuthSessionExpiredException> { provider.onUnauthorized(emptyMap()) }
+
+        assertEquals(1, tokenCalls, "an explicit invalid_grant is terminal even when a nonce was also rotated")
+        assertEquals(1, store.clearCalls, "the session must be cleared exactly once")
     }
 
     /**


### PR DESCRIPTION
Addresses **§1** of #164 plus **two further gaps found while reproducing it**, all three confirmed against the pinned `v9.9.0` (`DpopAuthProvider` has not changed since #163).

## Root cause

`failRefresh` clears the session store on `invalid_grant` but deliberately leaves the in-memory `session` intact. Nothing downstream can then distinguish "a prior refresh failed terminally" from "nothing has happened yet" — `rotatedWhileWaiting` reads unchanged tokens, and `adoptStoredSessionIfRotated` reads an empty store and reports "no rotation".

## What that caused

| | Gap | Effect |
|---|---|---|
| §1 | Coalesced waiters fall through both dedup checks | Each re-POSTs the dead refresh token and duplicate-clears |
| §4 *(new)* | `persistNonces()` saves unconditionally | The next 401 with a rotated `DPoP-Nonce` writes the dead session back over the cleared store |
| §5 *(new)* | Nonce-retry gate keys on `(401\|400) + DPoP-Nonce` only, never on the body | An `invalid_grant` that also rotates a nonce is misread as `use_dpop_nonce` and the rejected token is replayed |

§4 matters more than it looks: once the token is dead **every** request 401s, and the PDS rotates nonces routinely — so the resurrect fires on the very next request rather than in some rare race.

Replaying a single-use refresh token is exactly what AT Proto reuse detection revokes on, so each of these turns one rejection into several.

## Evidence

Downstream production telemetry (Crashlytics non-fatals recorded on every store `clear()`) shows **43 events across 11 sessions** — ~4 clears per logout — and a breadcrumb trail with two clears 3.3 s apart from unrelated callers:

```
02:06:00  [NotificationsRepository] unreadCount failed: invalid_grant (HTTP 400)
02:06:00  session_cleared { reason: invalid_grant, days_since_login: 0 }
02:06:03  [FollowRepository] follow failed: invalid_grant (HTTP 400)
02:06:03  session_cleared { reason: invalid_grant, days_since_login: 0 }
```

The failing stack arrives via `refreshTokensWithNonce` — i.e. through the §5 branch.

## Fix

- Latch `sessionTerminallyExpired` under `refreshMutex`, set immediately before `sessionStore.clear()`.
- `refreshTokensSingleFlight` short-circuits on the latch, so the terminal outcome is shared across the coalesced set exactly as a successful rotation is.
- `persistNonces` returns early on the latch — never resurrect a cleared session.
- `refreshTokens` parses the `error` field **before** deciding to retry with a rotated nonce; an explicit `invalid_grant` is terminal regardless of headers.

Chose a latch over the issue's proposed `sessionStore.load() == null` guard: several existing tests construct a provider against a store that legitimately returns `null`, and the latch caches the terminal result precisely (which is what fix (A) describes) without changing behaviour for any other store shape.

## Tests

Three regression tests in `DpopAuthProviderTest`. Mutation-checked — reverting only the `DpopAuthProvider.kt` change and rerunning:

```
WITH FIX:     tests=20 failures=0
WITHOUT FIX:  tests=20 failures=3   (all three new tests)
```

The §4 test uses an **opaque** access token on purpose. With an expired JWT the follow-up refresh clears the store a second time and masks the resurrect — that version passed against unfixed code and proved nothing.

All 66 `:oauth` tests pass; `spotlessCheck` verified cold (`--no-build-cache --rerun-tasks --no-daemon`).

## Not included

- **§2** (`failRefresh` re-reading the store to adopt a concurrent sibling rotation) — hardening for multi-instance/multi-process consumers, not reachable from a single shared provider. Worth doing, but it changes `failRefresh`'s shape and belongs in its own PR.
- **§3** (receive→persist durability window) — inherent; needs the write-ahead rotation marker discussed in the issue.

So #164 stays open.

Refs: #164