### PR TITLE
chore(lexicons): refresh the manifest to match upstream CIDs

### DIFF
--- a/generator/lexicons.json
+++ b/generator/lexicons.json
@@ -394,11 +394,11 @@
     },
     "app.bsky.graph.getFollowers": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.graph.getFollowers",
-      "cid": "bafyreihqdm5fzu64lo2hsjuzggasy6pu5v3rcy2cs3fdoo3v3d537hi5ay"
+      "cid": "bafyreiaboxa4aux2y5jxut5kw4iqlnctlswklofvgkhxl2wn7rkbjjrzru"
     },
     "app.bsky.graph.getFollows": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.graph.getFollows",
-      "cid": "bafyreidwk3pssvzpzzmnr7ykl5piiyrp2c5rwadgnouwjbwysghpu3gaui"
+      "cid": "bafyreicun6mwmjgrdmrtmnfqv3ws37g5okcmo3uiaf2qwopk3bhtj5rqae"
     },
     "app.bsky.graph.getKnownFollowers": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.graph.getKnownFollowers",
@@ -530,7 +530,7 @@
     },
     "app.bsky.notification.listNotifications": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.notification.listNotifications",
-      "cid": "bafyreicpn2mr6mvbug7wheniaqaou2lq3cjbdcu4y5perdy2ekjv32tunq"
+      "cid": "bafyreigqqfk3gvslu36fvmx3fc3yi4ibmsmbfvty55rq4vw7cvfhecpxge"
     },
     "app.bsky.notification.putActivitySubscription": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.notification.putActivitySubscription",
@@ -698,7 +698,7 @@
     },
     "chat.bsky.group.createGroup": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/chat.bsky.group.createGroup",
-      "cid": "bafyreicpqjbpipx4mxby5mujguw2rwpewycm2h6ybbdiycdnghxqgertju"
+      "cid": "bafyreidhalpchhospn2hwox54navotl4svw4pmt33aynj22gp52ofoxzau"
     },
     "chat.bsky.group.createJoinLink": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/chat.bsky.group.createJoinLink",

--- a/models/api/models.api
+++ b/models/api/models.api
@@ -7182,17 +7182,19 @@ public final class io/github/kikin81/atproto/app/bsky/graph/GetBlocksResponse$Co
 
 public final class io/github/kikin81/atproto/app/bsky/graph/GetFollowersRequest {
 	public static final field Companion Lio/github/kikin81/atproto/app/bsky/graph/GetFollowersRequest$Companion;
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1-mlEIfv0 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/Long;
-	public final fun copy-zhZdu3M (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;)Lio/github/kikin81/atproto/app/bsky/graph/GetFollowersRequest;
-	public static synthetic fun copy-zhZdu3M$default (Lio/github/kikin81/atproto/app/bsky/graph/GetFollowersRequest;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/graph/GetFollowersRequest;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy-icULqAM (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/graph/GetFollowersRequest;
+	public static synthetic fun copy-icULqAM$default (Lio/github/kikin81/atproto/app/bsky/graph/GetFollowersRequest;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/graph/GetFollowersRequest;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getActor-mlEIfv0 ()Ljava/lang/String;
 	public final fun getCursor ()Ljava/lang/String;
 	public final fun getLimit ()Ljava/lang/Long;
+	public final fun getSort ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -7246,17 +7248,19 @@ public final class io/github/kikin81/atproto/app/bsky/graph/GetFollowersResponse
 
 public final class io/github/kikin81/atproto/app/bsky/graph/GetFollowsRequest {
 	public static final field Companion Lio/github/kikin81/atproto/app/bsky/graph/GetFollowsRequest$Companion;
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1-mlEIfv0 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/Long;
-	public final fun copy-zhZdu3M (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;)Lio/github/kikin81/atproto/app/bsky/graph/GetFollowsRequest;
-	public static synthetic fun copy-zhZdu3M$default (Lio/github/kikin81/atproto/app/bsky/graph/GetFollowsRequest;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/graph/GetFollowsRequest;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy-icULqAM (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/graph/GetFollowsRequest;
+	public static synthetic fun copy-icULqAM$default (Lio/github/kikin81/atproto/app/bsky/graph/GetFollowsRequest;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/graph/GetFollowsRequest;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getActor-mlEIfv0 ()Ljava/lang/String;
 	public final fun getCursor ()Ljava/lang/String;
 	public final fun getLimit ()Ljava/lang/Long;
+	public final fun getSort ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -9641,9 +9645,10 @@ public final class io/github/kikin81/atproto/app/bsky/notification/ListActivityS
 
 public final class io/github/kikin81/atproto/app/bsky/notification/ListNotificationsNotification {
 	public static final field Companion Lio/github/kikin81/atproto/app/bsky/notification/ListNotificationsNotification$Companion;
-	public synthetic fun <init> (Lio/github/kikin81/atproto/app/bsky/actor/ProfileView;Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public synthetic fun <init> (Lio/github/kikin81/atproto/app/bsky/actor/ProfileView;Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lio/github/kikin81/atproto/app/bsky/actor/ProfileView;Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Lio/github/kikin81/atproto/app/bsky/graph/StarterPackViewBasic;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lio/github/kikin81/atproto/app/bsky/actor/ProfileView;Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Lio/github/kikin81/atproto/app/bsky/graph/StarterPackViewBasic;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lio/github/kikin81/atproto/app/bsky/actor/ProfileView;
+	public final fun component10-GUXd3rc ()Ljava/lang/String;
 	public final fun component2-LVDfoeI ()Ljava/lang/String;
 	public final fun component3-DnBUIck ()Ljava/lang/String;
 	public final fun component4 ()Z
@@ -9651,9 +9656,9 @@ public final class io/github/kikin81/atproto/app/bsky/notification/ListNotificat
 	public final fun component6 ()Ljava/lang/String;
 	public final fun component7-XX8z880 ()Ljava/lang/String;
 	public final fun component8 ()Lkotlinx/serialization/json/JsonObject;
-	public final fun component9-GUXd3rc ()Ljava/lang/String;
-	public final fun copy-fuaNEfE (Lio/github/kikin81/atproto/app/bsky/actor/ProfileView;Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/notification/ListNotificationsNotification;
-	public static synthetic fun copy-fuaNEfE$default (Lio/github/kikin81/atproto/app/bsky/notification/ListNotificationsNotification;Lio/github/kikin81/atproto/app/bsky/actor/ProfileView;Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/notification/ListNotificationsNotification;
+	public final fun component9 ()Lio/github/kikin81/atproto/app/bsky/graph/StarterPackViewBasic;
+	public final fun copy-IpaLm9A (Lio/github/kikin81/atproto/app/bsky/actor/ProfileView;Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Lio/github/kikin81/atproto/app/bsky/graph/StarterPackViewBasic;Ljava/lang/String;)Lio/github/kikin81/atproto/app/bsky/notification/ListNotificationsNotification;
+	public static synthetic fun copy-IpaLm9A$default (Lio/github/kikin81/atproto/app/bsky/notification/ListNotificationsNotification;Lio/github/kikin81/atproto/app/bsky/actor/ProfileView;Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Lio/github/kikin81/atproto/app/bsky/graph/StarterPackViewBasic;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kikin81/atproto/app/bsky/notification/ListNotificationsNotification;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAuthor ()Lio/github/kikin81/atproto/app/bsky/actor/ProfileView;
 	public final fun getCid-LVDfoeI ()Ljava/lang/String;
@@ -9662,6 +9667,7 @@ public final class io/github/kikin81/atproto/app/bsky/notification/ListNotificat
 	public final fun getReason ()Ljava/lang/String;
 	public final fun getReasonSubject-XX8z880 ()Ljava/lang/String;
 	public final fun getRecord ()Lkotlinx/serialization/json/JsonObject;
+	public final fun getStarterPack ()Lio/github/kikin81/atproto/app/bsky/graph/StarterPackViewBasic;
 	public final fun getUri-GUXd3rc ()Ljava/lang/String;
 	public fun hashCode ()I
 	public final fun isRead ()Z


### PR DESCRIPTION
## What

`main` has been red since #184 with:

```
Error: Lexicons manifest is out of date
  at Install lexicon corpus
```

That step runs before Gradle in both the **Build** and **Test** jobs, so every PR in the repo fails those two checks regardless of content — #186 is currently sitting red purely because of this.

Upstream republished four lexicons; `generator/lexicons.json` still pinned their old CIDs:

- `app.bsky.graph.getFollowers`
- `app.bsky.graph.getFollows`
- `app.bsky.notification.listNotifications`
- `chat.bsky.group.createGroup`

**No NSIDs added or removed** — CID updates only.

## Why `models.api` moves too

Regenerating from the refreshed corpus picks up new optional fields (`sort` on `GetFollowersRequest` / `GetFollowsRequest`, plus fields on the notification and chat types), so `:models:apiDump` is re-run.

Nothing is removed from the public API. The 13 removed lines are all constructor / `copy` / `component` signatures whose arity shifted because a field was added — the normal shape for an additive lexicon change. No public class or property disappears.

Worth noting for future drift PRs: `lexicon-bump.yaml` does **not** run `apiDump`, which is why its auto-PRs sit red on `:models:jvmApiCheck` while Build and Lint stay green.

## Verification

`generator/lexicons/` is gitignored, so a warm checkout re-uses its corpus and `npx lex install --ci` exits 0 **regardless of drift** — a local pass there proves nothing. The faithful check deletes the corpus first:

```bash
cd generator && rm -rf lexicons && npx lex install --ci
```

- **Before** the manifest refresh: reproduces the CI error exactly.
- **After**: exits 0, zero "out of date" errors.

Ran the same task set CI does — `:runtime:compileKotlinJvm`, `:models:compileKotlinJvm`, `:runtime:jvmTest`, `:generator:test`, `:samples:android:testDebugUnitTest`, `apiCheck`, `spotlessCheck`. **259 tests, 0 failures** on a forced rerun (`--rerun-tasks`, since the first pass came back in 3s off the cache and proved nothing).

Reproduced on `main`, which is the branch carrying the `@atproto/lex` 0.3.2 bump — reproducing against an older pin yields a different, misleadingly worse corpus.
