### PR TITLE
feat(oauth): expose DiscoveryChain.resolvePds as public API

### DIFF
--- a/oauth/api/oauth.api
+++ b/oauth/api/oauth.api
@@ -42,6 +42,7 @@ public final class io/github/kikin81/atproto/oauth/DiscoveryChain {
 	public synthetic fun <init> (Lio/ktor/client/HttpClient;Lkotlinx/serialization/json/Json;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun resolve (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun resolveKnownAuthServer (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun resolvePds (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class io/github/kikin81/atproto/oauth/DpopAuthProvider : io/github/kikin81/atproto/runtime/AuthProvider {

--- a/oauth/src/main/kotlin/io/github/kikin81/atproto/oauth/DiscoveryChain.kt
+++ b/oauth/src/main/kotlin/io/github/kikin81/atproto/oauth/DiscoveryChain.kt
@@ -272,9 +272,21 @@ class DiscoveryChain(
     }
 
     /**
-     * Extracts the PDS URL from the DID document's service array.
+     * Resolves a DID to the URL of the PDS hosting it, by fetching the DID
+     * document and reading its `#atproto_pds` service entry.
+     *
+     * Public because callers routinely have a DID already — `searchActorsTypeahead`
+     * and `getProfile` both return one — and want only this one hop. [resolve]
+     * would work but runs the whole chain (handle → DID → PDS → auth server →
+     * metadata), which is four extra round trips for an answer this method gets
+     * in one, and is far too heavy to run per row of a list.
+     *
+     * Handles `did:plc` (via `plc.directory`) and `did:web` (via the host's
+     * `/.well-known/did.json`). Throws [OAuthDiscoveryException] for an
+     * unsupported DID method, an unreachable or malformed document, or a
+     * document with no PDS service entry.
      */
-    internal suspend fun resolvePds(did: String): String {
+    suspend fun resolvePds(did: String): String {
         val doc = resolveDid(did)
         val pdsService = doc.service?.firstOrNull { it.id == "#atproto_pds" }
             ?: throw OAuthDiscoveryException("DID document for '$did' has no #atproto_pds service")

--- a/oauth/src/test/kotlin/io/github/kikin81/atproto/oauth/DiscoveryChainTest.kt
+++ b/oauth/src/test/kotlin/io/github/kikin81/atproto/oauth/DiscoveryChainTest.kt
@@ -350,4 +350,81 @@ class DiscoveryChainTest {
         assertEquals("flaky.test", hydrated.handle)
         assertEquals(null, hydrated.pdsUrl)
     }
+
+    // --- resolvePds, now part of the public surface ---
+
+    @Test
+    fun resolvePdsReadsTheAtprotoPdsServiceFromAPlcDocument() = runTest {
+        var requestedUrl: String? = null
+        val client = HttpClient(
+            MockEngine { request ->
+                requestedUrl = request.url.toString()
+                respond(
+                    ByteReadChannel(
+                        """{"id":"did:plc:abc","service":[{"id":"#atproto_pds","type":"AtprotoPersonalDataServer","serviceEndpoint":"https://shiitake.us-east.host.bsky.network"}]}""",
+                    ),
+                    HttpStatusCode.OK,
+                    jsonHeaders,
+                )
+            },
+        )
+
+        val pds = DiscoveryChain(client).resolvePds("did:plc:abc")
+
+        assertEquals("https://shiitake.us-east.host.bsky.network", pds)
+        // One hop only. The point of exposing this over resolve() is that a caller
+        // holding a DID pays a single request instead of the full four-step chain.
+        assertEquals("https://plc.directory/did:plc:abc", requestedUrl)
+    }
+
+    @Test
+    fun resolvePdsUsesTheHostsWellKnownDocumentForDidWeb() = runTest {
+        var requestedUrl: String? = null
+        val client = HttpClient(
+            MockEngine { request ->
+                requestedUrl = request.url.toString()
+                respond(
+                    ByteReadChannel(
+                        """{"id":"did:web:pds.example.com","service":[{"id":"#atproto_pds","type":"AtprotoPersonalDataServer","serviceEndpoint":"https://pds.example.com"}]}""",
+                    ),
+                    HttpStatusCode.OK,
+                    jsonHeaders,
+                )
+            },
+        )
+
+        val pds = DiscoveryChain(client).resolvePds("did:web:pds.example.com")
+
+        assertEquals("https://pds.example.com", pds)
+        assertEquals("https://pds.example.com/.well-known/did.json", requestedUrl)
+    }
+
+    @Test
+    fun resolvePdsFailsWhenTheDocumentDeclaresNoPdsService() = runTest {
+        val client = HttpClient(
+            MockEngine {
+                respond(
+                    // A syntactically valid DID document whose services do not
+                    // include #atproto_pds — callers must get a clear failure
+                    // rather than a silently wrong endpoint.
+                    ByteReadChannel("""{"id":"did:plc:abc","service":[{"id":"#other","type":"Other","serviceEndpoint":"https://nope.example"}]}"""),
+                    HttpStatusCode.OK,
+                    jsonHeaders,
+                )
+            },
+        )
+
+        assertFailsWith<OAuthDiscoveryException> {
+            DiscoveryChain(client).resolvePds("did:plc:abc")
+        }
+    }
+
+    @Test
+    fun resolvePdsRejectsAnUnsupportedDidMethod() = runTest {
+        val client = HttpClient(MockEngine { respond(ByteReadChannel(""), HttpStatusCode.OK) })
+
+        assertFailsWith<OAuthDiscoveryException> {
+            DiscoveryChain(client).resolvePds("did:example:abc")
+        }
+    }
 }


### PR DESCRIPTION
## Why

`DiscoveryChain.resolvePds` was `internal`, so a caller outside the module could only reach a DID's PDS by running the full `resolve()` chain — handle → DID → PDS → authorization server → metadata. That needs a *handle* as input and costs four extra round trips when the only unknown is the PDS.

The motivating consumer is a pre-login account typeahead: `app.bsky.actor.searchActorsTypeahead` already returns each account's DID, and the UI wants to annotate every suggestion with the network hosting it. One hop is all that's missing.

## What

- `resolvePds` widened `internal` → `public`. No behaviour change.
- `oauth.api` updated accordingly (`apiCheck` passes).
- Four tests added: a `did:plc` document, `did:web`, a document with no `#atproto_pds` service, and an unsupported DID method.

Verified with `:oauth:test`, `:oauth:apiCheck`, and a cold `spotlessApply --no-build-cache --rerun-tasks`. Exercised end to end against the live network from a downstream consumer built with `-PuseMavenLocal=true`.