### PR TITLE
chore(lexicons): bump @atproto/lex to 0.3.2

### DIFF
--- a/generator/package-lock.json
+++ b/generator/package-lock.json
@@ -8,19 +8,19 @@
       "name": "kikinlex-atproto-generator-lexicons",
       "version": "0.0.0",
       "dependencies": {
-        "@atproto/lex": "0.3.0"
+        "@atproto/lex": "0.3.2"
       }
     },
     "node_modules/@atproto-labs/did-resolver": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@atproto-labs/did-resolver/-/did-resolver-0.3.5.tgz",
-      "integrity": "sha512-0dMM+hj40VQiD/EJhlC1UMQgPXRwKeqM7NgJte7fVuYMv5b3P0W6+Lu3iDumHULcSjMmMXxJZzoi3i493Y0gCA==",
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@atproto-labs/did-resolver/-/did-resolver-0.3.6.tgz",
+      "integrity": "sha512-5Bb3xfDgOw4r+AjAVuZvk7lWQlUkq7dxJoRMHI46UTLEt99CQGqvKOBbA0xAXehYc76LJyaG9fulVQuWmVuqUA==",
       "license": "MIT",
       "dependencies": {
-        "@atproto-labs/fetch": "^0.3.4",
+        "@atproto-labs/fetch": "^0.3.5",
         "@atproto-labs/pipe": "^0.2.4",
-        "@atproto-labs/simple-store": "^0.4.4",
-        "@atproto-labs/simple-store-memory": "^0.2.4",
+        "@atproto-labs/simple-store": "^0.5.0",
+        "@atproto-labs/simple-store-memory": "^0.2.5",
         "@atproto/did": "^0.5.4",
         "zod": "^3.23.8"
       },
@@ -29,9 +29,9 @@
       }
     },
     "node_modules/@atproto-labs/fetch": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@atproto-labs/fetch/-/fetch-0.3.4.tgz",
-      "integrity": "sha512-YxXwi8HMk2HHDd5rljPGqxZ8bSeU78sFNz511Y222D0FraEq98p2r1ifkIgI23KQOfy0k0VzafeJAiGDh1CvfQ==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@atproto-labs/fetch/-/fetch-0.3.5.tgz",
+      "integrity": "sha512-iDFZEoNqfL17EVKE+uNzdUD7YF8LWhEhxeBtP6x+PNuAxoXv3ip9vLmB8nNzNxFwVn++FipfDtSiPqmziv1bdA==",
       "license": "MIT",
       "dependencies": {
         "@atproto-labs/pipe": "^0.2.4"
@@ -50,21 +50,21 @@
       }
     },
     "node_modules/@atproto-labs/simple-store": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@atproto-labs/simple-store/-/simple-store-0.4.4.tgz",
-      "integrity": "sha512-3YH03xg99ZUS6Fq/6jcKRiZwUbzDb58xmS7ibg0y4+dukwrHa92cV/md76RpQJkAo9KYBvwLETdvF6fNtwIoGw==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@atproto-labs/simple-store/-/simple-store-0.5.0.tgz",
+      "integrity": "sha512-tA/BmCahnrLV+seUZzjkC1xVZQbjogiooQ5C4kkC6we2mP68v7SreQTuv/XPhK2wsSES6c1SYCgDkkLlDTzALA==",
       "license": "MIT",
       "engines": {
         "node": ">=22"
       }
     },
     "node_modules/@atproto-labs/simple-store-memory": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@atproto-labs/simple-store-memory/-/simple-store-memory-0.2.4.tgz",
-      "integrity": "sha512-xAAUlOP9etqP9GGmJPq9gY1bRuJlZFdsC6wtAJSwUwMTwLRdenR7s8Qg5nxhbth5XL1XOtGABoD59NW3p+sl4A==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@atproto-labs/simple-store-memory/-/simple-store-memory-0.2.5.tgz",
+      "integrity": "sha512-Qme5VqkHKZA0w218/3pncvT+KYQzVdtP4aF72eCswh53SLrdGCG6F/NtllmJuYmp9uPGnHdql/Yt0BY1slAKjQ==",
       "license": "MIT",
       "dependencies": {
-        "@atproto-labs/simple-store": "^0.4.4",
+        "@atproto-labs/simple-store": "^0.5.0",
         "lru-cache": "^10.2.0"
       },
       "engines": {
@@ -72,14 +72,14 @@
       }
     },
     "node_modules/@atproto/common": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@atproto/common/-/common-0.7.2.tgz",
-      "integrity": "sha512-D43QVEnSgWhzEoelJTWouPrwdjfHPAe5xVEc5RtsA6OTKEPaEJN0LSFd495ZtanMrvvC+KrgW8Tk02C8kvp45A==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@atproto/common/-/common-0.7.3.tgz",
+      "integrity": "sha512-pmu+B6n83exJDJSCXazVVOpk+RuXsMK8VxKUnkiSXHP03+nRDDeNXaWEp1COBBU2dfAzYZZB6k4M8G3gq3zkcQ==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/common-web": "^0.5.6",
-        "@atproto/lex-cbor": "^0.1.4",
-        "@atproto/lex-data": "^0.1.5",
+        "@atproto/common-web": "^0.5.7",
+        "@atproto/lex-cbor": "^0.1.5",
+        "@atproto/lex-data": "^0.1.6",
         "multiformats": "^13.0.0",
         "pino": "^10.3.1"
       },
@@ -88,13 +88,13 @@
       }
     },
     "node_modules/@atproto/common-web": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/@atproto/common-web/-/common-web-0.5.6.tgz",
-      "integrity": "sha512-5Y4MIK9dpkJPiKiE6u7iEHitxj+g3aAU2GfGL686JlKE2zDKD4y18BJb+uVek6nXQKb5XOdNVvw+7BHarpn8Fw==",
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/@atproto/common-web/-/common-web-0.5.7.tgz",
+      "integrity": "sha512-lvU8lFO5UByacsl3AReXkpTWjcPBS8mBqt40B45HwCt+s58a+xT/YI/+AUpmzSmsPVZCpeCmP6wgsOSC8RILXg==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/lex-data": "^0.1.5",
-        "@atproto/lex-json": "^0.1.4",
+        "@atproto/lex-data": "^0.1.6",
+        "@atproto/lex-json": "^0.1.5",
         "@atproto/syntax": "^0.7.2",
         "zod": "^3.23.8"
       },
@@ -129,17 +129,17 @@
       }
     },
     "node_modules/@atproto/lex": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@atproto/lex/-/lex-0.3.0.tgz",
-      "integrity": "sha512-Ir5f60NrCScDMZ2JGoxUHOQm+h6XlsDSykk0HzET8/qEeHTLwnI+MJIlBwB64eBoqGQ72qAEoMc8L+bJil+huA==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@atproto/lex/-/lex-0.3.2.tgz",
+      "integrity": "sha512-/HcdVoq2BtkHxdWRo3vCciT6Cge9LfHVYtatnBrGlgHw6LYvjG2LHxmquhfPj26mKa3n2zVM8+3ia9RpoemSxw==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/lex-builder": "^0.1.8",
-        "@atproto/lex-client": "^0.3.0",
-        "@atproto/lex-data": "^0.1.5",
-        "@atproto/lex-installer": "^0.1.9",
-        "@atproto/lex-json": "^0.1.4",
-        "@atproto/lex-schema": "^0.2.2",
+        "@atproto/lex-builder": "^0.1.9",
+        "@atproto/lex-client": "^0.3.1",
+        "@atproto/lex-data": "^0.1.6",
+        "@atproto/lex-installer": "^0.1.11",
+        "@atproto/lex-json": "^0.1.5",
+        "@atproto/lex-schema": "^0.2.3",
         "tslib": "^2.8.1",
         "yargs": "^18.0.0"
       },
@@ -152,13 +152,13 @@
       }
     },
     "node_modules/@atproto/lex-builder": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/@atproto/lex-builder/-/lex-builder-0.1.8.tgz",
-      "integrity": "sha512-GYWisNom/J1MmFeSgMIFUgEj8yVKnvuJfyX1FwNKCczwfAunEdMy2Iiolq3JZNjWmH8uCtCWj7dg2GwQuEos7Q==",
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/@atproto/lex-builder/-/lex-builder-0.1.9.tgz",
+      "integrity": "sha512-NfvrxND66jibS9BDRCaKFVjubeaCenVz0j++yFGv10L+POu1XU6cc4naIjnLg9uvZrB4GXG8fvZJpyvfNghn0A==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/lex-document": "^0.1.6",
-        "@atproto/lex-schema": "^0.2.2",
+        "@atproto/lex-document": "^0.1.7",
+        "@atproto/lex-schema": "^0.2.3",
         "prettier": "^3.2.5",
         "ts-morph": "^27.0.0",
         "tslib": "^2.8.1"
@@ -168,12 +168,12 @@
       }
     },
     "node_modules/@atproto/lex-cbor": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@atproto/lex-cbor/-/lex-cbor-0.1.4.tgz",
-      "integrity": "sha512-1reaooZfNFunJn2Fz21Up7iFQBPZlifQKlBsRvQoLG67mv43nmH4dZWgnGLD54ShCu8dyZ8Y6Wgh7BCg+2gRSw==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@atproto/lex-cbor/-/lex-cbor-0.1.5.tgz",
+      "integrity": "sha512-JKDVu1/+QrRXy+cM72Ze7N7N3GUxhs3+wmwf3DyRQbDO0bdseC8mvZ9TYXhthM1Y92+pnCHIPci41etx8wz75Q==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/lex-data": "^0.1.5",
+        "@atproto/lex-data": "^0.1.6",
         "cborg": "^4.5.8",
         "tslib": "^2.8.1"
       },
@@ -182,14 +182,14 @@
       }
     },
     "node_modules/@atproto/lex-client": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@atproto/lex-client/-/lex-client-0.3.0.tgz",
-      "integrity": "sha512-P+S3hWdIIOgNTun7J42dvxSyCkQog3Q2ShTjvcwP761TqiRex7zDWaRAaT9gvCy6I4pRuNdBCStysjSMlJeSdg==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@atproto/lex-client/-/lex-client-0.3.1.tgz",
+      "integrity": "sha512-GK5rhqOtIhzxd2BEByQTs1/K7u1QJ+0NkkksV94HgrTAHG+0S3DBg5P5+RPQu2uhHIDKFzXFhP5L+fFJubX4GQ==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/lex-data": "^0.1.5",
-        "@atproto/lex-json": "^0.1.4",
-        "@atproto/lex-schema": "^0.2.2",
+        "@atproto/lex-data": "^0.1.6",
+        "@atproto/lex-json": "^0.1.5",
+        "@atproto/lex-schema": "^0.2.3",
         "tslib": "^2.8.1"
       },
       "engines": {
@@ -197,9 +197,9 @@
       }
     },
     "node_modules/@atproto/lex-data": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/@atproto/lex-data/-/lex-data-0.1.5.tgz",
-      "integrity": "sha512-TEM6GHuYpNm4O90LjNgbYq1Gmcr875S+BHrDxkg4PB5w/nlsz4HlbkGQG/WP/xbIV5O8TF5nNHDpCZ5ezTRrFA==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@atproto/lex-data/-/lex-data-0.1.6.tgz",
+      "integrity": "sha512-rvovRrYWDEuerX+ZeQbdI5dKs0bYvuMjhwDOtT+pkOvdY4MkfN41DJCz/RAYVAQ7noPdaalB6pAX9euukheE/w==",
       "license": "MIT",
       "dependencies": {
         "multiformats": "^13.0.0",
@@ -211,12 +211,12 @@
       }
     },
     "node_modules/@atproto/lex-document": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/@atproto/lex-document/-/lex-document-0.1.6.tgz",
-      "integrity": "sha512-Yxc6LJ8tE0cntQ35ewagGbl7HOMX4jRkuEQ3ct+I43LKJBQPSk02rlwTY9A7SR/ULptN4Dn7XVqskEntWmCjWA==",
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@atproto/lex-document/-/lex-document-0.1.7.tgz",
+      "integrity": "sha512-DcJagPJpjg3MTPhpDQRkjJDmSDPZy4F9MRftsni757qLZ1NCE5dYjfg9XX6DPya6/JvscAV7qga/CJrHeUFyiw==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/lex-schema": "^0.2.2",
+        "@atproto/lex-schema": "^0.2.3",
         "core-js": "^3",
         "tslib": "^2.8.1"
       },
@@ -225,17 +225,17 @@
       }
     },
     "node_modules/@atproto/lex-installer": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/@atproto/lex-installer/-/lex-installer-0.1.9.tgz",
-      "integrity": "sha512-9PdApXnwtBRGty0muK/t5CUHv18nBtkut5Q5ibDcBhYKrsVmBAVNCXLqMreC2kbZf3q5L4+IfqtqMejmAZw2Mg==",
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/@atproto/lex-installer/-/lex-installer-0.1.11.tgz",
+      "integrity": "sha512-7sH0GcRKneaR7GBdgkM/f59huz2jebTrsfgQ50RonfZKPqfO/6uNwIjsJb8r6BjSxM7I7Os2z6LWdPVMYyoYDg==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/lex-builder": "^0.1.8",
-        "@atproto/lex-cbor": "^0.1.4",
-        "@atproto/lex-data": "^0.1.5",
-        "@atproto/lex-document": "^0.1.6",
-        "@atproto/lex-resolver": "^0.2.2",
-        "@atproto/lex-schema": "^0.2.2",
+        "@atproto/lex-builder": "^0.1.9",
+        "@atproto/lex-cbor": "^0.1.5",
+        "@atproto/lex-data": "^0.1.6",
+        "@atproto/lex-document": "^0.1.7",
+        "@atproto/lex-resolver": "^0.2.4",
+        "@atproto/lex-schema": "^0.2.3",
         "@atproto/syntax": "^0.7.2",
         "tslib": "^2.8.1"
       },
@@ -244,12 +244,12 @@
       }
     },
     "node_modules/@atproto/lex-json": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@atproto/lex-json/-/lex-json-0.1.4.tgz",
-      "integrity": "sha512-ENR2cWkVrES+UL6TovbCRdX9BJOyHHJUS8jYx3Lxp3j4vEphjn/u+DW7bWloST2O8ID2OuVlt6+28ftNEEjmQQ==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@atproto/lex-json/-/lex-json-0.1.5.tgz",
+      "integrity": "sha512-qOp6+Za5p/xDXACYIP3vySbKaf9CJDwiZEN78ghPT1gRoJohKG3ONt/WmvOxBVJqc6VTRaqEpbG9vX9oLF2qsA==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/lex-data": "^0.1.5",
+        "@atproto/lex-data": "^0.1.6",
         "tslib": "^2.8.1"
       },
       "engines": {
@@ -257,18 +257,18 @@
       }
     },
     "node_modules/@atproto/lex-resolver": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@atproto/lex-resolver/-/lex-resolver-0.2.2.tgz",
-      "integrity": "sha512-/7rm1bq2me4ptNoPWOrWmlmzRSPhxbcm3BaeD0V8+OzJ5VKBrYHxqp8BBZTzqgVSmwF+TqANctUG4c/y0hkigw==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@atproto/lex-resolver/-/lex-resolver-0.2.4.tgz",
+      "integrity": "sha512-S7lxWp8CT5Par3eTq+VUXVpu6W5zHarq9oKZ6UneN0925Ey6juJ/kZI0jucxIpV/DXM+EF3GntOMbackFPxieg==",
       "license": "MIT",
       "dependencies": {
-        "@atproto-labs/did-resolver": "^0.3.5",
+        "@atproto-labs/did-resolver": "^0.3.6",
         "@atproto/crypto": "^0.5.4",
-        "@atproto/lex-client": "^0.3.0",
-        "@atproto/lex-data": "^0.1.5",
-        "@atproto/lex-document": "^0.1.6",
-        "@atproto/lex-schema": "^0.2.2",
-        "@atproto/repo": "^0.10.6",
+        "@atproto/lex-client": "^0.3.1",
+        "@atproto/lex-data": "^0.1.6",
+        "@atproto/lex-document": "^0.1.7",
+        "@atproto/lex-schema": "^0.2.3",
+        "@atproto/repo": "^0.10.7",
         "@atproto/syntax": "^0.7.2",
         "tslib": "^2.8.1"
       },
@@ -277,12 +277,12 @@
       }
     },
     "node_modules/@atproto/lex-schema": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@atproto/lex-schema/-/lex-schema-0.2.2.tgz",
-      "integrity": "sha512-UFK0EH8pw31dvL27aoZ5K78z+UMiD3ybIgkCyd7Idm267KM1IpycerTDeABqo4CYP3/IAnzjGpQaUaVc12bELA==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@atproto/lex-schema/-/lex-schema-0.2.3.tgz",
+      "integrity": "sha512-218xvlL7EdEdREY7ieAhaVPnBeGAf5h3tNkzE+X1Ob4tFLrWwA1sOQqliIURG9owE8v0ctqf9Uftx15eN0U0qQ==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/lex-data": "^0.1.5",
+        "@atproto/lex-data": "^0.1.6",
         "@atproto/syntax": "^0.7.2",
         "@standard-schema/spec": "^1.1.0",
         "tslib": "^2.8.1"
@@ -292,16 +292,16 @@
       }
     },
     "node_modules/@atproto/repo": {
-      "version": "0.10.6",
-      "resolved": "https://registry.npmjs.org/@atproto/repo/-/repo-0.10.6.tgz",
-      "integrity": "sha512-ayX/ieAni4ZMbpdu6VMOCYIjzT8HctCQtcSBWWR8eoynsGZ6FzK/Lln6bH8i0wAj8vPV2pcecd57d33YsahRcQ==",
+      "version": "0.10.7",
+      "resolved": "https://registry.npmjs.org/@atproto/repo/-/repo-0.10.7.tgz",
+      "integrity": "sha512-nMV3y4d/KERrt9VOe3hcKyl/FVQeo6+54YKCt6bLiMLl8CPEtjwdVGwWlSkekaCoayjL0rTQ4zvjmKs+vCA1Ew==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/common": "^0.7.2",
-        "@atproto/common-web": "^0.5.6",
+        "@atproto/common": "^0.7.3",
+        "@atproto/common-web": "^0.5.7",
         "@atproto/crypto": "^0.5.4",
-        "@atproto/lex-cbor": "^0.1.4",
-        "@atproto/lex-data": "^0.1.5",
+        "@atproto/lex-cbor": "^0.1.5",
+        "@atproto/lex-data": "^0.1.6",
         "@atproto/syntax": "^0.7.2",
         "varint": "^6.0.0",
         "zod": "^3.23.8"
@@ -416,9 +416,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -533,12 +533,12 @@
       "license": "ISC"
     },
     "node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.5"
+        "brace-expansion": "^5.0.8"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -618,9 +618,9 @@
       "license": "MIT"
     },
     "node_modules/prettier": {
-      "version": "3.9.5",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.5.tgz",
-      "integrity": "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg==",
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+      "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
       "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"
@@ -633,9 +633,9 @@
       }
     },
     "node_modules/process-warning": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
-      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.1.0.tgz",
+      "integrity": "sha512-jQSaVHsPgtyw60e1rQ/A+/ArPEj/S8pS/vFnyGa/gYFXrKk/6RuDkoqVDQ5NI5MmS01698ltlAk0NoDBNLujRw==",
       "funding": [
         {
           "type": "github",

--- a/generator/package.json
+++ b/generator/package.json
@@ -4,6 +4,6 @@
   "private": true,
   "description": "Pins the @atproto/lex release whose lexicon JSON is consumed by :generator. Not published.",
   "dependencies": {
-    "@atproto/lex": "0.3.0"
+    "@atproto/lex": "0.3.2"
   }
 }


### PR DESCRIPTION
## Lexicon corpus update

Bumps `@atproto/lex` from `0.3.0` to `0.3.2`.

### lexicons.json changes

**Added** (0):
- _(none)_

**Removed** (0):
- _(none)_

**Updated** (0):
- _(none)_

### What reviewers should check

- [ ] CI passes (generator regeneration, runtime tests, sample APK build)
- [ ] Skim the generator golden-file diff if any generator logic was affected
- [ ] Verify no new lexicon references are missing Kotlin types (compile failure in `:models`)

### Release impact

If this PR merges with only additive changes (new types, new fields), expect a `feat:` release. If it removes or renames anything, expect a `BREAKING CHANGE:` release — update the PR title to `feat!: bump @atproto/lex to <version>` before merging.