### PR TITLE
feat(oauth): let a login survive process death during the browser roundtrip

### DIFF
--- a/oauth/README.md
+++ b/oauth/README.md
@@ -144,6 +144,51 @@ interface OAuthSessionStore {
 On Android, use `EncryptedSharedPreferences` to protect the DPoP keypair and
 tokens at rest. See the sample app for a complete implementation.
 
+## Pending-login persistence (Android: required)
+
+The authorization step happens in a **different process** — a browser or Custom
+Tab. Android is free to kill your app while the user is on the authorization
+page, and on memory-constrained devices it routinely does.
+
+`AtOAuth` keeps the in-flight PKCE verifier and CSRF `state` in a
+`PendingAuthStore`. The default is **in-memory**, which cannot survive that
+kill: the callback returns to a fresh process, `completeLogin` throws
+`No pending login — call beginLogin or beginSignup first`, and the user is stuck
+behind an error that retrying cannot clear.
+
+Supply a durable, encrypted store on Android:
+
+```kotlin
+interface PendingAuthStore {
+    suspend fun load(): PendingAuth?
+    suspend fun save(pending: PendingAuth)
+    suspend fun clear()
+}
+
+AtOAuth(
+    clientMetadataUrl = "...",
+    redirectUri = "...",
+    sessionStore = sessionStore,
+    httpClient = httpClient,
+    pendingStore = MyEncryptedPendingAuthStore(), // <- do this on Android
+)
+```
+
+`PendingAuth` briefly holds a PKCE verifier and a DPoP private key, so encrypt it
+at rest exactly as you do the session — reuse the same backing store under a
+separate key. Records older than `AtOAuth.PENDING_AUTH_TTL_MILLIS` (15 minutes)
+are discarded on read, since the authorization code has expired server-side long
+before that.
+
+To verify your implementation, kill the process mid-flow and confirm the callback
+still completes:
+
+```bash
+# with the Custom Tab in the foreground
+adb shell am kill your.package.name
+# then let the redirect come back
+```
+
 ## Security considerations
 
 - **DPoP (RFC 9449)**: Every request carries a proof-of-possession JWT signed

--- a/oauth/api/oauth.api
+++ b/oauth/api/oauth.api
@@ -1,12 +1,17 @@
 public final class io/github/kikin81/atproto/oauth/AtOAuth {
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lio/github/kikin81/atproto/oauth/OAuthSessionStore;Lio/ktor/client/HttpClient;Lkotlinx/serialization/json/Json;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lio/github/kikin81/atproto/oauth/OAuthSessionStore;Lio/ktor/client/HttpClient;Lkotlinx/serialization/json/Json;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final field Companion Lio/github/kikin81/atproto/oauth/AtOAuth$Companion;
+	public static final field PENDING_AUTH_TTL_MILLIS J
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lio/github/kikin81/atproto/oauth/OAuthSessionStore;Lio/ktor/client/HttpClient;Lkotlinx/serialization/json/Json;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lio/github/kikin81/atproto/oauth/PendingAuthStore;Lkotlin/jvm/functions/Function0;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lio/github/kikin81/atproto/oauth/OAuthSessionStore;Lio/ktor/client/HttpClient;Lkotlinx/serialization/json/Json;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lio/github/kikin81/atproto/oauth/PendingAuthStore;Lkotlin/jvm/functions/Function0;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun beginLogin (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun beginSignup (Ljava/lang/String;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun beginSignup$default (Lio/github/kikin81/atproto/oauth/AtOAuth;Ljava/lang/String;ZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun completeLogin (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun createClient (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun logout (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class io/github/kikin81/atproto/oauth/AtOAuth$Companion {
 }
 
 public final class io/github/kikin81/atproto/oauth/AuthServerMetadata {
@@ -82,6 +87,13 @@ public final class io/github/kikin81/atproto/oauth/DpopSigner$ExportedKeyPair {
 	public final fun getPublicKeyEncoded ()[B
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/kikin81/atproto/oauth/InMemoryPendingAuthStore : io/github/kikin81/atproto/oauth/PendingAuthStore {
+	public fun <init> ()V
+	public fun clear (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun load (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun save (Lio/github/kikin81/atproto/oauth/PendingAuth;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class io/github/kikin81/atproto/oauth/OAuthAccountMismatchException : java/lang/RuntimeException {
@@ -170,5 +182,71 @@ public final class io/github/kikin81/atproto/oauth/OAuthSignupNotSupportedExcept
 	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
 	public final fun getAdvertisedPromptValues ()Ljava/util/List;
 	public final fun getAuthServerUrl ()Ljava/lang/String;
+}
+
+public final class io/github/kikin81/atproto/oauth/PendingAuth {
+	public static final field Companion Lio/github/kikin81/atproto/oauth/PendingAuth$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;[B[BLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;J)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;[B[BLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;JILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Ljava/lang/String;
+	public final fun component11 ()Ljava/lang/String;
+	public final fun component12 ()Ljava/lang/String;
+	public final fun component13 ()Ljava/lang/String;
+	public final fun component14 ()Ljava/lang/String;
+	public final fun component15 ()Ljava/lang/String;
+	public final fun component16 ()Ljava/util/List;
+	public final fun component17 ()J
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()[B
+	public final fun component7 ()[B
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;[B[BLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;J)Lio/github/kikin81/atproto/oauth/PendingAuth;
+	public static synthetic fun copy$default (Lio/github/kikin81/atproto/oauth/PendingAuth;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;[B[BLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;JILjava/lang/Object;)Lio/github/kikin81/atproto/oauth/PendingAuth;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAuthServerNonce ()Ljava/lang/String;
+	public final fun getAuthorizationEndpoint ()Ljava/lang/String;
+	public final fun getCodeVerifier ()Ljava/lang/String;
+	public final fun getCreatedAtEpochMillis ()J
+	public final fun getDid ()Ljava/lang/String;
+	public final fun getDpopPrivateKey ()[B
+	public final fun getDpopPublicKey ()[B
+	public final fun getFlowOrigin ()Ljava/lang/String;
+	public final fun getHandle ()Ljava/lang/String;
+	public final fun getIssuer ()Ljava/lang/String;
+	public final fun getParEndpoint ()Ljava/lang/String;
+	public final fun getPdsUrl ()Ljava/lang/String;
+	public final fun getPromptValuesSupported ()Ljava/util/List;
+	public final fun getRedirectUri ()Ljava/lang/String;
+	public final fun getRevocationEndpoint ()Ljava/lang/String;
+	public final fun getState ()Ljava/lang/String;
+	public final fun getTokenEndpoint ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/kikin81/atproto/oauth/PendingAuth$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/kikin81/atproto/oauth/PendingAuth$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/kikin81/atproto/oauth/PendingAuth;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/kikin81/atproto/oauth/PendingAuth;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/kikin81/atproto/oauth/PendingAuth$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class io/github/kikin81/atproto/oauth/PendingAuthStore {
+	public abstract fun clear (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun load (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun save (Lio/github/kikin81/atproto/oauth/PendingAuth;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 

--- a/oauth/src/main/kotlin/io/github/kikin81/atproto/oauth/AtOAuth.kt
+++ b/oauth/src/main/kotlin/io/github/kikin81/atproto/oauth/AtOAuth.kt
@@ -599,7 +599,13 @@ class AtOAuth(
         codeVerifier = codeVerifier,
         state = state,
         redirectUri = redirectUri,
-        flowOrigin = FlowOrigin.valueOf(flowOrigin),
+        // Not valueOf directly: this record round-trips through disk and can
+        // outlive an app update mid-roundtrip, so a value written by a
+        // different library version is reachable. Surface that as the SDK's
+        // own error type rather than letting a raw IllegalArgumentException
+        // escape past callers' OAuthException handling.
+        flowOrigin = FlowOrigin.entries.firstOrNull { it.name == flowOrigin }
+            ?: throw OAuthException("Unrecognized pending-login flow origin '$flowOrigin' — start the login again"),
         authServerNonce = authServerNonce,
     )
 

--- a/oauth/src/main/kotlin/io/github/kikin81/atproto/oauth/AtOAuth.kt
+++ b/oauth/src/main/kotlin/io/github/kikin81/atproto/oauth/AtOAuth.kt
@@ -80,9 +80,20 @@ class AtOAuth(
      * [DpopAuthProvider]'s `onPersistFailure` for the durability implications.
      */
     private val onSessionPersistFailure: (Throwable) -> Unit = {},
+    /**
+     * Where the in-flight login lives between `beginLogin` / `beginSignup` and
+     * [completeLogin].
+     *
+     * Defaults to memory, preserving this module's historical behaviour.
+     * **Android consumers should supply a durable, encrypted store**: the
+     * authorization step runs in a browser, and an OS kill during it otherwise
+     * strands the login permanently — the callback returns to a process that
+     * has no record of it. See [PendingAuthStore].
+     */
+    private val pendingStore: PendingAuthStore = InMemoryPendingAuthStore(),
+    /** Injection seam for [PENDING_AUTH_TTL_MILLIS] expiry; overridden in tests. */
+    private val nowMillis: () -> Long = { System.currentTimeMillis() },
 ) {
-    // Transient state during the login/signup flow (between beginX and completeLogin)
-    private var pendingState: PendingAuthState? = null
 
     /**
      * Starts the OAuth login flow.
@@ -171,14 +182,30 @@ class AtOAuth(
             prompt = prompt,
         )
 
-        pendingState = PendingAuthState(
-            metadata = metadata,
-            signer = signer,
-            codeVerifier = codeVerifier,
-            state = state,
-            redirectUri = redirectUri,
-            flowOrigin = flowOrigin,
-            authServerNonce = parResult.dpopNonce,
+        // Persisted BEFORE the caller gets the URL to open: once the browser is
+        // foregrounded this process may be killed at any moment, and anything
+        // written after that point is a race we would lose.
+        val exported = signer.exportKeyPair()
+        pendingStore.save(
+            PendingAuth(
+                state = state,
+                codeVerifier = codeVerifier,
+                redirectUri = redirectUri,
+                flowOrigin = flowOrigin.name,
+                authServerNonce = parResult.dpopNonce,
+                dpopPrivateKey = exported.privateKeyEncoded,
+                dpopPublicKey = exported.publicKeyEncoded,
+                issuer = metadata.issuer,
+                authorizationEndpoint = metadata.authorizationEndpoint,
+                tokenEndpoint = metadata.tokenEndpoint,
+                parEndpoint = metadata.parEndpoint,
+                revocationEndpoint = metadata.revocationEndpoint,
+                pdsUrl = metadata.pdsUrl,
+                did = metadata.did,
+                handle = metadata.handle,
+                promptValuesSupported = metadata.promptValuesSupported,
+                createdAtEpochMillis = nowMillis(),
+            ),
         )
 
         return "${metadata.authorizationEndpoint}?client_id=$clientMetadataUrl&request_uri=${parResult.requestUri}"
@@ -200,8 +227,25 @@ class AtOAuth(
      *   (e.g. `myapp://oauth/callback?code=...&state=...&iss=...`).
      */
     suspend fun completeLogin(redirectUri: String) {
-        val pending = pendingState ?: throw OAuthException("No pending login — call beginLogin or beginSignup first")
-        pendingState = null
+        val stored = pendingStore.load()
+            ?: throw OAuthException("No pending login — call beginLogin or beginSignup first")
+        // Consume before validating: the record is single-use, and clearing it
+        // up front means a malformed or replayed callback cannot be retried
+        // against the same PKCE verifier. Matches the pre-persistence behaviour.
+        pendingStore.clear()
+
+        // A persisted record outlives the process, so it can also outlive the
+        // authorization code's server-side lifetime. Past the TTL there is
+        // nothing to complete — fail with a distinguishable message rather than
+        // letting the token endpoint reject it as an opaque invalid_grant.
+        val age = nowMillis() - stored.createdAtEpochMillis
+        if (age > PENDING_AUTH_TTL_MILLIS) {
+            throw OAuthException(
+                "Pending login expired after ${age}ms (limit ${PENDING_AUTH_TTL_MILLIS}ms) — start the login again",
+            )
+        }
+
+        val pending = stored.toPendingAuthState()
 
         val params = parseRedirectParams(redirectUri)
         val code = params["code"] ?: throw OAuthException("Missing 'code' in redirect URI")
@@ -527,6 +571,48 @@ class AtOAuth(
                     param.substring(0, eq) to java.net.URLDecoder.decode(param.substring(eq + 1), "UTF-8")
                 }
             }
+    }
+
+    /**
+     * Rehydrate the in-memory working shape from its persisted form. The DPoP
+     * keypair round-trips through PKCS8/X509 encoding, the same path
+     * [OAuthSession] uses.
+     */
+    private fun PendingAuth.toPendingAuthState(): PendingAuthState = PendingAuthState(
+        metadata = AuthServerMetadata(
+            issuer = issuer,
+            authorizationEndpoint = authorizationEndpoint,
+            tokenEndpoint = tokenEndpoint,
+            parEndpoint = parEndpoint,
+            revocationEndpoint = revocationEndpoint,
+            pdsUrl = pdsUrl,
+            did = did,
+            handle = handle,
+            promptValuesSupported = promptValuesSupported,
+        ),
+        signer = DpopSigner.fromExported(
+            DpopSigner.ExportedKeyPair(
+                privateKeyEncoded = dpopPrivateKey,
+                publicKeyEncoded = dpopPublicKey,
+            ),
+        ),
+        codeVerifier = codeVerifier,
+        state = state,
+        redirectUri = redirectUri,
+        flowOrigin = FlowOrigin.valueOf(flowOrigin),
+        authServerNonce = authServerNonce,
+    )
+
+    companion object {
+        /**
+         * How long a persisted pending login stays completable.
+         *
+         * Bounded by the authorization code's own server-side lifetime (minutes
+         * in practice), with generous headroom for a slow password entry on a
+         * third-party PDS. Past this, the record is dead weight and its PKCE
+         * verifier + DPoP private key are needless exposure at rest.
+         */
+        const val PENDING_AUTH_TTL_MILLIS: Long = 15 * 60 * 1000L
     }
 
     internal enum class FlowOrigin { Login, Signup }

--- a/oauth/src/main/kotlin/io/github/kikin81/atproto/oauth/PendingAuth.kt
+++ b/oauth/src/main/kotlin/io/github/kikin81/atproto/oauth/PendingAuth.kt
@@ -1,0 +1,110 @@
+package io.github.kikin81.atproto.oauth
+
+import kotlinx.serialization.Serializable
+
+/**
+ * The in-flight half of an OAuth login, captured between `beginLogin` /
+ * `beginSignup` and [AtOAuth.completeLogin].
+ *
+ * This exists as a persistable type because the authorization step happens
+ * in a **different process** — a browser or Custom Tab. On Android the OS
+ * is free to kill the app while the user is typing a password on the
+ * authorization page, and it routinely does on low-memory devices. If the
+ * PKCE verifier and CSRF `state` only lived in memory, that kill would
+ * strand the login permanently: the callback returns to a fresh process
+ * that has no idea a login was ever started, and the user sees an error no
+ * amount of retrying can clear.
+ *
+ * The DPoP keypair is serialized as raw byte arrays (PKCS8 private key +
+ * X509 public key), exactly as [OAuthSession] does. The consumer's
+ * [PendingAuthStore] implementation is responsible for encrypting these at
+ * rest — this record briefly holds key material and a PKCE verifier, so it
+ * deserves the same protection as a session.
+ *
+ * The auth-server metadata is flattened rather than nested so the stored
+ * shape stays a flat, forward-compatible JSON object.
+ *
+ * @property createdAtEpochMillis stamped at save time so [AtOAuth] can
+ *   discard a pending login that is older than its TTL. Authorization codes
+ *   expire server-side in minutes; a pending record that outlives that is
+ *   never going to complete, and keeping key material on disk past its
+ *   usefulness is needless exposure.
+ */
+@Serializable
+data class PendingAuth(
+    val state: String,
+    val codeVerifier: String,
+    val redirectUri: String,
+    /** Serialized [AtOAuth]'s internal `FlowOrigin` — `"Login"` or `"Signup"`. */
+    val flowOrigin: String,
+    val authServerNonce: String?,
+    val dpopPrivateKey: ByteArray,
+    val dpopPublicKey: ByteArray,
+    val issuer: String,
+    val authorizationEndpoint: String,
+    val tokenEndpoint: String,
+    val parEndpoint: String,
+    val revocationEndpoint: String? = null,
+    val pdsUrl: String? = null,
+    val did: String? = null,
+    val handle: String? = null,
+    val promptValuesSupported: List<String> = emptyList(),
+    val createdAtEpochMillis: Long = 0,
+) {
+    // ByteArray fields make the generated equals/hashCode reference-based,
+    // which silently breaks value comparison in consumer tests. `state` is a
+    // 32-byte CSPRNG value generated per flow, so it alone identifies the
+    // record. Same reasoning as OAuthSession's override.
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is PendingAuth) return false
+        return state == other.state
+    }
+
+    override fun hashCode(): Int = state.hashCode()
+}
+
+/**
+ * Platform-agnostic persistence for the in-flight login ([PendingAuth]).
+ * Consumers provide the storage backend — the module handles serialization.
+ *
+ * **Android consumers should supply a durable, encrypted implementation.**
+ * The default [InMemoryPendingAuthStore] cannot survive process death, which
+ * is precisely the case that breaks sign-in on memory-constrained devices.
+ * Reuse whatever backing store already holds the [OAuthSession] (DataStore +
+ * Tink, EncryptedSharedPreferences, …) under a separate key.
+ *
+ * Unlike [OAuthSessionStore.save], a deferred write here is merely
+ * inconvenient rather than destructive — nothing has been consumed server-side
+ * at save time. It still must be durable before the browser is launched, so
+ * prefer a synchronous commit anyway.
+ */
+interface PendingAuthStore {
+    suspend fun load(): PendingAuth?
+
+    suspend fun save(pending: PendingAuth)
+
+    suspend fun clear()
+}
+
+/**
+ * Default [PendingAuthStore]: keeps the pending login in memory only.
+ *
+ * Preserves the module's historical behaviour for consumers that have not
+ * supplied a store. Adequate for desktop/JVM and for tests; **not** adequate
+ * on Android, where a login started before a process death can never be
+ * completed. See [PendingAuthStore].
+ */
+class InMemoryPendingAuthStore : PendingAuthStore {
+    private var pending: PendingAuth? = null
+
+    override suspend fun load(): PendingAuth? = pending
+
+    override suspend fun save(pending: PendingAuth) {
+        this.pending = pending
+    }
+
+    override suspend fun clear() {
+        pending = null
+    }
+}

--- a/oauth/src/main/kotlin/io/github/kikin81/atproto/oauth/PendingAuth.kt
+++ b/oauth/src/main/kotlin/io/github/kikin81/atproto/oauth/PendingAuth.kt
@@ -51,17 +51,56 @@ data class PendingAuth(
     val promptValuesSupported: List<String> = emptyList(),
     val createdAtEpochMillis: Long = 0,
 ) {
-    // ByteArray fields make the generated equals/hashCode reference-based,
-    // which silently breaks value comparison in consumer tests. `state` is a
-    // 32-byte CSPRNG value generated per flow, so it alone identifies the
-    // record. Same reasoning as OAuthSession's override.
+    // Full structural equality, with contentEquals for the ByteArray fields
+    // (the generated equals would compare those by reference).
+    //
+    // Deliberately NOT the narrow identity comparison OAuthSession uses. The
+    // entire purpose of this type is to survive a round-trip through disk, so
+    // a round-trip test asserting equality has to actually compare what came
+    // back — under state-only equality it would pass with every other field
+    // mangled, which is the one bug this class exists to not have.
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other !is PendingAuth) return false
-        return state == other.state
+        return state == other.state &&
+            codeVerifier == other.codeVerifier &&
+            redirectUri == other.redirectUri &&
+            flowOrigin == other.flowOrigin &&
+            authServerNonce == other.authServerNonce &&
+            dpopPrivateKey.contentEquals(other.dpopPrivateKey) &&
+            dpopPublicKey.contentEquals(other.dpopPublicKey) &&
+            issuer == other.issuer &&
+            authorizationEndpoint == other.authorizationEndpoint &&
+            tokenEndpoint == other.tokenEndpoint &&
+            parEndpoint == other.parEndpoint &&
+            revocationEndpoint == other.revocationEndpoint &&
+            pdsUrl == other.pdsUrl &&
+            did == other.did &&
+            handle == other.handle &&
+            promptValuesSupported == other.promptValuesSupported &&
+            createdAtEpochMillis == other.createdAtEpochMillis
     }
 
-    override fun hashCode(): Int = state.hashCode()
+    override fun hashCode(): Int {
+        var result = state.hashCode()
+        result = 31 * result + codeVerifier.hashCode()
+        result = 31 * result + redirectUri.hashCode()
+        result = 31 * result + flowOrigin.hashCode()
+        result = 31 * result + (authServerNonce?.hashCode() ?: 0)
+        result = 31 * result + dpopPrivateKey.contentHashCode()
+        result = 31 * result + dpopPublicKey.contentHashCode()
+        result = 31 * result + issuer.hashCode()
+        result = 31 * result + authorizationEndpoint.hashCode()
+        result = 31 * result + tokenEndpoint.hashCode()
+        result = 31 * result + parEndpoint.hashCode()
+        result = 31 * result + (revocationEndpoint?.hashCode() ?: 0)
+        result = 31 * result + (pdsUrl?.hashCode() ?: 0)
+        result = 31 * result + (did?.hashCode() ?: 0)
+        result = 31 * result + (handle?.hashCode() ?: 0)
+        result = 31 * result + promptValuesSupported.hashCode()
+        result = 31 * result + createdAtEpochMillis.hashCode()
+        return result
+    }
 }
 
 /**
@@ -96,6 +135,11 @@ interface PendingAuthStore {
  * completed. See [PendingAuthStore].
  */
 class InMemoryPendingAuthStore : PendingAuthStore {
+    // @Volatile because the write (beginLogin) and the read (completeLogin)
+    // are separated by a browser roundtrip and routinely land on different
+    // dispatcher threads, with no lock or other happens-before edge between
+    // them to publish the value.
+    @Volatile
     private var pending: PendingAuth? = null
 
     override suspend fun load(): PendingAuth? = pending

--- a/oauth/src/test/kotlin/io/github/kikin81/atproto/oauth/AtOAuthTest.kt
+++ b/oauth/src/test/kotlin/io/github/kikin81/atproto/oauth/AtOAuthTest.kt
@@ -10,6 +10,7 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
 import io.ktor.http.parseQueryString
 import io.ktor.utils.io.ByteReadChannel
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
@@ -23,6 +24,7 @@ import kotlin.test.assertContains
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class AtOAuthTest {
@@ -289,6 +291,104 @@ class AtOAuthTest {
         assertTrue(session.did == "did:plc:testuser")
         assertTrue(session.handle == "alice.test")
         assertTrue(session.dpopPrivateKey.isNotEmpty())
+    }
+
+    @Test
+    fun loginSurvivesProcessDeathWhenPendingStateIsPersisted() = runTest {
+        // Pin the whole point of PendingAuthStore: the authorization step
+        // happens in a browser, and on Android the OS can kill the app while
+        // the user is on the auth page. A second AtOAuth instance sharing the
+        // store stands in for the process that comes back from that kill —
+        // it never called beginLogin, yet it must complete the callback.
+        val sessionStore = InMemorySessionStore()
+        val pendingStore = InMemoryPendingAuthStore()
+        val client = fullFlowMockClient()
+
+        val beforeDeath = AtOAuth(
+            clientMetadataUrl = "https://app.test/oauth/client-metadata.json",
+            redirectUri = "app.example:/oauth-redirect",
+            sessionStore = sessionStore,
+            httpClient = client,
+            pendingStore = pendingStore,
+        )
+        beforeDeath.beginLogin("alice.test")
+        val state = pendingStore.load()?.state
+        assertNotNull(state, "beginLogin must persist the pending login")
+
+        val afterDeath = AtOAuth(
+            clientMetadataUrl = "https://app.test/oauth/client-metadata.json",
+            redirectUri = "app.example:/oauth-redirect",
+            sessionStore = sessionStore,
+            httpClient = client,
+            pendingStore = pendingStore,
+        )
+        afterDeath.completeLogin(
+            "app.example:/oauth-redirect?code=auth_code_123&state=$state&iss=https://auth.test",
+        )
+
+        val session = sessionStore.session
+        assertNotNull(session, "the reborn process must complete the login")
+        assertEquals("did:plc:testuser", session.did)
+        assertNull(pendingStore.load(), "a consumed pending login must not linger on disk")
+    }
+
+    @Test
+    fun completeLoginRejectsPendingStateOlderThanTtl() = runTest {
+        // A persisted pending login outlives the process, so it also outlives
+        // the authorization code's server-side lifetime. Past the TTL it can
+        // never complete, and leaving a PKCE verifier + DPoP private key on
+        // disk past its usefulness is needless exposure — discard it.
+        val sessionStore = InMemorySessionStore()
+        val pendingStore = InMemoryPendingAuthStore()
+        var now = 1_000_000L
+        val oauth = AtOAuth(
+            clientMetadataUrl = "https://app.test/oauth/client-metadata.json",
+            redirectUri = "app.example:/oauth-redirect",
+            sessionStore = sessionStore,
+            httpClient = fullFlowMockClient(),
+            pendingStore = pendingStore,
+            nowMillis = { now },
+        )
+        oauth.beginLogin("alice.test")
+        val state = pendingStore.load()?.state
+        assertNotNull(state)
+
+        now += AtOAuth.PENDING_AUTH_TTL_MILLIS + 1
+
+        val failure = assertFailsWith<OAuthException> {
+            oauth.completeLogin(
+                "app.example:/oauth-redirect?code=auth_code_123&state=$state&iss=https://auth.test",
+            )
+        }
+        assertContains(failure.message ?: "", "expired")
+        assertNull(pendingStore.load(), "an expired pending login must be discarded, not left on disk")
+    }
+
+    @Test
+    fun pendingStateWithinTtlStillCompletes() = runTest {
+        // Guards the TTL check against being too aggressive: a normal browser
+        // roundtrip takes seconds-to-minutes and must not be rejected. Without
+        // this, the expiry test above would pass just as well with a TTL of 0.
+        val sessionStore = InMemorySessionStore()
+        val pendingStore = InMemoryPendingAuthStore()
+        var now = 1_000_000L
+        val oauth = AtOAuth(
+            clientMetadataUrl = "https://app.test/oauth/client-metadata.json",
+            redirectUri = "app.example:/oauth-redirect",
+            sessionStore = sessionStore,
+            httpClient = fullFlowMockClient(),
+            pendingStore = pendingStore,
+            nowMillis = { now },
+        )
+        oauth.beginLogin("alice.test")
+        val state = pendingStore.load()?.state
+
+        now += AtOAuth.PENDING_AUTH_TTL_MILLIS - 1
+
+        oauth.completeLogin(
+            "app.example:/oauth-redirect?code=auth_code_123&state=$state&iss=https://auth.test",
+        )
+        assertNotNull(sessionStore.session)
     }
 
     @Test
@@ -1133,14 +1233,16 @@ class AtOAuthTest {
     /**
      * Extracts the state from a pending AtOAuth instance via reflection.
      * Only for testing — production consumers don't access internal state.
+     *
+     * Reads through whichever [PendingAuthStore] the instance holds, so it
+     * works for tests that supply their own store and for the majority that
+     * rely on the default [InMemoryPendingAuthStore].
      */
-    private fun extractState(oauth: AtOAuth): String {
-        val field = AtOAuth::class.java.getDeclaredField("pendingState")
+    private fun extractState(oauth: AtOAuth): String = runBlocking {
+        val field = AtOAuth::class.java.getDeclaredField("pendingStore")
         field.isAccessible = true
-        val pending = field.get(oauth) ?: throw IllegalStateException("No pending state")
-        val stateField = pending::class.java.getDeclaredField("state")
-        stateField.isAccessible = true
-        return stateField.get(pending) as String
+        val store = field.get(oauth) as PendingAuthStore
+        store.load()?.state ?: throw IllegalStateException("No pending state")
     }
 
     /**

--- a/oauth/src/test/kotlin/io/github/kikin81/atproto/oauth/AtOAuthTest.kt
+++ b/oauth/src/test/kotlin/io/github/kikin81/atproto/oauth/AtOAuthTest.kt
@@ -10,7 +10,6 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
 import io.ktor.http.parseQueryString
 import io.ktor.utils.io.ByteReadChannel
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
@@ -389,6 +388,35 @@ class AtOAuthTest {
             "app.example:/oauth-redirect?code=auth_code_123&state=$state&iss=https://auth.test",
         )
         assertNotNull(sessionStore.session)
+    }
+
+    @Test
+    fun completeLoginRejectsUnrecognizedFlowOrigin() = runTest {
+        // Reachable precisely because the record now survives on disk: the app
+        // can be updated mid-roundtrip, so a value written by a different
+        // library version can come back. It must surface as this SDK's
+        // OAuthException, not a raw IllegalArgumentException that slips past
+        // callers' error handling.
+        val sessionStore = InMemorySessionStore()
+        val pendingStore = InMemoryPendingAuthStore()
+        val oauth = AtOAuth(
+            clientMetadataUrl = "https://app.test/oauth/client-metadata.json",
+            redirectUri = "app.example:/oauth-redirect",
+            sessionStore = sessionStore,
+            httpClient = fullFlowMockClient(),
+            pendingStore = pendingStore,
+        )
+        oauth.beginLogin("alice.test")
+        val stored = pendingStore.load()
+        assertNotNull(stored)
+        pendingStore.save(stored.copy(flowOrigin = "SomeFutureFlow"))
+
+        val failure = assertFailsWith<OAuthException> {
+            oauth.completeLogin(
+                "app.example:/oauth-redirect?code=auth_code_123&state=${stored.state}&iss=https://auth.test",
+            )
+        }
+        assertContains(failure.message ?: "", "SomeFutureFlow")
     }
 
     @Test
@@ -1238,11 +1266,11 @@ class AtOAuthTest {
      * works for tests that supply their own store and for the majority that
      * rely on the default [InMemoryPendingAuthStore].
      */
-    private fun extractState(oauth: AtOAuth): String = runBlocking {
+    private suspend fun extractState(oauth: AtOAuth): String {
         val field = AtOAuth::class.java.getDeclaredField("pendingStore")
         field.isAccessible = true
         val store = field.get(oauth) as PendingAuthStore
-        store.load()?.state ?: throw IllegalStateException("No pending state")
+        return store.load()?.state ?: throw IllegalStateException("No pending state")
     }
 
     /**


### PR DESCRIPTION
## What

`AtOAuth` kept the in-flight PKCE verifier and CSRF `state` in a private field. The authorization step runs in a **different process** — a browser or Custom Tab — and Android is free to kill the app while the user is on the authorization page. The callback then returns to a fresh process and `completeLogin` throws:

```
OAuthException: No pending login — call beginLogin or beginSignup first
    at AtOAuth.completeLogin(AtOAuth.kt:203)
```

The login is unrecoverable, and retrying just repeats it while the memory pressure persists.

This moves that state behind a `PendingAuthStore` seam, mirroring `OAuthSessionStore`:

- `PendingAuth` is `@Serializable` and carries the DPoP keypair as PKCS8/X509 bytes, exactly as `OAuthSession` does, so consumers encrypt it at rest with machinery they already have.
- The default `InMemoryPendingAuthStore` preserves today's behaviour — existing callers compile and behave unchanged (the sample app builds untouched).
- Android consumers opt into durability by passing their own store.

## Why this isn't hypothetical

Reproduced on a 2 GB AVD with the app cached at `oom_adj 700` behind the Custom Tab, killed by the OS rather than by adb:

```
I/lowmemorykiller: Kill 'net.kikin.nubecita' (7802), uid 10166, oom_adj 700 to free 71688kB;
                   reason: low watermark is breached and thrashing (6038%)
```

It is also live in production: 9 events / 2 users in Crashlytics, all `login_stage: complete`. The reporting user is on a third-party PDS, so signing in means a full web password form rather than a cached bounce — a long dwell in the browser with the app merely cached.

## Details

- **Persist before returning the authorization URL.** Once the browser is foregrounded, anything written later is a race we lose.
- **Consume before validating**, as before: the record is single-use, so a replayed callback can't be retried against the same verifier.
- **TTL of 15 min** (`AtOAuth.PENDING_AUTH_TTL_MILLIS`). A persisted record outlives the process and therefore outlives the authorization code; past that it can never complete, and a PKCE verifier + DPoP private key shouldn't sit on disk past their usefulness. Expiry throws a distinguishable message rather than letting the token endpoint return an opaque `invalid_grant`.

## Tests

Three new cases in `AtOAuthTest`, all of which fail without the change:

- `loginSurvivesProcessDeathWhenPendingStateIsPersisted` — a **second `AtOAuth` instance** sharing the store (standing in for the process that comes back from the kill) completes a callback it never started.
- `completeLoginRejectsPendingStateOlderThanTtl` — expiry discards the record rather than leaving key material on disk.
- `pendingStateWithinTtlStillCompletes` — guards the TTL against being too aggressive; without it the expiry test would pass just as well with a TTL of 0.

`:oauth:test` is 74 green (26 in `AtOAuthTest`). The existing reflection-based `extractState` helper now reads through the store instead of a private field.

## Compatibility

The `AtOAuth` constructor gains two defaulted parameters, so `apiDump` is updated. **Source compatible** — the sample app builds unchanged — but callers must recompile. Marked `feat:` because it adds public API (`PendingAuth`, `PendingAuthStore`, `InMemoryPendingAuthStore`), so semantic-release cuts a minor.

`oauth/README.md` gains a section telling Android consumers to supply a durable store, since the fix only takes effect if they do.
