### PR TITLE
fix(oauth): never abandon a token rotation the server already applied

### DIFF
--- a/oauth/src/main/kotlin/io/github/kikin81/atproto/oauth/DpopAuthProvider.kt
+++ b/oauth/src/main/kotlin/io/github/kikin81/atproto/oauth/DpopAuthProvider.kt
@@ -8,8 +8,10 @@ import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.Parameters
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonObject
@@ -51,6 +53,20 @@ class DpopAuthProvider(
     @Volatile private var session: OAuthSession,
     private val signer: DpopSigner,
     private val sessionStore: OAuthSessionStore,
+    /**
+     * Client used for token-endpoint POSTs.
+     *
+     * Should be bounded by a request timeout — Ktor's `HttpTimeout` plugin, or
+     * timeouts configured on the engine. This library installs neither and
+     * cannot enforce it, so it is the caller's responsibility.
+     *
+     * It matters more here than for an ordinary request: the refresh runs under
+     * `NonCancellable`, because once the token endpoint has been POSTed the
+     * refresh token is consumed server-side and abandoning the call would
+     * strand the rotation. That removes cancellation as an escape hatch, so a
+     * timeout is what bounds a hung socket. An unbounded client will hold the
+     * calling coroutine until the socket resolves on its own.
+     */
     private val refreshClient: HttpClient,
     private val json: Json = Json { ignoreUnknownKeys = true },
     /**
@@ -178,7 +194,21 @@ class DpopAuthProvider(
                 return true
             }
 
-            return refreshTokens()
+            // NonCancellable from here down, and NOT a line earlier. Everything
+            // above is either a cheap local check or a wait on the mutex, where
+            // a cancelled caller has caused no server-side effect and should be
+            // free to give up. Once the token endpoint is POSTed the refresh
+            // token is CONSUMED and a new one issued, so abandoning the call
+            // does not undo anything — it only loses the replacement, leaving
+            // the store holding a token the server will reject as reuse
+            // (RFC 9700) on the next attempt. In the field the canceller was a
+            // WorkManager CoroutineWorker being stopped mid-poll, and the user
+            // was silently signed out minutes later.
+            //
+            // Bounded by the refresh client's request timeout, not by
+            // withTimeout: a timeout wrapper here would reintroduce the very
+            // cancellation this exists to prevent. See [refreshClient].
+            return withContext(NonCancellable) { refreshTokens() }
         }
     }
 

--- a/oauth/src/test/kotlin/io/github/kikin81/atproto/oauth/DpopAuthProviderTest.kt
+++ b/oauth/src/test/kotlin/io/github/kikin81/atproto/oauth/DpopAuthProviderTest.kt
@@ -10,6 +10,7 @@ import io.ktor.utils.io.ByteReadChannel
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import kotlin.coroutines.cancellation.CancellationException
 import kotlin.io.encoding.Base64
@@ -781,5 +782,81 @@ class DpopAuthProviderTest {
         val header = Base64.UrlSafe.encode("""{"alg":"ES256","typ":"at+jwt"}""".toByteArray()).trimEnd('=')
         val payload = Base64.UrlSafe.encode("""{"exp":$exp}""".toByteArray()).trimEnd('=')
         return "$header.$payload.fakesignature"
+    }
+
+    @Test
+    fun rotatedTokenSurvivesCallerCancellationDuringPersist() = runTest {
+        // Regression for the nubecita spurious-logout chain.
+        //
+        // The refresh runs inside whatever coroutine needed a token — in the
+        // field that was a WorkManager CoroutineWorker polling chat.bsky.convo
+        // .getLog, which WorkManager cancels on Doze / constraint loss / the
+        // execution limit. If the caller is cancelled AFTER the server has
+        // consumed and rotated the refresh token but BEFORE the rotation is
+        // persisted, the stored token is the CONSUMED one. The next refresh
+        // replays it, the authorization server treats a replayed refresh token
+        // as reuse (RFC 9700), and the user is silently signed out.
+        //
+        // Once the request is in flight the rotation MUST be durable, because
+        // the server-side effect has already happened and cannot be undone.
+        val persistReached = CompletableDeferred<Unit>()
+        val releasePersist = CompletableDeferred<Unit>()
+        val refreshClient = HttpClient(
+            MockEngine { _ ->
+                respond(
+                    ByteReadChannel(
+                        """{"access_token":"at_rotated","refresh_token":"rt_rotated","token_type":"DPoP"}""",
+                    ),
+                    HttpStatusCode.OK,
+                    jsonHeaders,
+                )
+            },
+        )
+
+        val signer = DpopSigner.generate()
+        val exported = signer.exportKeyPair()
+        val store = object : OAuthSessionStore {
+            var session: OAuthSession? = null
+            override suspend fun load(): OAuthSession? = session
+            override suspend fun save(session: OAuthSession) {
+                // Stand in for the real store's encrypt + DataStore write: a
+                // suspending gap the caller's cancellation can land inside.
+                persistReached.complete(Unit)
+                releasePersist.await()
+                this.session = session
+            }
+            override suspend fun clear() {
+                session = null
+            }
+        }
+        val session = OAuthSession(
+            accessToken = makeJwtWithExp((System.currentTimeMillis() / 1000) - 3600),
+            refreshToken = "rt_consumed",
+            did = "did:plc:testuser",
+            handle = "alice.test",
+            pdsUrl = "https://pds.test",
+            tokenEndpoint = "https://auth.test/token",
+            clientId = "https://app.test/meta.json",
+            dpopPrivateKey = exported.privateKeyEncoded,
+            dpopPublicKey = exported.publicKeyEncoded,
+        )
+        store.session = session
+        val provider = DpopAuthProvider(session, signer, store, refreshClient)
+
+        // The worker that needed the token, and the cancellation that killed it.
+        val caller = launch { provider.onUnauthorized(emptyMap()) }
+        persistReached.await()
+        caller.cancel()
+        releasePersist.complete(Unit)
+        caller.join()
+
+        val persisted = store.session
+        assertNotNull(persisted)
+        assertEquals(
+            "rt_rotated",
+            persisted.refreshToken,
+            "the server already consumed rt_consumed, so abandoning the rotation " +
+                "leaves a token that will be rejected as reuse on the next refresh",
+        )
     }
 }


### PR DESCRIPTION
## The bug

A refresh runs inside whatever coroutine happened to need a token. If that coroutine is cancelled **after** the token endpoint has been POSTed, the server has already consumed the old refresh token and issued a new one — but the client never persists the replacement.

The stored token is then the **consumed** one. The next refresh replays it, the authorization server treats a replayed refresh token as reuse (RFC 9700), answers `invalid_grant`, and the session is cleared. The user is silently signed out.

Once the request is in flight, abandoning it undoes nothing — the server-side effect has already happened. It only loses the replacement.

## How it was found

From a real logout, not from reading code. Crashlytics breadcrumbs on the affected device:

```
21:59:12  last foreground use
23:09:20  [ChatRepository] getLog failed: Job was cancelled   <-- here
23:14:45  session_start  (user tapped a chat notification)
23:14:46  session cleared - invalid_grant
```

`getLog` runs in a WorkManager `CoroutineWorker`, which the platform stops on Doze, constraint loss, or the execution limit — its scope is cancellable by design. The session was **one day old** (`days_since_login=1`), so nothing had expired; the rotation had been lost five minutes earlier.

It looked random for months because it needs a background poll to be cancelled inside the short window of a rotation.

## The fix

`withContext(NonCancellable)` around the POST and its persist — and deliberately **not one line earlier**. Waiting on the refresh mutex stays cancellable: a caller that has not yet POSTed has caused no server-side effect and should be free to give up. Only the irreversible part is protected.

Bounded by the refresh client's `HttpTimeout`, **not** `withTimeout` — a timeout wrapper here would reintroduce the very cancellation this exists to prevent. That was previously an unstated assumption; the constructor KDoc now makes it a documented requirement, since `NonCancellable` makes the HTTP timeout the only bound.

## Verification

The regression test cancels the caller while the persist is suspended, then asserts the rotated token still reaches the store. On the code before this change it fails with exactly the field symptom:

```
expected: <rt_rotated> but was: <rt_consumed>
```

397 SDK tests pass, `apiCheck` clean (no API change), cold `spotlessApply --no-build-cache --rerun-tasks`.

## What this does not claim

It closes the window we can demonstrate. Process death between rotation and persist remains possible and is not addressable here — that one is reported through `onPersistFailure`, except when the cause is cancellation, which the downstream consumer currently drops. Making that case countable is tracked separately, so the effect of this fix can be measured rather than assumed.