### PR TITLE
chore(lexicons): bump @atproto/lex to 0.3.8

### DIFF
--- a/generator/lexicons.json
+++ b/generator/lexicons.json
@@ -162,7 +162,7 @@
   "resolutions": {
     "app.bsky.actor.defs": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.actor.defs",
-      "cid": "bafyreielcp7ccfxuvtdthry5qqdqmvcqo5wx3shkuz32xd5rlypmhw6ufa"
+      "cid": "bafyreidv4wr3sla7dvnhdcxw6fkg4wst4njoifeysti7mmgflfhl36yxjq"
     },
     "app.bsky.actor.getPreferences": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.actor.getPreferences",
@@ -218,7 +218,7 @@
     },
     "app.bsky.draft.createDraft": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.draft.createDraft",
-      "cid": "bafyreiac6mvg7bdmdb3dndr3dvtpbn6ifjtv5uoweliw4sk2wpbdcwlfca"
+      "cid": "bafyreid43zfsfg4wk4p3mf3gihwhpqh4d5rmpw7l5n3zks3kl53bsrsaba"
     },
     "app.bsky.draft.defs": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.draft.defs",
@@ -266,11 +266,11 @@
     },
     "app.bsky.embed.video": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.embed.video",
-      "cid": "bafyreie3nug4ezpwodl6yrpgv5edkazzn22t7ea4yaeuun4rctyekkngai"
+      "cid": "bafyreihoxb7lvczityqcv2s5od3rllmkee7tn3m4qg6wn34kd6m45p6v24"
     },
     "app.bsky.feed.defs": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.feed.defs",
-      "cid": "bafyreibg2zvz4n25vtd5yfqlodqra72s4h4lz7vwdexoutv3523wbw6jca"
+      "cid": "bafyreihxsdr5eig2gntbwn5duiskdae6lb7xyrtvump6nzzuz7sspyqv3e"
     },
     "app.bsky.feed.describeFeedGenerator": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.feed.describeFeedGenerator",
@@ -378,7 +378,7 @@
     },
     "app.bsky.graph.defs": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.graph.defs",
-      "cid": "bafyreifcipomli7yggtl46xufgxlnrw7se6xmsdxmzgfcz2tiu76ljatxm"
+      "cid": "bafyreief2f7zpllyicjugbn7faohmnzwujeiytfzj76uckxmrqmtdvechy"
     },
     "app.bsky.graph.follow": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.graph.follow",
@@ -426,7 +426,7 @@
     },
     "app.bsky.graph.getMutes": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.graph.getMutes",
-      "cid": "bafyreif4wfqhk2eldaqwn4552ppul26p6z4e4epuqkngb6dkpll7akfqbm"
+      "cid": "bafyreibnvq62dmchuulpzvvl6w2x6z4mofnqdrfbsvc5ynoo6cazr7wove"
     },
     "app.bsky.graph.getRelationships": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.graph.getRelationships",
@@ -462,7 +462,7 @@
     },
     "app.bsky.graph.muteActor": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.graph.muteActor",
-      "cid": "bafyreiauvwzkpqibtwpegxofryhdwldk2aitvmz7g2gidchlfcdkamwk6a"
+      "cid": "bafyreiebgeqbzitzytuvuu23nxgiyxjdh3iawcxonsiu6t2aubqd6ugt6m"
     },
     "app.bsky.graph.muteActorList": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.graph.muteActorList",
@@ -562,7 +562,7 @@
     },
     "app.bsky.video.defs": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.video.defs",
-      "cid": "bafyreifgpicywqtgxj3afrw3fsadrr3qeykesmu52we3arwp5sps2blgpm"
+      "cid": "bafyreicorzkcw5zp4zjsiepyakpfn3vvtpwsbqwzsy43d2y6i3t5rp3meu"
     },
     "app.bsky.video.getJobStatus": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.video.getJobStatus",
@@ -638,7 +638,7 @@
     },
     "chat.bsky.convo.leaveConvo": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/chat.bsky.convo.leaveConvo",
-      "cid": "bafyreigdjs5t2jod6zojwnj5giqucsad257vhocykv6fftkj3qkqzqlqua"
+      "cid": "bafyreiamg2fhox2xl3ah76ru3eoxgynzuowexy4lzril5ckqnv3pwui7bm"
     },
     "chat.bsky.convo.listConvoRequests": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/chat.bsky.convo.listConvoRequests",

--- a/generator/package-lock.json
+++ b/generator/package-lock.json
@@ -8,19 +8,19 @@
       "name": "kikinlex-atproto-generator-lexicons",
       "version": "0.0.0",
       "dependencies": {
-        "@atproto/lex": "0.3.2"
+        "@atproto/lex": "0.3.8"
       }
     },
     "node_modules/@atproto-labs/did-resolver": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@atproto-labs/did-resolver/-/did-resolver-0.3.6.tgz",
-      "integrity": "sha512-5Bb3xfDgOw4r+AjAVuZvk7lWQlUkq7dxJoRMHI46UTLEt99CQGqvKOBbA0xAXehYc76LJyaG9fulVQuWmVuqUA==",
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/@atproto-labs/did-resolver/-/did-resolver-0.3.7.tgz",
+      "integrity": "sha512-F3M3U5cU1QSAXX3J5auGEc5N2pgDgpirAjvyDFsytXuyWfrjWfTPd/H+DZrrED7gK+noW0cAWtxxjdX7/cTSVQ==",
       "license": "MIT",
       "dependencies": {
         "@atproto-labs/fetch": "^0.3.5",
         "@atproto-labs/pipe": "^0.2.4",
-        "@atproto-labs/simple-store": "^0.5.0",
-        "@atproto-labs/simple-store-memory": "^0.2.5",
+        "@atproto-labs/simple-store": "^0.5.1",
+        "@atproto-labs/simple-store-memory": "^0.2.6",
         "@atproto/did": "^0.5.4",
         "zod": "^3.23.8"
       },
@@ -50,21 +50,21 @@
       }
     },
     "node_modules/@atproto-labs/simple-store": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@atproto-labs/simple-store/-/simple-store-0.5.0.tgz",
-      "integrity": "sha512-tA/BmCahnrLV+seUZzjkC1xVZQbjogiooQ5C4kkC6we2mP68v7SreQTuv/XPhK2wsSES6c1SYCgDkkLlDTzALA==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@atproto-labs/simple-store/-/simple-store-0.5.1.tgz",
+      "integrity": "sha512-vfvoDhu6ds6BT3Pqe+d2/LBU1WpDRtt69y6zltlfMCoucPm82m1j50/Wb6xTvv+oZ+2j0JyZVXsmXQ12SWYQJg==",
       "license": "MIT",
       "engines": {
         "node": ">=22"
       }
     },
     "node_modules/@atproto-labs/simple-store-memory": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@atproto-labs/simple-store-memory/-/simple-store-memory-0.2.5.tgz",
-      "integrity": "sha512-Qme5VqkHKZA0w218/3pncvT+KYQzVdtP4aF72eCswh53SLrdGCG6F/NtllmJuYmp9uPGnHdql/Yt0BY1slAKjQ==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@atproto-labs/simple-store-memory/-/simple-store-memory-0.2.6.tgz",
+      "integrity": "sha512-DD1v7MEfYF3BAcEpMTTpzfBLWLoI2HuyBhku2YpjHoqPrRrhCtE1alkxfPHjtjJVIjuU/XNU0cF/wB3+5FiKsA==",
       "license": "MIT",
       "dependencies": {
-        "@atproto-labs/simple-store": "^0.5.0",
+        "@atproto-labs/simple-store": "^0.5.1",
         "lru-cache": "^10.2.0"
       },
       "engines": {
@@ -72,14 +72,14 @@
       }
     },
     "node_modules/@atproto/common": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/@atproto/common/-/common-0.7.3.tgz",
-      "integrity": "sha512-pmu+B6n83exJDJSCXazVVOpk+RuXsMK8VxKUnkiSXHP03+nRDDeNXaWEp1COBBU2dfAzYZZB6k4M8G3gq3zkcQ==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@atproto/common/-/common-0.8.1.tgz",
+      "integrity": "sha512-WvgY0CDgodmTS7B1KDVFt868h1b85iQtQZeoDVI+6oOZmg1jINWUl+bZ1rwf59Tk1PqcMz5OzH6OS2J7Mb9/Iw==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/common-web": "^0.5.7",
-        "@atproto/lex-cbor": "^0.1.5",
-        "@atproto/lex-data": "^0.1.6",
+        "@atproto/common-web": "^0.5.10",
+        "@atproto/lex-cbor": "^0.1.6",
+        "@atproto/lex-data": "^0.1.7",
         "multiformats": "^13.0.0",
         "pino": "^10.3.1"
       },
@@ -88,14 +88,14 @@
       }
     },
     "node_modules/@atproto/common-web": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/@atproto/common-web/-/common-web-0.5.7.tgz",
-      "integrity": "sha512-lvU8lFO5UByacsl3AReXkpTWjcPBS8mBqt40B45HwCt+s58a+xT/YI/+AUpmzSmsPVZCpeCmP6wgsOSC8RILXg==",
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/@atproto/common-web/-/common-web-0.5.10.tgz",
+      "integrity": "sha512-w4JUdsJ3VXt8ewkavYh5m/u0UbxDtFdCKhNZPEpJ0U1vcWIjDaSInIexteETDgD7fBJAhidIEi30MGz1kk49ug==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/lex-data": "^0.1.6",
-        "@atproto/lex-json": "^0.1.5",
-        "@atproto/syntax": "^0.7.2",
+        "@atproto/lex-data": "^0.1.7",
+        "@atproto/lex-json": "^0.1.6",
+        "@atproto/syntax": "^0.7.5",
         "zod": "^3.23.8"
       },
       "engines": {
@@ -129,17 +129,17 @@
       }
     },
     "node_modules/@atproto/lex": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@atproto/lex/-/lex-0.3.2.tgz",
-      "integrity": "sha512-/HcdVoq2BtkHxdWRo3vCciT6Cge9LfHVYtatnBrGlgHw6LYvjG2LHxmquhfPj26mKa3n2zVM8+3ia9RpoemSxw==",
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/@atproto/lex/-/lex-0.3.8.tgz",
+      "integrity": "sha512-8X7f6wxVDm4IVNR80Yg3BV3IXb89sKo/KIZeYb4or/EHP7ljazVU4qU+RPXmlELnWiIcw+PiJE+hPSkGLnMPOA==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/lex-builder": "^0.1.9",
-        "@atproto/lex-client": "^0.3.1",
-        "@atproto/lex-data": "^0.1.6",
-        "@atproto/lex-installer": "^0.1.11",
-        "@atproto/lex-json": "^0.1.5",
-        "@atproto/lex-schema": "^0.2.3",
+        "@atproto/lex-builder": "^0.1.13",
+        "@atproto/lex-client": "^0.3.5",
+        "@atproto/lex-data": "^0.1.7",
+        "@atproto/lex-installer": "^0.1.17",
+        "@atproto/lex-json": "^0.1.6",
+        "@atproto/lex-schema": "^0.2.6",
         "tslib": "^2.8.1",
         "yargs": "^18.0.0"
       },
@@ -152,14 +152,14 @@
       }
     },
     "node_modules/@atproto/lex-builder": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/@atproto/lex-builder/-/lex-builder-0.1.9.tgz",
-      "integrity": "sha512-NfvrxND66jibS9BDRCaKFVjubeaCenVz0j++yFGv10L+POu1XU6cc4naIjnLg9uvZrB4GXG8fvZJpyvfNghn0A==",
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/@atproto/lex-builder/-/lex-builder-0.1.13.tgz",
+      "integrity": "sha512-YHSONY88fWdMcN6Xa/Noap98DNW2m5zVZGspQWaROsX2lFx1mLf7g/XKLBcPRVDpE3OWRZ98QkkSZN3SgbOXrg==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/lex-document": "^0.1.7",
-        "@atproto/lex-schema": "^0.2.3",
-        "prettier": "^3.2.5",
+        "@atproto/lex-document": "^0.1.10",
+        "@atproto/lex-schema": "^0.2.6",
+        "prettier": "^3.9.6",
         "ts-morph": "^27.0.0",
         "tslib": "^2.8.1"
       },
@@ -168,12 +168,12 @@
       }
     },
     "node_modules/@atproto/lex-cbor": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/@atproto/lex-cbor/-/lex-cbor-0.1.5.tgz",
-      "integrity": "sha512-JKDVu1/+QrRXy+cM72Ze7N7N3GUxhs3+wmwf3DyRQbDO0bdseC8mvZ9TYXhthM1Y92+pnCHIPci41etx8wz75Q==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@atproto/lex-cbor/-/lex-cbor-0.1.6.tgz",
+      "integrity": "sha512-PxLQy7jzV8u9zTGURNF8ZczLPk+ZH+WNx/2z/z7RacJbu7sWNpx26U2pC7cIkWtt4jyDaruaLhssw3w3atLotA==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/lex-data": "^0.1.6",
+        "@atproto/lex-data": "^0.1.7",
         "cborg": "^4.5.8",
         "tslib": "^2.8.1"
       },
@@ -182,14 +182,14 @@
       }
     },
     "node_modules/@atproto/lex-client": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@atproto/lex-client/-/lex-client-0.3.1.tgz",
-      "integrity": "sha512-GK5rhqOtIhzxd2BEByQTs1/K7u1QJ+0NkkksV94HgrTAHG+0S3DBg5P5+RPQu2uhHIDKFzXFhP5L+fFJubX4GQ==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@atproto/lex-client/-/lex-client-0.3.5.tgz",
+      "integrity": "sha512-IOYjgQ2H+pw8QhV0vMMG9PTRg+oh5In9APbGBvotNZlbF4SCZNDVd7dONFY4rU2Dg6BHSkiqbqoNUHNgTC+ITA==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/lex-data": "^0.1.6",
-        "@atproto/lex-json": "^0.1.5",
-        "@atproto/lex-schema": "^0.2.3",
+        "@atproto/lex-data": "^0.1.7",
+        "@atproto/lex-json": "^0.1.6",
+        "@atproto/lex-schema": "^0.2.6",
         "tslib": "^2.8.1"
       },
       "engines": {
@@ -197,9 +197,9 @@
       }
     },
     "node_modules/@atproto/lex-data": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/@atproto/lex-data/-/lex-data-0.1.6.tgz",
-      "integrity": "sha512-rvovRrYWDEuerX+ZeQbdI5dKs0bYvuMjhwDOtT+pkOvdY4MkfN41DJCz/RAYVAQ7noPdaalB6pAX9euukheE/w==",
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@atproto/lex-data/-/lex-data-0.1.7.tgz",
+      "integrity": "sha512-kW/dPLqo/WgCLV+XESR4JKwV6c1rZWJGOfuPupZGTjEDAKoBbKXdaEzX9/1vKQYbZ9U3j0DS/n7OFFK7wBugyQ==",
       "license": "MIT",
       "dependencies": {
         "multiformats": "^13.0.0",
@@ -211,13 +211,13 @@
       }
     },
     "node_modules/@atproto/lex-document": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/@atproto/lex-document/-/lex-document-0.1.7.tgz",
-      "integrity": "sha512-DcJagPJpjg3MTPhpDQRkjJDmSDPZy4F9MRftsni757qLZ1NCE5dYjfg9XX6DPya6/JvscAV7qga/CJrHeUFyiw==",
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/@atproto/lex-document/-/lex-document-0.1.10.tgz",
+      "integrity": "sha512-7ivrxWttSxInDksR2rtM24xGdntY/3Ew5j08W5SiG45B+T2nyARL5EOk2xMXEm3MLjPrpNYAybA21ZEDYhGG0Q==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/lex-schema": "^0.2.3",
-        "core-js": "^3",
+        "@atproto/lex-schema": "^0.2.6",
+        "core-js": "^3.50.0",
         "tslib": "^2.8.1"
       },
       "engines": {
@@ -225,18 +225,18 @@
       }
     },
     "node_modules/@atproto/lex-installer": {
-      "version": "0.1.11",
-      "resolved": "https://registry.npmjs.org/@atproto/lex-installer/-/lex-installer-0.1.11.tgz",
-      "integrity": "sha512-7sH0GcRKneaR7GBdgkM/f59huz2jebTrsfgQ50RonfZKPqfO/6uNwIjsJb8r6BjSxM7I7Os2z6LWdPVMYyoYDg==",
+      "version": "0.1.17",
+      "resolved": "https://registry.npmjs.org/@atproto/lex-installer/-/lex-installer-0.1.17.tgz",
+      "integrity": "sha512-XSXiFLoDT7YEe+GuUdwczKQmhuLrA2CHVVlL8s5U8FLtWC5Cr3ELmz1t1b/Y8dV+R31hWyvdsk/t992B6+WW3Q==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/lex-builder": "^0.1.9",
-        "@atproto/lex-cbor": "^0.1.5",
-        "@atproto/lex-data": "^0.1.6",
-        "@atproto/lex-document": "^0.1.7",
-        "@atproto/lex-resolver": "^0.2.4",
-        "@atproto/lex-schema": "^0.2.3",
-        "@atproto/syntax": "^0.7.2",
+        "@atproto/lex-builder": "^0.1.13",
+        "@atproto/lex-cbor": "^0.1.6",
+        "@atproto/lex-data": "^0.1.7",
+        "@atproto/lex-document": "^0.1.10",
+        "@atproto/lex-resolver": "^0.2.10",
+        "@atproto/lex-schema": "^0.2.6",
+        "@atproto/syntax": "^0.7.5",
         "tslib": "^2.8.1"
       },
       "engines": {
@@ -244,12 +244,12 @@
       }
     },
     "node_modules/@atproto/lex-json": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/@atproto/lex-json/-/lex-json-0.1.5.tgz",
-      "integrity": "sha512-qOp6+Za5p/xDXACYIP3vySbKaf9CJDwiZEN78ghPT1gRoJohKG3ONt/WmvOxBVJqc6VTRaqEpbG9vX9oLF2qsA==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@atproto/lex-json/-/lex-json-0.1.6.tgz",
+      "integrity": "sha512-mvrAd0lbyuecIHjyld8QN6MN6CBf4j0GCxLzegsvLh0SvDf+GbYWklkcQqmITL44yFQOwmA/QNIQj0Uvh7+R/g==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/lex-data": "^0.1.6",
+        "@atproto/lex-data": "^0.1.7",
         "tslib": "^2.8.1"
       },
       "engines": {
@@ -257,19 +257,19 @@
       }
     },
     "node_modules/@atproto/lex-resolver": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@atproto/lex-resolver/-/lex-resolver-0.2.4.tgz",
-      "integrity": "sha512-S7lxWp8CT5Par3eTq+VUXVpu6W5zHarq9oKZ6UneN0925Ey6juJ/kZI0jucxIpV/DXM+EF3GntOMbackFPxieg==",
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/@atproto/lex-resolver/-/lex-resolver-0.2.10.tgz",
+      "integrity": "sha512-0Ml37emPqi6zr7hBAVR8fi7XDgG6xWsksBotoMU4Doh/PNFNt/H79Zopt/jnmDRcl8DGj9PNqZOZjzcAr2IuFw==",
       "license": "MIT",
       "dependencies": {
-        "@atproto-labs/did-resolver": "^0.3.6",
+        "@atproto-labs/did-resolver": "^0.3.7",
         "@atproto/crypto": "^0.5.4",
-        "@atproto/lex-client": "^0.3.1",
-        "@atproto/lex-data": "^0.1.6",
-        "@atproto/lex-document": "^0.1.7",
-        "@atproto/lex-schema": "^0.2.3",
-        "@atproto/repo": "^0.10.7",
-        "@atproto/syntax": "^0.7.2",
+        "@atproto/lex-client": "^0.3.5",
+        "@atproto/lex-data": "^0.1.7",
+        "@atproto/lex-document": "^0.1.10",
+        "@atproto/lex-schema": "^0.2.6",
+        "@atproto/repo": "^0.10.12",
+        "@atproto/syntax": "^0.7.5",
         "tslib": "^2.8.1"
       },
       "engines": {
@@ -277,13 +277,13 @@
       }
     },
     "node_modules/@atproto/lex-schema": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@atproto/lex-schema/-/lex-schema-0.2.3.tgz",
-      "integrity": "sha512-218xvlL7EdEdREY7ieAhaVPnBeGAf5h3tNkzE+X1Ob4tFLrWwA1sOQqliIURG9owE8v0ctqf9Uftx15eN0U0qQ==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@atproto/lex-schema/-/lex-schema-0.2.6.tgz",
+      "integrity": "sha512-8fe/gmhjMImBsy073jMANkbHHQLe/w4s9XLATpAz+Qd6WrR9RYTqc2DU8uZDL13F5bfdGTj8KECt/Xs4CoPXdQ==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/lex-data": "^0.1.6",
-        "@atproto/syntax": "^0.7.2",
+        "@atproto/lex-data": "^0.1.7",
+        "@atproto/syntax": "^0.7.5",
         "@standard-schema/spec": "^1.1.0",
         "tslib": "^2.8.1"
       },
@@ -292,17 +292,17 @@
       }
     },
     "node_modules/@atproto/repo": {
-      "version": "0.10.7",
-      "resolved": "https://registry.npmjs.org/@atproto/repo/-/repo-0.10.7.tgz",
-      "integrity": "sha512-nMV3y4d/KERrt9VOe3hcKyl/FVQeo6+54YKCt6bLiMLl8CPEtjwdVGwWlSkekaCoayjL0rTQ4zvjmKs+vCA1Ew==",
+      "version": "0.10.12",
+      "resolved": "https://registry.npmjs.org/@atproto/repo/-/repo-0.10.12.tgz",
+      "integrity": "sha512-SnDSoFi1bRAfN0IcDjSPFcefknDCIIjKgJXgFsd5jvktCkopmzml8BpQEP5t2/mcZ7NvEn5onQ0kaWkXhgL+5g==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/common": "^0.7.3",
-        "@atproto/common-web": "^0.5.7",
+        "@atproto/common": "^0.8.1",
+        "@atproto/common-web": "^0.5.10",
         "@atproto/crypto": "^0.5.4",
-        "@atproto/lex-cbor": "^0.1.5",
-        "@atproto/lex-data": "^0.1.6",
-        "@atproto/syntax": "^0.7.2",
+        "@atproto/lex-cbor": "^0.1.6",
+        "@atproto/lex-data": "^0.1.7",
+        "@atproto/syntax": "^0.7.5",
         "varint": "^6.0.0",
         "zod": "^3.23.8"
       },
@@ -311,9 +311,9 @@
       }
     },
     "node_modules/@atproto/syntax": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@atproto/syntax/-/syntax-0.7.2.tgz",
-      "integrity": "sha512-tZ1Tr0R9pK4bI4Zs69t29cjMlCFQvRNBeNkqJC5pGeNuCt64D0eoF7s/AlqeVmYppClmQ0xJquggGgsMDP6j7w==",
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/@atproto/syntax/-/syntax-0.7.5.tgz",
+      "integrity": "sha512-6vnLQK8OAzg0dO6z/xnvuXn5zMV0UMI54zbxk7G7BXhGlIlLMb1yo+JVYtAlv8Nxzr+AaFdNZ8AJt+L/QhJMFQ==",
       "license": "MIT",
       "dependencies": {
         "iso-datestring-validator": "^2.2.2",
@@ -457,11 +457,14 @@
       "license": "MIT"
     },
     "node_modules/core-js": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
-      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.50.0.tgz",
+      "integrity": "sha512-BRWgOLKkFeCgRudR6zrs8p9XJZcE14grzKMMssoYrk6krtuEZ7MTKPIY5RzOnqsEKIR9kst7wNzphttraT+Yqw==",
       "hasInstallScript": true,
       "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
@@ -569,9 +572,9 @@
       "license": "MIT"
     },
     "node_modules/picomatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
-      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
       "license": "MIT",
       "engines": {
         "node": ">=12"

--- a/generator/package.json
+++ b/generator/package.json
@@ -4,6 +4,6 @@
   "private": true,
   "description": "Pins the @atproto/lex release whose lexicon JSON is consumed by :generator. Not published.",
   "dependencies": {
-    "@atproto/lex": "0.3.2"
+    "@atproto/lex": "0.3.8"
   }
 }


### PR DESCRIPTION
## Lexicon corpus update

Bumps `@atproto/lex` from `0.3.2` to `0.3.8`.

### lexicons.json changes

**Added** (0):
- _(none)_

**Removed** (0):
- _(none)_

**Updated** (9):
- `app.bsky.actor.defs`
- `app.bsky.draft.createDraft`
- `app.bsky.embed.video`
- `app.bsky.feed.defs`
- `app.bsky.graph.defs`
- `app.bsky.graph.getMutes`
- `app.bsky.graph.muteActor`
- `app.bsky.video.defs`
- `chat.bsky.convo.leaveConvo`

### What reviewers should check

- [ ] CI passes (generator regeneration, runtime tests, sample APK build)
- [ ] Skim the generator golden-file diff if any generator logic was affected
- [ ] Verify no new lexicon references are missing Kotlin types (compile failure in `:models`)

### Release impact

If this PR merges with only additive changes (new types, new fields), expect a `feat:` release. If it removes or renames anything, expect a `BREAKING CHANGE:` release — update the PR title to `feat!: bump @atproto/lex to <version>` before merging.